### PR TITLE
Add setting for max image width when viewing .note files

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -7,6 +7,7 @@ interface SupernotePluginSettings {
 	showTOC: boolean;
 	showExportButtons: boolean;
 	collapseRecognizedText: boolean,
+	noteImageMaxWidth: number;
 }
 
 const DEFAULT_SETTINGS: SupernotePluginSettings = {
@@ -15,7 +16,8 @@ const DEFAULT_SETTINGS: SupernotePluginSettings = {
 	showTOC: true,
 	showExportButtons: true,
 	collapseRecognizedText: false,
-};
+	noteImageMaxWidth: 0,
+}
 
 function generateTimestamp(): string {
 	const date = new Date();
@@ -194,6 +196,9 @@ export class SupernoteView extends FileView {
 			imgElement.src = imageDataUrl;
 			if (this.settings.invertColorsWhenDark) {
 				imgElement.addClass("supernote-invert-dark");
+			}
+			if (this.settings.noteImageMaxWidth > 0) {
+				imgElement.setAttr('style', 'width: 100%; max-width: ' + this.settings.noteImageMaxWidth + 'px')
 			}
 			imgElement.draggable = true;
 
@@ -461,6 +466,16 @@ class SupernoteSettingTab extends PluginSettingTab {
 				.setValue(this.plugin.settings.collapseRecognizedText)
 				.onChange(async (value) => {
 					this.plugin.settings.collapseRecognizedText = value;
+		
+		new Setting(containerEl)
+			.setName('Note width in .note files')
+			.setDesc('Width of the note image when viewing .note files, in pixels. Does not affect exported images and markdown. Set to 0 to allow the image to scale freely.')
+			.addSlider(text => text
+				.setLimits(0, 1400, 50) // Width of an A6X2/Nomad page at 100% is 1404 px
+				.setDynamicTooltip()
+				.setValue(this.plugin.settings.noteImageMaxWidth)
+				.onChange(async (value) => {
+					this.plugin.settings.noteImageMaxWidth = value;
 					await this.plugin.saveSettings();
 				})
 			);

--- a/main.ts
+++ b/main.ts
@@ -467,8 +467,8 @@ class SupernoteSettingTab extends PluginSettingTab {
 					this.plugin.settings.collapseRecognizedText = value;
 		
 		new Setting(containerEl)
-			.setName('Note width in .note files')
-			.setDesc('Width of the note image when viewing .note files, in pixels. Does not affect exported images and markdown.')
+			.setName('Max image width in .note files')
+			.setDesc('Maximum width of the note image when viewing .note files, in pixels. Does not affect exported images and markdown.')
 			.addSlider(text => text
 				.setLimits(100, 1400, 50) // Width of an A5X/A6X2/Nomad page is 1404 px (with no upscaling)
 				.setDynamicTooltip()

--- a/main.ts
+++ b/main.ts
@@ -468,7 +468,7 @@ class SupernoteSettingTab extends PluginSettingTab {
 		
 		new Setting(containerEl)
 			.setName('Note width in .note files')
-			.setDesc('Width of the note image when viewing .note files, in pixels. Does not affect exported images and markdown. Set to 0 to allow the image to scale freely.')
+			.setDesc('Width of the note image when viewing .note files, in pixels. Does not affect exported images and markdown.')
 			.addSlider(text => text
 				.setLimits(100, 1400, 50) // Width of an A5X/A6X2/Nomad page is 1404 px (with no upscaling)
 				.setDynamicTooltip()

--- a/main.ts
+++ b/main.ts
@@ -7,7 +7,7 @@ interface SupernotePluginSettings {
 	showTOC: boolean;
 	showExportButtons: boolean;
 	collapseRecognizedText: boolean,
-	noteImageMaxWidth: number;
+	noteImageMaxDim: number;
 }
 
 const DEFAULT_SETTINGS: SupernotePluginSettings = {
@@ -16,7 +16,7 @@ const DEFAULT_SETTINGS: SupernotePluginSettings = {
 	showTOC: true,
 	showExportButtons: true,
 	collapseRecognizedText: false,
-	noteImageMaxWidth: 1400, // Default to (nearly) the full width of the image
+	noteImageMaxDim: 800, // Sensible default for Nomad pages to be legible but not too big. Unit: px
 }
 
 function generateTimestamp(): string {
@@ -165,8 +165,13 @@ export class SupernoteView extends FileView {
 		for (let i = 0; i < images.length; i++) {
 			const imageDataUrl = images[i].toDataURL();
 
+			const pageContainer = container.createEl("div", {
+				cls: 'page-container',
+			})
+			pageContainer.setAttr('style', 'max-width: ' + this.settings.noteImageMaxDim + 'px;')
+
 			if (images.length > 1 && this.settings.showTOC) {
-				const a = container.createEl("a");
+				const a = pageContainer.createEl("a");
 				a.id = `page${i + 1}`;
 				a.href = "#toc";
 				a.createEl("h3", { text: `Page ${i + 1}` });
@@ -178,31 +183,31 @@ export class SupernoteView extends FileView {
 
 				// If Collapse Text setting is enabled, place the text into an HTML `details` element
 				if (this.settings.collapseRecognizedText) {
-					text = container.createEl('details', {
+					text = pageContainer.createEl('details', {
 						text: '\n' + sn.pages[i].text,
+						cls: 'page-recognized-text',
 					});
 					text.createEl('summary', { text: `Page ${i + 1} Recognized Text` });
 				} else {
-					text = container.createEl('div', {
+					text = pageContainer.createEl('div', {
 						text: sn.pages[i].text,
+						cls: 'page-recognized-text',
 					});
 				}
-
-				text.setAttr('style', 'user-select: text; white-space: pre-line; margin-top: 1.2em;');
 			}
 
 			// Show the img of the page
-			const imgElement = container.createEl("img");
+			const imgElement = pageContainer.createEl("img");
 			imgElement.src = imageDataUrl;
 			if (this.settings.invertColorsWhenDark) {
 				imgElement.addClass("supernote-invert-dark");
 			}
-			imgElement.setAttr('style', 'width: 100%; max-width: ' + this.settings.noteImageMaxWidth + 'px') // Note width responsive to container width, up to the set max width
+			imgElement.setAttr('style', 'max-height: ' + this.settings.noteImageMaxDim + 'px;')
 			imgElement.draggable = true;
 
 			// Create a button to save image to vault
 			if (this.settings.showExportButtons) {
-				const saveButton = container.createEl("button", {
+				const saveButton = pageContainer.createEl("button", {
 					text: "Save image to vault",
 					cls: "mod-cta",
 				});
@@ -469,14 +474,14 @@ class SupernoteSettingTab extends PluginSettingTab {
 			);
 		
 		new Setting(containerEl)
-			.setName('Max image width in .note files')
-			.setDesc('Maximum width of the note image when viewing .note files, in pixels. Does not affect exported images and markdown.')
+			.setName('Max image side length in .note files')
+			.setDesc('Maximum width and height (in pixels) of the note image when viewing .note files. Does not affect exported images and markdown.')
 			.addSlider(text => text
-				.setLimits(100, 1400, 50) // Width of an A5X/A6X2/Nomad page is 1404 px (with no upscaling)
+				.setLimits(200, 1900, 100) // Resolution of an A5X/A6X2/Nomad page is 1404 x 1872 px (with no upscaling)
 				.setDynamicTooltip()
-				.setValue(this.plugin.settings.noteImageMaxWidth)
+				.setValue(this.plugin.settings.noteImageMaxDim)
 				.onChange(async (value) => {
-					this.plugin.settings.noteImageMaxWidth = value;
+					this.plugin.settings.noteImageMaxDim = value;
 					await this.plugin.saveSettings();
 				})
 			);

--- a/main.ts
+++ b/main.ts
@@ -17,6 +17,7 @@ const DEFAULT_SETTINGS: SupernotePluginSettings = {
 	showExportButtons: true,
 	collapseRecognizedText: false,
 	noteImageMaxWidth: 0,
+	noteImageMaxWidth: 1400, // Default to (nearly) the full width of the image
 }
 
 function generateTimestamp(): string {
@@ -197,9 +198,7 @@ export class SupernoteView extends FileView {
 			if (this.settings.invertColorsWhenDark) {
 				imgElement.addClass("supernote-invert-dark");
 			}
-			if (this.settings.noteImageMaxWidth > 0) {
-				imgElement.setAttr('style', 'width: 100%; max-width: ' + this.settings.noteImageMaxWidth + 'px')
-			}
+			imgElement.setAttr('style', 'width: 100%; max-width: ' + this.settings.noteImageMaxWidth + 'px') // Note width responsive to container width, up to the set max width
 			imgElement.draggable = true;
 
 			// Create a button to save image to vault
@@ -471,7 +470,7 @@ class SupernoteSettingTab extends PluginSettingTab {
 			.setName('Note width in .note files')
 			.setDesc('Width of the note image when viewing .note files, in pixels. Does not affect exported images and markdown. Set to 0 to allow the image to scale freely.')
 			.addSlider(text => text
-				.setLimits(0, 1400, 50) // Width of an A6X2/Nomad page at 100% is 1404 px
+				.setLimits(100, 1400, 50) // Width of an A5X/A6X2/Nomad page is 1404 px (with no upscaling)
 				.setDynamicTooltip()
 				.setValue(this.plugin.settings.noteImageMaxWidth)
 				.onChange(async (value) => {

--- a/main.ts
+++ b/main.ts
@@ -16,7 +16,6 @@ const DEFAULT_SETTINGS: SupernotePluginSettings = {
 	showTOC: true,
 	showExportButtons: true,
 	collapseRecognizedText: false,
-	noteImageMaxWidth: 0,
 	noteImageMaxWidth: 1400, // Default to (nearly) the full width of the image
 }
 
@@ -465,6 +464,9 @@ class SupernoteSettingTab extends PluginSettingTab {
 				.setValue(this.plugin.settings.collapseRecognizedText)
 				.onChange(async (value) => {
 					this.plugin.settings.collapseRecognizedText = value;
+					await this.plugin.saveSettings();
+				})
+			);
 		
 		new Setting(containerEl)
 			.setName('Max image width in .note files')

--- a/styles.css
+++ b/styles.css
@@ -13,3 +13,18 @@
 .theme-light img.supernote-invert-light {
     filter: invert(1);
 }
+
+button.mod-cta {
+    display: block;
+}
+
+.page-recognized-text {
+    user-select: text; 
+    white-space: pre-line; 
+    margin-top: 1.2em;
+}
+
+div.page-container {
+    display: inline-block; 
+    vertical-align: top;
+}


### PR DESCRIPTION
Per issue #22, I took a stab at adding a max px width setting in the settings pane:

![Screenshot 2024-05-12 at 11 18 09 PM](https://github.com/philips/supernote-obsidian-plugin/assets/9400858/b21b90f3-513e-42b1-9c54-7a73a37d659a)

Set to 500 px as shown above, my test note looks like this:

![Screenshot 2024-05-12 at 11 18 36 PM](https://github.com/philips/supernote-obsidian-plugin/assets/9400858/77a2d6ee-2aee-4c33-87b4-5d8ac4ab8c23)

Notes are still responsive to window size below the max width. 

The default value is 1400px, which is nearly the max width of a note (both A5X and A6X2) in portrait orientation. This is the same as the preexisting behavior. That same test note looks like this at the max 1400px width:

![Screenshot 2024-05-12 at 11 18 45 PM](https://github.com/philips/supernote-obsidian-plugin/assets/9400858/5743826d-680f-43fb-985e-c81da09edc0b)

I am pretty new to contributing on Github so I would like any and all feedback, thanks! 