### PR TITLE
Add additional settings to show/hide elements when viewing .note files

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -191,7 +191,7 @@ export class SupernoteView extends FileView {
 					text = container.createEl('details', {
 						text: '\n' + sn.pages[i].text,
 					});
-					text.createEl('summary', { text: `Page ${i+1} Recognized Text` });
+					text.createEl('summary', { text: `Page ${i+1} Text` });
 				} else {
 					text = container.createEl('div', {
 						text: sn.pages[i].text,

--- a/main.ts
+++ b/main.ts
@@ -4,11 +4,13 @@ import { SupernoteX, toImage, fetchMirrorFrame } from 'supernote-typescript';
 interface SupernotePluginSettings {
 	mirrorIP: string;
 	invertColorsWhenDark: boolean;
+	showTOC: boolean;
 }
 
 const DEFAULT_SETTINGS: SupernotePluginSettings = {
 	mirrorIP: '',
 	invertColorsWhenDark: true,
+	showTOC: true,
 }
 
 function generateTimestamp(): string {
@@ -140,7 +142,7 @@ export class SupernoteView extends FileView {
 			vw.attachNoteFiles(file);
 		});
 
-		if (images.length > 1) {
+		if (images.length > 1 && this.settings.showTOC) {
 			const atoc = container.createEl("a");
 			atoc.id = "toc";
 			atoc.createEl("h2", { text: "Table of contents" });
@@ -156,7 +158,7 @@ export class SupernoteView extends FileView {
 		for (let i = 0; i < images.length; i++) {
 			const imageDataUrl = images[i].toDataURL();
 
-			if (images.length > 1) {
+			if (images.length > 1 && this.settings.showTOC) {
 				const a = container.createEl("a");
 				a.id = `page${i + 1}`;
 				a.href = "#toc";
@@ -402,6 +404,17 @@ class SupernoteSettingTab extends PluginSettingTab {
 				.setValue(this.plugin.settings.invertColorsWhenDark)
 				.onChange(async (value) => {
 					this.plugin.settings.invertColorsWhenDark = value;
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
+			.setName('Show table of contents')
+			.setDesc('When viewing .note files, show a table of contents and headers for each page')
+			.addToggle(text => text
+				.setValue(this.plugin.settings.showTOC)
+				.onChange(async (value) => {
+					this.plugin.settings.showTOC = value;
 					await this.plugin.saveSettings();
 				})
 			);

--- a/main.ts
+++ b/main.ts
@@ -186,7 +186,7 @@ export class SupernoteView extends FileView {
 					});
 				}
 
-				text.setAttr('style', 'user-select: text; white-space: pre-line;');
+				text.setAttr('style', 'user-select: text; white-space: pre-line; margin-top: 1.2em;');
 			}
 
 			// Show the img of the page
@@ -427,9 +427,9 @@ class SupernoteSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
-			.setName('Show table of contents')
+			.setName('Show table of contents and page headings')
 			.setDesc(
-				'When viewing .note files, show a table of contents and headers for each page',
+				'When viewing .note files, show a table of contents and page number headings',
 			)
 			.addToggle((text) =>
 				text

--- a/main.ts
+++ b/main.ts
@@ -53,7 +53,7 @@ class VaultWriter {
 		content += '\n';
 
 		for (let i = 0; i < sn.pages.length; i++) {
-			content += `## Page ${i + 1}\n\n`;
+			content += `## Page ${i + 1}\n\n`
 			if (sn.pages[i].text !== undefined && sn.pages[i].text.length > 0) {
 				content += `${sn.pages[i].text}\n`;
 			}
@@ -63,11 +63,7 @@ class VaultWriter {
 					subpath = '#supernote-invert-dark';
 				}
 
-				const link = this.app.fileManager.generateMarkdownLink(
-					imgs[i],
-					filename,
-					subpath,
-				);
+				const link = this.app.fileManager.generateMarkdownLink(imgs[i], filename, subpath);
 				content += `${link}\n`;
 			}
 		}
@@ -79,16 +75,8 @@ class VaultWriter {
 		let images = await toImage(sn);
 		let imgs: TFile[] = [];
 		for (let i = 0; i < images.length; i++) {
-			let filename =
-				await this.app.fileManager.getAvailablePathForAttachment(
-					`${file.basename}-${i}.png`,
-				);
-			imgs.push(
-				await this.app.vault.createBinary(
-					filename,
-					images[i].toBuffer(),
-				),
-			);
+			let filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}-${i}.png`);
+			imgs.push(await this.app.vault.createBinary(filename, images[i].toBuffer()));
 		}
 		return imgs;
 	}
@@ -110,7 +98,7 @@ class VaultWriter {
 }
 
 let vw: VaultWriter;
-export const VIEW_TYPE_SUPERNOTE = 'supernote-view';
+export const VIEW_TYPE_SUPERNOTE = "supernote-view";
 
 export class SupernoteView extends FileView {
 	file: TFile;
@@ -126,7 +114,7 @@ export class SupernoteView extends FileView {
 
 	getDisplayText() {
 		if (!this.file) {
-			return 'Supernote View';
+			return "Supernote View"
 		}
 		return this.file.basename;
 	}
@@ -134,41 +122,41 @@ export class SupernoteView extends FileView {
 	async onLoadFile(file: TFile): Promise<void> {
 		const container = this.containerEl.children[1];
 		container.empty();
-		container.createEl('h1', { text: file.name });
+		container.createEl("h1", { text: file.name });
 
 		const note = await this.app.vault.readBinary(file);
 		let sn = new SupernoteX(new Uint8Array(note));
 		let images = await toImage(sn);
 
 		if (this.settings.showExportButtons) {
-			const exportNoteBtn = container.createEl('p').createEl('button', {
-				text: 'Attach markdown to vault',
-				cls: 'mod-cta',
+			const exportNoteBtn = container.createEl("p").createEl("button", {
+				text: "Attach markdown to vault",
+				cls: "mod-cta",
 			});
 
-			exportNoteBtn.addEventListener('click', async () => {
+			exportNoteBtn.addEventListener("click", async () => {
 				vw.attachMarkdownFile(file);
 			});
 
-			const exportAllBtn = container.createEl('p').createEl('button', {
-				text: 'Attach markdown and images to vault',
-				cls: 'mod-cta',
+			const exportAllBtn = container.createEl("p").createEl("button", {
+				text: "Attach markdown and images to vault",
+				cls: "mod-cta",
 			});
 
-			exportAllBtn.addEventListener('click', async () => {
+			exportAllBtn.addEventListener("click", async () => {
 				vw.attachNoteFiles(file);
 			});
 		}
 
 		if (images.length > 1 && this.settings.showTOC) {
-			const atoc = container.createEl('a');
-			atoc.id = 'toc';
-			atoc.createEl('h2', { text: 'Table of contents' });
-			const ul = container.createEl('ul');
+			const atoc = container.createEl("a");
+			atoc.id = "toc";
+			atoc.createEl("h2", { text: "Table of contents" });
+			const ul = container.createEl("ul");
 			for (let i = 0; i < images.length; i++) {
-				const a = container.createEl('li').createEl('a');
-				a.href = `#page${i + 1}`;
-				a.text = `Page ${i + 1}`;
+				const a = container.createEl("li").createEl("a");
+				a.href = `#page${i + 1}`
+				a.text = `Page ${i + 1}`
 			}
 		}
 
@@ -176,10 +164,10 @@ export class SupernoteView extends FileView {
 			const imageDataUrl = images[i].toDataURL();
 
 			if (images.length > 1 && this.settings.showTOC) {
-				const a = container.createEl('a');
+				const a = container.createEl("a");
 				a.id = `page${i + 1}`;
-				a.href = '#toc';
-				a.createEl('h3', { text: `Page ${i + 1}` });
+				a.href = "#toc";
+				a.createEl("h3", { text: `Page ${i + 1}` });
 			}
 
 			// Show the text of the page, if any
@@ -202,35 +190,29 @@ export class SupernoteView extends FileView {
 			}
 
 			// Show the img of the page
-			const imgElement = container.createEl('img');
+			const imgElement = container.createEl("img");
 			imgElement.src = imageDataUrl;
 			if (this.settings.invertColorsWhenDark) {
-				imgElement.addClass('supernote-invert-dark');
+				imgElement.addClass("supernote-invert-dark");
 			}
 			imgElement.draggable = true;
 
 			// Create a button to save image to vault
 			if (this.settings.showExportButtons) {
-				const saveButton = container.createEl('button', {
-					text: 'Save image to vault',
-					cls: 'mod-cta',
+				const saveButton = container.createEl("button", {
+					text: "Save image to vault",
+					cls: "mod-cta",
 				});
 
-				saveButton.addEventListener('click', async () => {
-					const filename =
-						await this.app.fileManager.getAvailablePathForAttachment(
-							`${file.basename}}.png`,
-						);
-					await this.app.vault.createBinary(
-						filename,
-						images[i].toBuffer(),
-					);
+				saveButton.addEventListener("click", async () => {
+					const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}}.png`);
+					await this.app.vault.createBinary(filename, images[i].toBuffer());
 				});
 			}
 		}
 	}
 
-	async onClose() {}
+	async onClose() { }
 }
 
 export default class SupernotePlugin extends Plugin {
@@ -244,7 +226,7 @@ export default class SupernotePlugin extends Plugin {
 
 		this.registerView(
 			VIEW_TYPE_SUPERNOTE,
-			(leaf) => new SupernoteView(leaf, this.settings),
+			(leaf) => new SupernoteView(leaf, this.settings)
 		);
 		this.registerExtensions(['note'], VIEW_TYPE_SUPERNOTE);
 
@@ -255,33 +237,20 @@ export default class SupernotePlugin extends Plugin {
 				// generate a unique filename for the mirror based on the current note path
 				let ts = generateTimestamp();
 				const f = this.app.workspace.activeEditor?.file?.basename || '';
-				const filename =
-					await this.app.fileManager.getAvailablePathForAttachment(
-						`supernote-mirror-${f}-${ts}.png`,
-					);
+				const filename = await this.app.fileManager.getAvailablePathForAttachment(`supernote-mirror-${f}-${ts}.png`);
 
 				try {
 					if (this.settings.mirrorIP.length == 0) {
-						throw new Error(
-							'IP is unset, please set in Supernote plugin settings',
-						);
+						throw new Error("IP is unset, please set in Supernote plugin settings")
 					}
-					let image = await fetchMirrorFrame(
-						`${this.settings.mirrorIP}:8080`,
-					);
+					let image = await fetchMirrorFrame(`${this.settings.mirrorIP}:8080`);
 
-					const file = await this.app.vault.createBinary(
-						filename,
-						image.toBuffer(),
-					);
+					const file = await this.app.vault.createBinary(filename, image.toBuffer());
 					const path = this.app.workspace.activeEditor?.file?.path;
 					if (!path) {
-						throw new Error('Active file path is null');
+						throw new Error("Active file path is null")
 					}
-					const link = this.app.fileManager.generateMarkdownLink(
-						file,
-						path,
-					);
+					const link = this.app.fileManager.generateMarkdownLink(file, path);
 					editor.replaceRange(link, editor.getCursor());
 				} catch (err: any) {
 					new MirrorErrorModal(this.app, this.settings, err).open();
@@ -296,13 +265,13 @@ export default class SupernotePlugin extends Plugin {
 				const file = this.app.workspace.getActiveFile();
 				const ext = file?.extension;
 
-				if (ext === 'note') {
+				if (ext === "note") {
 					if (checking) {
-						return true;
+						return true
 					}
 					try {
 						if (!file) {
-							throw new Error('No file to attach');
+							throw new Error("No file to attach");
 						}
 						vw.attachNoteFiles(file);
 					} catch (err: any) {
@@ -322,13 +291,13 @@ export default class SupernotePlugin extends Plugin {
 				const file = this.app.workspace.getActiveFile();
 				const ext = file?.extension;
 
-				if (ext === 'note') {
+				if (ext === "note") {
 					if (checking) {
-						return true;
+						return true
 					}
 					try {
 						if (!file) {
-							throw new Error('No file to attach');
+							throw new Error("No file to attach");
 						}
 						vw.attachMarkdownFile(file);
 					} catch (err: any) {
@@ -342,7 +311,9 @@ export default class SupernotePlugin extends Plugin {
 		});
 	}
 
-	onunload() {}
+	onunload() {
+
+	}
 
 	async activateView() {
 		const { workspace } = this.app;
@@ -358,12 +329,9 @@ export default class SupernotePlugin extends Plugin {
 			// in the right sidebar for it
 			leaf = workspace.getRightLeaf(false);
 			if (!leaf) {
-				throw new Error('leaf is null');
+				throw new Error("leaf is null");
 			}
-			await leaf.setViewState({
-				type: VIEW_TYPE_SUPERNOTE,
-				active: true,
-			});
+			await leaf.setViewState({ type: VIEW_TYPE_SUPERNOTE, active: true });
 		}
 
 		// "Reveal" the leaf in case it is in a collapsed sidebar
@@ -371,17 +339,14 @@ export default class SupernotePlugin extends Plugin {
 	}
 
 	async loadSettings() {
-		this.settings = Object.assign(
-			{},
-			DEFAULT_SETTINGS,
-			await this.loadData(),
-		);
+		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
 	}
 
 	async saveSettings() {
 		await this.saveData(this.settings);
 	}
 }
+
 
 class MirrorErrorModal extends Modal {
 	error: Error;
@@ -395,9 +360,7 @@ class MirrorErrorModal extends Modal {
 
 	onOpen() {
 		const { contentEl } = this;
-		contentEl.setText(
-			`Error: ${this.error.message}. Is the Supernote connected to Wifi on IP ${this.settings.mirrorIP} and running Screen Mirroring?`,
-		);
+		contentEl.setText(`Error: ${this.error.message}. Is the Supernote connected to Wifi on IP ${this.settings.mirrorIP} and running Screen Mirroring?`);
 	}
 
 	onClose() {
@@ -426,6 +389,7 @@ class ErrorModal extends Modal {
 	}
 }
 
+
 class SupernoteSettingTab extends PluginSettingTab {
 	plugin: SupernotePlugin;
 
@@ -441,31 +405,25 @@ class SupernoteSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName('Supernote IP address for "Screen Mirroring"')
-			.setDesc(
-				'See Supernote "Screen Mirroring" documentation for how to enable',
-			)
-			.addText((text) =>
-				text
-					.setPlaceholder('IP )e.g. 192.168.1.2')
-					.setValue(this.plugin.settings.mirrorIP)
-					.onChange(async (value) => {
-						this.plugin.settings.mirrorIP = value;
-						await this.plugin.saveSettings();
-					}),
+			.setDesc('See Supernote "Screen Mirroring" documentation for how to enable')
+			.addText(text => text
+				.setPlaceholder('IP )e.g. 192.168.1.2')
+				.setValue(this.plugin.settings.mirrorIP)
+				.onChange(async (value) => {
+					this.plugin.settings.mirrorIP = value;
+					await this.plugin.saveSettings();
+				})
 			);
 
 		new Setting(containerEl)
 			.setName('Invert colors in "Dark mode"')
-			.setDesc(
-				'When Obsidian is in "Dark mode" increase image visibility by inverting colors of images',
-			)
-			.addToggle((text) =>
-				text
-					.setValue(this.plugin.settings.invertColorsWhenDark)
-					.onChange(async (value) => {
-						this.plugin.settings.invertColorsWhenDark = value;
-						await this.plugin.saveSettings();
-					}),
+			.setDesc('When Obsidian is in "Dark mode" increase image visibility by inverting colors of images')
+			.addToggle(text => text
+				.setValue(this.plugin.settings.invertColorsWhenDark)
+				.onChange(async (value) => {
+					this.plugin.settings.invertColorsWhenDark = value;
+					await this.plugin.saveSettings();
+				})
 			);
 
 		new Setting(containerEl)


### PR DESCRIPTION
This PR proposes adding a few simple on/off settings for viewing `.note` files. I find these nice to have for a cleaner viewing experience, especially if I just want to look through many pages and am not planning to do much exporting.

All three of these settings look and work fine when used independently of each other in different combinations.

I haven't actually tested in combination with #24, but I expect these changes to work fine together.

## Defaults/current behavior

The default settings shown below preserve the current behavior of the plugin:

![image](https://github.com/philips/supernote-obsidian-plugin/assets/9400858/2e33d17e-8b8a-4062-b03b-950ebce4b9d7)

My test note looks like this:

![image](https://github.com/philips/supernote-obsidian-plugin/assets/9400858/95144c60-4a98-4370-87df-74b3ba6284a4)

## Hiding the table of contents and page number headings

Switching "Show table of contents" OFF removes the table of contents and the page number headings:

![image](https://github.com/philips/supernote-obsidian-plugin/assets/9400858/f1ca343d-e67d-4cdb-a013-5418c3431092)

![image](https://github.com/philips/supernote-obsidian-plugin/assets/9400858/3f1b732a-4f2c-437e-a1e3-1bfe326898ba)

## Hiding export buttons

Switching "Show export buttons" OFF hides the buttons:

![image](https://github.com/philips/supernote-obsidian-plugin/assets/9400858/2496a18e-191b-4735-b5c1-bfe07a60095a)

![image](https://github.com/philips/supernote-obsidian-plugin/assets/9400858/cbc3f788-5cf7-4ee8-a7fb-384e47c17cd3)

## Collapsing recognized text

Finally, switching "Collapse recognized text" ON tucks the recognized text under an HTML `details` element:

![image](https://github.com/philips/supernote-obsidian-plugin/assets/9400858/f50494aa-8226-49e2-8199-0cb6f9d372b8)

![image](https://github.com/philips/supernote-obsidian-plugin/assets/9400858/ff7ed944-0c93-48e9-86dc-672a60c183a4)

Clicking on that element expands it to show the text:

![image](https://github.com/philips/supernote-obsidian-plugin/assets/9400858/6552449e-1412-4fbb-855c-970925a1656e)

---

Thanks for considering these unsolicited changes!