### PR TITLE
Custom dictionary

### DIFF
--- a/customDictionary.ts
+++ b/customDictionary.ts
@@ -177,17 +177,10 @@ export function createCustomDictionarySettingsUI(containerEl: HTMLElement, plugi
 	createDictionaryTableUI(customDictionaryContainer, plugin);
 }
 
-// Escape special characters in a string to be used in a regular expression
-function escapeRegExp(string: string): string {
-	return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 // Replace text with custom dictionary entries
 export function replaceTextWithCustomDictionary(text: string, customDictionary: CustomDictionarySettings['customDictionary']): string {
 	for (const entry of customDictionary) {
-		const safeSrc = escapeRegExp(entry.source);
-		const safeReplace = escapeRegExp(entry.replace);
-		text = text.replace(new RegExp(safeSrc, 'g'), safeReplace);
+		text = text.replace(new RegExp(entry.source, 'g'), entry.replace);
 	}
 	return text;
 }

--- a/customDictionary.ts
+++ b/customDictionary.ts
@@ -49,7 +49,7 @@ function createDictionaryEntryUI({id, entry, tbody, plugin}: {id: string, entry:
 
 	// Delete dictionary entry when delete button is clicked
 	deleteButton.addEventListener('click', async () => {
-		delete plugin.settings.customDictionary[sourceInput.value];
+		delete plugin.settings.customDictionary[id];
 		await plugin.saveSettings();
 		tr.remove();
 	});
@@ -57,9 +57,12 @@ function createDictionaryEntryUI({id, entry, tbody, plugin}: {id: string, entry:
 
 export function createCustomDictionarySettingsUI(containerEl: HTMLElement, plugin: SupernotePlugin): void {
 	const customDictionaryContainer = containerEl.createDiv();
-	customDictionaryContainer.createEl('hr');
-	customDictionaryContainer.createEl('h2', { text: 'Custom Dictionary' });
-	customDictionaryContainer.createEl('small', { text: 'You can add custom entries to your dictionary to fix errors from Supernote\'s handwriting recognition. This also lets you automatically swap out certain text with your preferred wording.' });
+	customDictionaryContainer
+		.addClasses(['setting-item', 'supernote-settings-custom-dictionary']);
+	customDictionaryContainer.createDiv({ text: 'Custom Dictionary' })
+		.addClass('setting-item-name');
+	customDictionaryContainer.createDiv({ text: 'You can add custom entries to your dictionary to fix errors from Supernote\'s handwriting recognition. This also lets you automatically swap out certain text with your preferred wording.' })
+		.addClass('setting-item-description');
 
 	const table = customDictionaryContainer.createEl('table');
 	const thead = table.createEl('thead');
@@ -95,4 +98,17 @@ export function createCustomDictionarySettingsUI(containerEl: HTMLElement, plugi
 
 	const addEntryButton = customDictionaryContainer.createEl('button', { text: 'Add dictionary entry' });
 	addEntryButton.addEventListener('click', addEmptyRow);
+}
+
+function escapeRegExp(string: string): string {
+	return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function replaceTextWithCustomDictionary(text: string, customDictionary: Record<string, CustomDictionaryEntry>): string {
+	for (const entry of Object.values(customDictionary)) {
+		const safeSrc = escapeRegExp(entry.src);
+		const safeReplace = escapeRegExp(entry.replace);
+		text = text.replace(new RegExp(safeSrc, 'g'), safeReplace);
+	}
+	return text;
 }

--- a/customDictionary.ts
+++ b/customDictionary.ts
@@ -1,0 +1,98 @@
+import SupernotePlugin from "./main";
+import { randomUUID } from 'crypto';
+
+type CustomDictionaryEntry = {
+	src: string,
+	replace: string,
+}
+
+export interface CustomDictionarySettings {
+	isCustomDictionaryEnabled: boolean,
+	customDictionary: Record<string, CustomDictionaryEntry>
+}
+
+export const CUSTOM_DICTIONARY_DEFAULT_SETTINGS: CustomDictionarySettings = {
+	isCustomDictionaryEnabled: false,
+	customDictionary: {},
+}
+
+function getDictionaryEntryId(): string {
+	return randomUUID();
+}
+
+function createDictionaryEntryUI({id, entry, tbody, plugin}: {id: string, entry: CustomDictionaryEntry, tbody: HTMLElement, plugin: SupernotePlugin}) {	
+	const tr = tbody.createEl('tr');
+
+	// Source Text Input
+	const sourceTd = tr.createEl('td');
+	const sourceInput = sourceTd.createEl('input');
+	sourceInput.type = 'text';
+	sourceInput.value = entry.src;
+
+	// Replace Text Input
+	const replaceTd = tr.createEl('td');
+	const replaceInput = replaceTd.createEl('input');
+	replaceInput.type = 'text';
+	replaceInput.value = entry.replace;
+
+	// Delete Button (in Options column)
+	const optionsTd = tr.createEl('td');
+	const deleteButton = optionsTd.createEl('button', { text: 'Delete' });
+
+	// Update dictionary entry when input changes
+	const updateDictionaryEntry = async () => {
+		plugin.settings.customDictionary[id] = {src: sourceInput.value, replace: replaceInput.value};
+		await plugin.saveSettings();
+	}
+	sourceInput.addEventListener('input', updateDictionaryEntry);
+	replaceInput.addEventListener('input', updateDictionaryEntry);
+
+	// Delete dictionary entry when delete button is clicked
+	deleteButton.addEventListener('click', async () => {
+		delete plugin.settings.customDictionary[sourceInput.value];
+		await plugin.saveSettings();
+		tr.remove();
+	});
+}
+
+export function createCustomDictionarySettingsUI(containerEl: HTMLElement, plugin: SupernotePlugin): void {
+	const customDictionaryContainer = containerEl.createDiv();
+	customDictionaryContainer.createEl('hr');
+	customDictionaryContainer.createEl('h2', { text: 'Custom Dictionary' });
+	customDictionaryContainer.createEl('small', { text: 'You can add custom entries to your dictionary to fix errors from Supernote\'s handwriting recognition. This also lets you automatically swap out certain text with your preferred wording.' });
+
+	const table = customDictionaryContainer.createEl('table');
+	const thead = table.createEl('thead');
+	const trHead = thead.createEl('tr');
+	trHead.createEl('th', { text: 'Source Text' });
+	trHead.createEl('th', { text: 'Replace Text' });
+	trHead.createEl('th', { text: 'Options' });
+
+	const tbody = table.createEl('tbody');
+
+	const addEmptyRow = () => {
+		createDictionaryEntryUI({
+			id: getDictionaryEntryId(),
+			entry: {src: '', replace: ''},
+			tbody,
+			plugin
+		});
+	}
+
+
+	for (const [id, entry] of Object.entries(plugin.settings.customDictionary)) {
+		createDictionaryEntryUI({
+			id,
+			entry,
+			tbody,
+			plugin
+		});
+	}
+
+	if (Object.keys(plugin.settings.customDictionary).length === 0) {
+		addEmptyRow();
+	}
+
+	const addEntryButton = customDictionaryContainer.createEl('button', { text: 'Add dictionary entry' });
+	addEntryButton.addEventListener('click', addEmptyRow);
+}

--- a/customDictionary.ts
+++ b/customDictionary.ts
@@ -177,10 +177,17 @@ export function createCustomDictionarySettingsUI(containerEl: HTMLElement, plugi
 	createDictionaryTableUI(customDictionaryContainer, plugin);
 }
 
+// Escape special characters in a string to be used in a regular expression
+function escapeRegExp(string: string): string {
+	return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 // Replace text with custom dictionary entries
 export function replaceTextWithCustomDictionary(text: string, customDictionary: CustomDictionarySettings['customDictionary']): string {
-	for (const entry of customDictionary) {
-		text = text.replace(new RegExp(entry.source, 'g'), entry.replace);
-	}
-	return text;
+	customDictionary.map(entry => escapeRegExp(entry.source)).join('|');
+
+	return text.replace(new RegExp(customDictionary.map(entry => escapeRegExp(entry.source)).join('|'), 'g'), (match) => {
+		const entry = customDictionary.find(entry => new RegExp(escapeRegExp(entry.source)).test(match));
+		return entry ? entry.replace : match;
+	});
 }

--- a/customDictionary.ts
+++ b/customDictionary.ts
@@ -1,5 +1,4 @@
 import SupernotePlugin from "./main";
-import { randomUUID } from 'crypto';
 
 type CustomDictionaryEntry = {
 	src: string,
@@ -8,19 +7,15 @@ type CustomDictionaryEntry = {
 
 export interface CustomDictionarySettings {
 	isCustomDictionaryEnabled: boolean,
-	customDictionary: Record<string, CustomDictionaryEntry>
+	customDictionary: CustomDictionaryEntry[]
 }
 
 export const CUSTOM_DICTIONARY_DEFAULT_SETTINGS: CustomDictionarySettings = {
 	isCustomDictionaryEnabled: false,
-	customDictionary: {},
+	customDictionary: [],
 }
 
-function getDictionaryEntryId(): string {
-	return randomUUID();
-}
-
-function createDictionaryEntryUI({id, entry, tbody, plugin}: {id: string, entry: CustomDictionaryEntry, tbody: HTMLElement, plugin: SupernotePlugin}) {	
+function createDictionaryEntryUI({entry, tbody, plugin}: {entry: CustomDictionaryEntry, tbody: HTMLElement, plugin: SupernotePlugin}) {	
 	const tr = tbody.createEl('tr');
 
 	// Source Text Input
@@ -41,7 +36,11 @@ function createDictionaryEntryUI({id, entry, tbody, plugin}: {id: string, entry:
 
 	// Update dictionary entry when input changes
 	const updateDictionaryEntry = async () => {
-		plugin.settings.customDictionary[id] = {src: sourceInput.value, replace: replaceInput.value};
+		const index = Array.from(tbody.children).indexOf(tr)
+		plugin.settings.customDictionary[index] = {
+			src: sourceInput.value,
+			replace: replaceInput.value
+		};
 		await plugin.saveSettings();
 	}
 	sourceInput.addEventListener('input', updateDictionaryEntry);
@@ -49,10 +48,54 @@ function createDictionaryEntryUI({id, entry, tbody, plugin}: {id: string, entry:
 
 	// Delete dictionary entry when delete button is clicked
 	deleteButton.addEventListener('click', async () => {
-		delete plugin.settings.customDictionary[id];
+		const index = Array.from(tbody.children).indexOf(tr);
+		plugin.settings.customDictionary.splice(index, 1);
 		await plugin.saveSettings();
 		tr.remove();
 	});
+}
+
+function createDictionaryTableUI(containerEl: HTMLElement, plugin: SupernotePlugin) {
+	const CONTAINER_CLASSNAME = 'supernote-settings-custom-dictionary-entries';
+
+	// Remove existing dictionary entries to prepare for re-render
+	containerEl.find(`.${CONTAINER_CLASSNAME}`)?.remove();
+
+	const dictionaryEntriesContainer = containerEl.createDiv();
+	const table = dictionaryEntriesContainer.createEl('table');
+	const thead = table.createEl('thead');
+	const trHead = thead.createEl('tr');
+	const tbody = table.createEl('tbody');
+
+	dictionaryEntriesContainer.addClass(CONTAINER_CLASSNAME);
+	trHead.createEl('th', { text: 'Source Text' });
+	trHead.createEl('th', { text: 'Replace Text' });
+	trHead.createEl('th', { text: 'Options' });
+
+
+	const addEmptyRow = () => {
+		createDictionaryEntryUI({
+			entry: {src: '', replace: ''},
+			tbody,
+			plugin
+		});
+	}
+
+
+	for (const entry of plugin.settings.customDictionary) {
+		createDictionaryEntryUI({
+			entry,
+			tbody,
+			plugin
+		});
+	}
+
+	if (plugin.settings.customDictionary.length === 0) {
+		addEmptyRow();
+	}
+
+	const addEntryButton = dictionaryEntriesContainer.createEl('button', { text: 'Add dictionary entry' });
+	addEntryButton.addEventListener('click', addEmptyRow);
 }
 
 export function createCustomDictionarySettingsUI(containerEl: HTMLElement, plugin: SupernotePlugin): void {
@@ -64,40 +107,7 @@ export function createCustomDictionarySettingsUI(containerEl: HTMLElement, plugi
 	customDictionaryContainer.createDiv({ text: 'You can add custom entries to your dictionary to fix errors from Supernote\'s handwriting recognition. This also lets you automatically swap out certain text with your preferred wording.' })
 		.addClass('setting-item-description');
 
-	const table = customDictionaryContainer.createEl('table');
-	const thead = table.createEl('thead');
-	const trHead = thead.createEl('tr');
-	trHead.createEl('th', { text: 'Source Text' });
-	trHead.createEl('th', { text: 'Replace Text' });
-	trHead.createEl('th', { text: 'Options' });
-
-	const tbody = table.createEl('tbody');
-
-	const addEmptyRow = () => {
-		createDictionaryEntryUI({
-			id: getDictionaryEntryId(),
-			entry: {src: '', replace: ''},
-			tbody,
-			plugin
-		});
-	}
-
-
-	for (const [id, entry] of Object.entries(plugin.settings.customDictionary)) {
-		createDictionaryEntryUI({
-			id,
-			entry,
-			tbody,
-			plugin
-		});
-	}
-
-	if (Object.keys(plugin.settings.customDictionary).length === 0) {
-		addEmptyRow();
-	}
-
-	const addEntryButton = customDictionaryContainer.createEl('button', { text: 'Add dictionary entry' });
-	addEntryButton.addEventListener('click', addEmptyRow);
+	createDictionaryTableUI(customDictionaryContainer, plugin);
 }
 
 function escapeRegExp(string: string): string {

--- a/customDictionary.ts
+++ b/customDictionary.ts
@@ -1,13 +1,19 @@
 import { setIcon, Setting } from "obsidian";
 import SupernotePlugin from "./main";
 
+/** Custom dictionary entry type */
 type CustomDictionaryEntry = {
-	src: string,
+	/** The source text from Supernote .note file */
+	source: string,
+	/** String to replace if the source text is matched */
 	replace: string,
 }
 
+/** Settings for Supernote's plugin custom dictionary options */
 export interface CustomDictionarySettings {
+	/** Whether the custom dictionary is enabled and text replacement should occur when extracting text to Obsidian  */
 	isCustomDictionaryEnabled: boolean,
+	/** The custom dictionary entries */
 	customDictionary: CustomDictionaryEntry[]
 }
 
@@ -16,6 +22,7 @@ export const CUSTOM_DICTIONARY_DEFAULT_SETTINGS: CustomDictionarySettings = {
 	customDictionary: [],
 }
 
+// Create the UI for a single dictionary entry
 function createDictionaryEntryUI({entry, tbody, plugin}: {entry: CustomDictionaryEntry, tbody: HTMLElement, plugin: SupernotePlugin}) {	
 	const tr = tbody.createEl('tr');
 
@@ -23,7 +30,7 @@ function createDictionaryEntryUI({entry, tbody, plugin}: {entry: CustomDictionar
 	const sourceTd = tr.createEl('td');
 	const sourceInput = sourceTd.createEl('input');
 	sourceInput.type = 'text';
-	sourceInput.value = entry.src;
+	sourceInput.value = entry.source;
 
 	// Create replace text input
 	const replaceTd = tr.createEl('td');
@@ -50,7 +57,7 @@ function createDictionaryEntryUI({entry, tbody, plugin}: {entry: CustomDictionar
 	const updateDictionaryEntry = async () => {
 		const index = Array.from(tbody.children).indexOf(tr)
 		plugin.settings.customDictionary[index] = {
-			src: sourceInput.value,
+			source: sourceInput.value,
 			replace: replaceInput.value
 		};
 		await plugin.saveSettings();
@@ -91,22 +98,23 @@ function createDictionaryEntryUI({entry, tbody, plugin}: {entry: CustomDictionar
 	});
 }
 
+// Create the UI for the dictionary table
 function createDictionaryTableUI(containerEl: HTMLElement, plugin: SupernotePlugin) {
 	const CONTAINER_CLASSNAME = 'supernote-settings-custom-dictionary-entries';
 
 	// Remove existing dictionary entries to prepare for re-render
 	containerEl.find(`.${CONTAINER_CLASSNAME}`)?.remove();
 
+	// Create the dictionary entries container
 	const dictionaryEntriesContainer = containerEl.createDiv();
-
 	dictionaryEntriesContainer
 		.addClasses(['setting-item', CONTAINER_CLASSNAME]);
-
 	dictionaryEntriesContainer.createDiv({ text: 'Custom Dictionary' })
 		.addClass('setting-item-name');
-	dictionaryEntriesContainer.createDiv({ text: 'Add an entry for every text string you would like to replace in the Supernote\'s recognized text. The plugin will match and replace text based on the order in the table, starting from the top and moving to the bottom. So, if you want a more specific text to be replaced first, make sure to add it at the top. This way, the plugin can fall back to less strict matching if needed.' })
+	dictionaryEntriesContainer.createDiv({ text: 'Add an entry for every text string you would like to replace from Supernote\'s recognized text. The plugin will match and replace text based on the order in the table, starting from the top and moving to the bottom. So, if you want a more specific text to be replaced first, make sure to add it at the top. This way, the plugin can fall back to less strict matching if needed.' })
 		.addClasses(['setting-item-description']);
 
+	// Create the dictionary entries table
 	const table = dictionaryEntriesContainer.createEl('table');
 	const thead = table.createEl('thead');
 	const trHead = thead.createEl('tr');
@@ -116,16 +124,15 @@ function createDictionaryTableUI(containerEl: HTMLElement, plugin: SupernotePlug
 	trHead.createEl('th', { text: 'Replacement' });
 	trHead.createEl('th', { text: 'Options' });
 
-
 	const addEmptyRow = () => {
 		createDictionaryEntryUI({
-			entry: {src: '', replace: ''},
+			entry: {source: '', replace: ''},
 			tbody,
 			plugin
 		});
 	}
 
-
+	// Create UI for existing dictionary entries
 	for (const entry of plugin.settings.customDictionary) {
 		createDictionaryEntryUI({
 			entry,
@@ -134,14 +141,17 @@ function createDictionaryTableUI(containerEl: HTMLElement, plugin: SupernotePlug
 		});
 	}
 
+	// Add an empty row if there are no dictionary entries
 	if (plugin.settings.customDictionary.length === 0) {
 		addEmptyRow();
 	}
 
+	// Create the "Add dictionary entry" button
 	const addEntryButton = dictionaryEntriesContainer.createEl('button', { text: 'Add dictionary entry' });
 	addEntryButton.addEventListener('click', addEmptyRow);
 }
 
+// Create the UI for the custom dictionary settings
 export function createCustomDictionarySettingsUI(containerEl: HTMLElement, plugin: SupernotePlugin): void {
 	const customDictionaryContainer = containerEl.createDiv();
 	customDictionaryContainer
@@ -151,7 +161,8 @@ export function createCustomDictionarySettingsUI(containerEl: HTMLElement, plugi
 	customDictionaryContainer.createDiv({ text: 'You can add custom entries to your dictionary to fix errors from Supernote\'s handwriting recognition. This also lets you automatically swap out certain text with your preferred wording, add special markdown characters, etc.' })
 		.addClasses(['setting-item-description', 'supernote-settings-custom-dictionary-subtitle']);
 		
-		new Setting(customDictionaryContainer)
+	// Create the "Enable Custom Dictionary" setting
+	new Setting(customDictionaryContainer)
 		.setName('Enable Custom Dictionary')
 		.setDesc('Enable or disable the custom dictionary.')
 		.addToggle(text => text
@@ -162,16 +173,19 @@ export function createCustomDictionarySettingsUI(containerEl: HTMLElement, plugi
 			})
 		);
 
-		createDictionaryTableUI(customDictionaryContainer, plugin);
+	// Create the dictionary entries setting
+	createDictionaryTableUI(customDictionaryContainer, plugin);
 }
 
+// Escape special characters in a string to be used in a regular expression
 function escapeRegExp(string: string): string {
 	return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+// Replace text with custom dictionary entries
 export function replaceTextWithCustomDictionary(text: string, customDictionary: CustomDictionarySettings['customDictionary']): string {
 	for (const entry of customDictionary) {
-		const safeSrc = escapeRegExp(entry.src);
+		const safeSrc = escapeRegExp(entry.source);
 		const safeReplace = escapeRegExp(entry.replace);
 		text = text.replace(new RegExp(safeSrc, 'g'), safeReplace);
 	}

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { App, Modal, TFolder, TFile, Plugin, PluginSettingTab, Editor, Setting, MarkdownView, WorkspaceLeaf, FileView, SettingTab } from 'obsidian';
+import { App, Modal, TFile, Plugin, PluginSettingTab, Editor, Setting, MarkdownView, WorkspaceLeaf, FileView } from 'obsidian';
 import { SupernoteX, toImage, fetchMirrorFrame } from 'supernote-typescript';
 import { CustomDictionarySettings, CUSTOM_DICTIONARY_DEFAULT_SETTINGS, createCustomDictionarySettingsUI, replaceTextWithCustomDictionary } from './customDictionary';
 
@@ -32,6 +32,13 @@ function generateTimestamp(): string {
 	return timestamp;
 }
 
+/**
+ * Processes the Supernote text based on the provided settings.
+ * 
+ * @param text - The input text to be processed.
+ * @param settings - The settings for the Supernote plugin.
+ * @returns The processed text.
+ */
 function processSupernoteText(text: string, settings: SupernotePluginSettings): string {
 	if (settings.isCustomDictionaryEnabled) {
 		return replaceTextWithCustomDictionary(text, settings.customDictionary);

--- a/main.ts
+++ b/main.ts
@@ -1,7 +1,8 @@
-import { App, Modal, TFolder, TFile, Plugin, PluginSettingTab, Editor, Setting, MarkdownView, WorkspaceLeaf, FileView } from 'obsidian';
+import { App, Modal, TFolder, TFile, Plugin, PluginSettingTab, Editor, Setting, MarkdownView, WorkspaceLeaf, FileView, SettingTab } from 'obsidian';
 import { SupernoteX, toImage, fetchMirrorFrame } from 'supernote-typescript';
+import { CustomDictionarySettings, CUSTOM_DICTIONARY_DEFAULT_SETTINGS, createCustomDictionarySettingsUI } from './customDictionary';
 
-interface SupernotePluginSettings {
+interface SupernotePluginSettings extends CustomDictionarySettings {
 	mirrorIP: string;
 	invertColorsWhenDark: boolean;
 	showTOC: boolean;
@@ -15,6 +16,7 @@ const DEFAULT_SETTINGS: SupernotePluginSettings = {
 	showTOC: true,
 	showExportButtons: true,
 	collapseRecognizedText: false,
+	...CUSTOM_DICTIONARY_DEFAULT_SETTINGS,
 };
 
 function generateTimestamp(): string {
@@ -464,5 +466,9 @@ class SupernoteSettingTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 				})
 			);
+
+		// Add custom dictionary settings to the settings tab
+		createCustomDictionarySettingsUI(containerEl, this.plugin);
+
 	}
 }

--- a/styles.css
+++ b/styles.css
@@ -13,3 +13,22 @@
 .theme-light img.supernote-invert-light {
     filter: invert(1);
 }
+
+/* Custom dictionary settings styles */
+.supernote-settings-custom-dictionary {
+	display: block;
+}
+
+.supernote-settings-custom-dictionary table {
+	margin-block-start: var(--size-4-2);
+    margin-block-end: var(--size-2-1);
+	font-size: smaller;
+}
+
+.supernote-settings-custom-dictionary table, .supernote-settings-custom-dictionary table input {
+	width: 100%;
+}
+
+.supernote-settings-custom-dictionary table th {
+	text-align: start;
+}

--- a/styles.css
+++ b/styles.css
@@ -15,7 +15,11 @@
 }
 
 /* Custom dictionary settings styles */
-.supernote-settings-custom-dictionary {
+.supernote-settings-custom-dictionary-subtitle {
+	padding: 0 0 0.75em;
+}
+
+.supernote-settings-custom-dictionary-entries {
 	display: block;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -36,3 +36,9 @@
 .supernote-settings-custom-dictionary table th {
 	text-align: start;
 }
+
+.supernote-settings-custom-dictionary-entry-options {
+	display: grid;
+	grid-gap: var(--size-4-1);
+	grid-auto-flow: column;
+}

--- a/styles.css
+++ b/styles.css
@@ -42,3 +42,13 @@
 	grid-gap: var(--size-4-1);
 	grid-auto-flow: column;
 }
+
+.supernote-settings-custom-dictionary button {
+	cursor: pointer;
+}
+
+.supernote-settings-custom-dictionary-entry-options button.active {
+	color: var(--text-on-accent);
+	--icon-color: var(--text-on-accent);
+    background-color: var(--interactive-accent);
+}


### PR DESCRIPTION
Adds a settings panel to configure a custom dictionary: #32.

- Simple UI to:
  - Enable/disable replacement
  - Edit key/value pairs that serve as source and replacer values
  - Change order of replaces so more specific matched text can be replaced first.
- Automatically replaces text inline for both the note preview and text copied to markdown 

<img width="829" alt="Screenshot 2024-08-28 at 4 02 34 PM" src="https://github.com/user-attachments/assets/a0df8075-86b9-4cc7-b699-b169672c6159">
