### PR TITLE
Max image width bugfix: Add margin around page containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ Thank you to [Tiemen Schuijbroek](https://gitlab.com/Tiemen/supernote) for devel
 
 **A** Because the [Obsidian Outline](https://help.obsidian.md/Plugins/Outline) sidebar accomplishes this same feature.
 
-**Q** Can the images be larger or smaller?
-
-**A** Add a number, in pixels, after a `|` in the link like `![[20240419_100426-0.png|100]]`. [See Obsidian docs](https://help.obsidian.md/Linking+notes+and+files/Embed+files#Embed+an+image+in+a+note). Also, you can use the mouse wheel zoom plugin suggested below to make this easier.
-
 ## Other Helpful Plugins
 
 These are not endorsements but might be useful to pair with this plugin.

--- a/styles.css
+++ b/styles.css
@@ -21,10 +21,11 @@ button.mod-cta {
 .page-recognized-text {
     user-select: text; 
     white-space: pre-line; 
-    margin-top: 1.2em;
+    margin: 1.2em 0;
 }
 
 div.page-container {
     display: inline-block; 
     vertical-align: top;
+    margin: 1.2em;
 }


### PR DESCRIPTION
Addresses #38 by adding margin around page container so that the recognized text of one page doesn't run into that of the next page. 

I settled on 1.2em, seems like a reasonable amount for readability, but open to feedback/preferences!

Before this fix:
<img width="710" alt="no margin" src="https://github.com/user-attachments/assets/fb15d890-15a4-49dd-809e-7b01a2471beb" />

After this fix:
<img width="710" alt="with margin" src="https://github.com/user-attachments/assets/0f9b3c9a-77e4-46e7-925a-449ee4083bb3" />

I also removed an FAQ entry that was added because of my question #22 and is now moot.