### PR TITLE
Feat/auto markdown links tags

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -2,6 +2,10 @@ import esbuild from "esbuild";
 import process from "process";
 import builtins from "builtin-modules";
 import inlineWorkerPlugin from "esbuild-plugin-inline-worker";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const bresenhamMjs = require.resolve("bresenham-zingl/dist/index.mjs");
 
 const banner =
 `/*
@@ -18,10 +22,11 @@ const context = await esbuild.context({
 	},
 	entryPoints: ["src/main.ts"],
 	alias: {
-		'supernote-typescript': 'supernote-typescript'
+		'supernote-typescript': 'supernote-typescript',
+		'bresenham-zingl': bresenhamMjs,
 	},
 	bundle: true,
-	plugins: [inlineWorkerPlugin()],
+	plugins: [inlineWorkerPlugin({ alias: { 'bresenham-zingl': bresenhamMjs } })],
 	external: [
 		"obsidian",
 		"electron",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"dependencies": {
 		"esbuild-plugin-inline-worker": "^0.1.1",
 		"fast-png": "^7.0.1",
-		"image-js": "^0.35.6",
+		"image-js": "1.2.0",
 		"jspdf": "^2.5.2",
 		"supernote": "github:philips/supernote-typescript"
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { installAtPolyfill } from './polyfills';
-import { App, Modal, TFile, Plugin, Editor, MarkdownView, WorkspaceLeaf, FileView } from 'obsidian';
+import { App, Modal, TFile, Plugin, Editor, MarkdownView, WorkspaceLeaf, FileView, getAllTags } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS } from './settings';
 import { SupernoteX, fetchMirrorFrame } from 'supernote-typescript';
 import { DownloadListModal, UploadListModal } from './FileListModal';
@@ -36,17 +36,48 @@ function dataUrlToBuffer(dataUrl: string): ArrayBuffer {
 }
 
 /**
+ * Transforms #-prefixed words into vault tags or headings, and @-mentions into [[links]].
+ *
+ * For each `#word` or `# word` token:
+ *   - If `word` is already a tag in the vault → `#word` (inline tag, no space)
+ *   - Otherwise → `# word` (heading, space added)
+ *
+ * For each `@word` token → `[[word]]`
+ */
+function processHashtagsAndMentions(text: string, app: App): string {
+	const tagSet = new Set<string>();
+	for (const file of app.vault.getMarkdownFiles()) {
+		const cache = app.metadataCache.getFileCache(file);
+		if (cache) {
+			for (const tag of getAllTags(cache) ?? []) {
+				tagSet.add(tag.toLowerCase());
+			}
+		}
+	}
+
+	const result = text
+		.replace(/#\s*(\w[\w-]*)/g, (_match, word) => {
+			return tagSet.has(`#${word.toLowerCase()}`) ? `#${word}` : `# ${word}`;
+		})
+		.replace(/@(\w+)/g, '[[$1]]');
+
+	return result;
+}
+
+/**
  * Processes the Supernote text based on the provided settings.
- * 
+ *
  * @param text - The input text to be processed.
  * @param settings - The settings for the Supernote plugin.
+ * @param app - The Obsidian app instance (used for tag lookup).
  * @returns The processed text.
  */
-function processSupernoteText(text: string, settings: SupernotePluginSettings): string {
+function processSupernoteText(text: string, settings: SupernotePluginSettings, app: App): string {
 	let processedText = text;
 	if (settings.isCustomDictionaryEnabled) {
 		processedText = replaceTextWithCustomDictionary(processedText, settings.customDictionary);
 	}
+	processedText = processHashtagsAndMentions(processedText, app);
 	return processedText;
 }
 
@@ -166,7 +197,7 @@ class VaultWriter {
 		for (let i = 0; i < sn.pages.length; i++) {
 			content += `## Page ${i + 1}\n\n`
 			if (sn.pages[i].text !== undefined && sn.pages[i].text.length > 0) {
-				content += `${processSupernoteText(sn.pages[i].text, this.settings)}\n`;
+				content += `${processSupernoteText(sn.pages[i].text, this.settings, this.app)}\n`;
 			}
 			if (imgs) {
 				let subpath = '';
@@ -255,7 +286,7 @@ class VaultWriter {
 			if (sn.pages[i].text !== undefined && sn.pages[i].text.length > 0) {
 				pdf.setFontSize(100);
 				pdf.setTextColor(0, 0, 0, 0); // Transparent text
-				pdf.text(processSupernoteText(sn.pages[i].text, this.settings), 20, 20, { maxWidth: sn.pageWidth });
+				pdf.text(processSupernoteText(sn.pages[i].text, this.settings, this.app), 20, 20, { maxWidth: sn.pageWidth });
 				pdf.setTextColor(0, 0, 0, 1);
 			}
 
@@ -372,13 +403,13 @@ export class SupernoteView extends FileView {
 				// If Collapse Text setting is enabled, place the text into an HTML `details` element
 				if (this.settings.collapseRecognizedText) {
 					text = pageContainer.createEl('details', {
-						text: '\n' + processSupernoteText(sn.pages[i].text,this.settings),
+						text: '\n' + processSupernoteText(sn.pages[i].text, this.settings, this.app),
 						cls: 'page-recognized-text',
 					});
 					text.createEl('summary', { text: `Page ${i + 1} Recognized Text` });
 				} else {
 					text = pageContainer.createEl('div', {
-						text: processSupernoteText(sn.pages[i].text, this.settings),
+						text: processSupernoteText(sn.pages[i].text, this.settings, this.app),
 						cls: 'page-recognized-text',
 					});
 				}

--- a/src/main.ts
+++ b/src/main.ts
@@ -146,14 +146,18 @@ class VaultWriter {
 		this.settings = settings;
 	}
 
-	async writeMarkdownFile(file: TFile, sn: SupernoteX, imgs: TFile[] | null) {
+	async writeMarkdownFile(file: TFile, sn: SupernoteX, imgs: TFile[] | null, overwrite = false) {
 		let content = '';
 
-		// Generate a non-conflicting filename - it has a bit of a race but that is OK
-		let filename = `${file.parent?.path}/${file.basename}.md`;
-		let i = 0;
-		while (this.app.vault.getFileByPath(filename) !== null) {
-			filename = `${file.parent?.path}/${file.basename} ${++i}.md`;
+		const baseFilename = `${file.parent?.path}/${file.basename}.md`;
+		let filename = baseFilename;
+
+		if (!overwrite) {
+			// Generate a non-conflicting filename - it has a bit of a race but that is OK
+			let i = 0;
+			while (this.app.vault.getFileByPath(filename) !== null) {
+				filename = `${file.parent?.path}/${file.basename} ${++i}.md`;
+			}
 		}
 
 		content = this.app.fileManager.generateMarkdownLink(file, filename);
@@ -175,7 +179,16 @@ class VaultWriter {
 			}
 		}
 
-		this.app.vault.create(filename, content);
+		if (overwrite) {
+			const existing = this.app.vault.getFileByPath(baseFilename);
+			if (existing) {
+				this.app.vault.modify(existing, content);
+			} else {
+				this.app.vault.create(baseFilename, content);
+			}
+		} else {
+			this.app.vault.create(filename, content);
+		}
 	}
 
 	async writeImageFiles(file: TFile, sn: SupernoteX): Promise<TFile[]> {
@@ -198,11 +211,11 @@ class VaultWriter {
 		return imgs;
 	}
 
-	async attachMarkdownFile(file: TFile) {
+	async attachMarkdownFile(file: TFile, overwrite = false) {
 		const note = await this.app.vault.readBinary(file);
 		let sn = new SupernoteX(new Uint8Array(note));
 
-		this.writeMarkdownFile(file, sn, null);
+		this.writeMarkdownFile(file, sn, null, overwrite);
 	}
 
 	async attachNoteFiles(file: TFile) {
@@ -549,6 +562,29 @@ export default class SupernotePlugin extends Plugin {
 				return false;
 			},
 		});
+
+		const syncDebounceMap = new Map<string, ReturnType<typeof setTimeout>>();
+
+		this.registerEvent(
+			this.app.vault.on('create', (file) => {
+				if (!(file instanceof TFile) || file.extension !== 'note') return;
+				if (!this.settings.autoSyncMarkdown) return;
+				vw.attachMarkdownFile(file, true);
+			})
+		);
+
+		this.registerEvent(
+			this.app.vault.on('modify', (file) => {
+				if (!(file instanceof TFile) || file.extension !== 'note') return;
+				if (!this.settings.autoSyncMarkdown) return;
+				const existing = syncDebounceMap.get(file.path);
+				if (existing) clearTimeout(existing);
+				syncDebounceMap.set(file.path, setTimeout(() => {
+					syncDebounceMap.delete(file.path);
+					vw.attachMarkdownFile(file, true);
+				}, 2000));
+			})
+		);
 	}
 
 	onunload() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -211,10 +211,12 @@ class VaultWriter {
 	async writeMarkdownFile(file: TFile, sn: SupernoteX, imgs: TFile[] | null, overwrite = false) {
 		let content = '';
 
-		// Derive base filename from file.path (always correctly formatted by Obsidian,
-		// unlike file.parent?.path which is "/" for root files causing "//name.md").
-		const baseFilename = file.path.replace(/\.note$/i, '.md');
-		const dir = file.path.slice(0, file.path.length - file.name.length);
+		// Derive the output path. When a mirror folder is configured, replicate the
+		// note's relative path under that folder; otherwise save alongside the note.
+		const relMdPath = file.path.replace(/\.note$/i, '.md');
+		const mirrorFolder = this.settings.markdownMirrorFolder;
+		const baseFilename = mirrorFolder ? `${mirrorFolder}/${relMdPath}` : relMdPath;
+		const dir = baseFilename.slice(0, baseFilename.length - `${file.basename}.md`.length);
 		let filename = baseFilename;
 
 		if (!overwrite) {
@@ -224,6 +226,9 @@ class VaultWriter {
 				filename = `${dir}${file.basename} ${++i}.md`;
 			}
 		}
+
+		// Create any missing parent folders before writing.
+		if (dir) await this.ensureFolderExists(dir.replace(/\/$/, ''));
 
 		content = this.app.fileManager.generateMarkdownLink(file, filename);
 		content += '\n';
@@ -327,6 +332,21 @@ class VaultWriter {
 			}
 		} else {
 			await this.app.vault.create(filename, content);
+		}
+	}
+
+	private async ensureFolderExists(path: string): Promise<void> {
+		const parts = path.split('/').filter(Boolean);
+		let current = '';
+		for (const part of parts) {
+			current = current ? `${current}/${part}` : part;
+			if (!this.app.vault.getAbstractFileByPath(current)) {
+				try {
+					await this.app.vault.createFolder(current);
+				} catch {
+					// Folder may have been created concurrently; ignore.
+				}
+			}
 		}
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -753,16 +753,16 @@ export default class SupernotePlugin extends Plugin {
 
 		this.registerEvent(
 			this.app.vault.on('create', (file) => {
-				if (!(file instanceof TFile) || file.extension !== 'note') return;
 				if (!this.settings.isAutoSyncMarkdownEnabled) return;
+				if (!(file instanceof TFile) || file.extension !== 'note') return;
 				vw.attachMarkdownFile(file, true).catch(e => console.error('Supernote auto-sync (create) error:', e));
 			})
 		);
 
 		this.registerEvent(
 			this.app.vault.on('modify', (file) => {
-				if (!(file instanceof TFile) || file.extension !== 'note') return;
 				if (!this.settings.isAutoSyncMarkdownEnabled) return;
+				if (!(file instanceof TFile) || file.extension !== 'note') return;
 				const existing = syncDebounceMap.get(file.path);
 				if (existing) clearTimeout(existing);
 				syncDebounceMap.set(file.path, setTimeout(() => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -83,7 +83,7 @@ function processHashtagsAndMentions(
 			// Not a tag → Markdown heading.
 			return `# ${word}${next ?? ''}`;
 		})
-		.replace(/@(\w+)/g, '[[$1]]');
+		.replace(/@\s*(.+)/g, (_, text) => `[[${text.trim()}]]`);
 
 	return result;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { installAtPolyfill } from './polyfills';
 import { App, Modal, TFile, Plugin, Editor, MarkdownView, WorkspaceLeaf, FileView } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS } from './settings';
 import { SupernoteX, fetchMirrorFrame, ILink } from 'supernote-typescript';
+import { encode } from 'image-js';
 import { DownloadListModal, UploadListModal } from './FileListModal';
 import { jsPDF } from 'jspdf';
 import { SupernoteWorkerMessage, SupernoteWorkerResponse } from './myworker.worker';
@@ -657,7 +658,7 @@ export default class SupernotePlugin extends Plugin {
 					}
 					let image = await fetchMirrorFrame(`${this.settings.directConnectIP}:8080`);
 
-					const file = await this.app.vault.createBinary(filename, image.toBuffer());
+					const file = await this.app.vault.createBinary(filename, encode(image).buffer);
 					const path = this.app.workspace.activeEditor?.file?.path;
 					if (!path) {
 						throw new Error("Active file path is null")

--- a/src/main.ts
+++ b/src/main.ts
@@ -209,14 +209,17 @@ class VaultWriter {
 	async writeMarkdownFile(file: TFile, sn: SupernoteX, imgs: TFile[] | null, overwrite = false) {
 		let content = '';
 
-		const baseFilename = `${file.parent?.path}/${file.basename}.md`;
+		// Derive base filename from file.path (always correctly formatted by Obsidian,
+		// unlike file.parent?.path which is "/" for root files causing "//name.md").
+		const baseFilename = file.path.replace(/\.note$/i, '.md');
+		const dir = file.path.slice(0, file.path.length - file.name.length);
 		let filename = baseFilename;
 
 		if (!overwrite) {
 			// Generate a non-conflicting filename - it has a bit of a race but that is OK
 			let i = 0;
 			while (this.app.vault.getFileByPath(filename) !== null) {
-				filename = `${file.parent?.path}/${file.basename} ${++i}.md`;
+				filename = `${dir}${file.basename} ${++i}.md`;
 			}
 		}
 
@@ -300,12 +303,20 @@ class VaultWriter {
 		if (overwrite) {
 			const existing = this.app.vault.getFileByPath(baseFilename);
 			if (existing) {
-				this.app.vault.modify(existing, content);
+				await this.app.vault.modify(existing, content);
 			} else {
-				this.app.vault.create(baseFilename, content);
+				try {
+					await this.app.vault.create(baseFilename, content);
+				} catch {
+					// Race condition: 'create' and 'modify' vault events both fire when
+					// a .note file syncs. The file may have been created between the
+					// getFileByPath check and vault.create — update it instead.
+					const raceFile = this.app.vault.getFileByPath(baseFilename);
+					if (raceFile) await this.app.vault.modify(raceFile, content);
+				}
 			}
 		} else {
-			this.app.vault.create(filename, content);
+			await this.app.vault.create(filename, content);
 		}
 	}
 
@@ -359,7 +370,7 @@ class VaultWriter {
 		const note = await this.app.vault.readBinary(file);
 		let sn = new SupernoteX(new Uint8Array(note));
 
-		this.writeMarkdownFile(file, sn, null, overwrite);
+		await this.writeMarkdownFile(file, sn, null, overwrite);
 	}
 
 	async attachNoteFiles(file: TFile) {
@@ -713,7 +724,7 @@ export default class SupernotePlugin extends Plugin {
 			this.app.vault.on('create', (file) => {
 				if (!(file instanceof TFile) || file.extension !== 'note') return;
 				if (!this.settings.autoSyncMarkdown) return;
-				vw.attachMarkdownFile(file, true);
+				vw.attachMarkdownFile(file, true).catch(e => console.error('Supernote auto-sync (create) error:', e));
 			})
 		);
 
@@ -725,7 +736,7 @@ export default class SupernotePlugin extends Plugin {
 				if (existing) clearTimeout(existing);
 				syncDebounceMap.set(file.path, setTimeout(() => {
 					syncDebounceMap.delete(file.path);
-					vw.attachMarkdownFile(file, true);
+					vw.attachMarkdownFile(file, true).catch(e => console.error('Supernote auto-sync (modify) error:', e));
 				}, 2000));
 			})
 		);

--- a/src/main.ts
+++ b/src/main.ts
@@ -212,11 +212,24 @@ class VaultWriter {
 	async writeMarkdownFile(file: TFile, sn: SupernoteX, imgs: TFile[] | null, overwrite = false) {
 		let content = '';
 
-		// Derive the output path. When a mirror folder is configured, replicate the
-		// note's relative path under that folder; otherwise save alongside the note.
+		// Derive the output path. The mirror folder applies only when the file is
+		// inside the watched folder (or no watched folder is set). Files outside the
+		// watched folder always save alongside the note. When both are set, the
+		// watched folder prefix is stripped from the mirror path to avoid duplication.
 		const relMdPath = file.path.replace(/\.note$/i, '.md');
 		const mirrorFolder = this.settings.markdownMirrorFolder;
-		const baseFilename = mirrorFolder ? `${mirrorFolder}/${relMdPath}` : relMdPath;
+		const watchFolder = this.settings.noteWatchFolder.replace(/\/$/, '');
+		let baseFilename: string;
+		if (mirrorFolder && (!watchFolder || file.path.startsWith(watchFolder + '/'))) {
+			let mirrorRelPath = relMdPath;
+			if (watchFolder) {
+				const prefix = watchFolder + '/';
+				if (mirrorRelPath.startsWith(prefix)) mirrorRelPath = mirrorRelPath.slice(prefix.length);
+			}
+			baseFilename = `${mirrorFolder}/${mirrorRelPath}`;
+		} else {
+			baseFilename = relMdPath;
+		}
 		const dir = baseFilename.slice(0, baseFilename.length - `${file.basename}.md`.length);
 		let filename = baseFilename;
 
@@ -755,6 +768,8 @@ export default class SupernotePlugin extends Plugin {
 			this.app.vault.on('create', (file) => {
 				if (!this.settings.isAutoSyncMarkdownEnabled) return;
 				if (!(file instanceof TFile) || file.extension !== 'note') return;
+				const wf = this.settings.noteWatchFolder.replace(/\/$/, '');
+				if (wf && !file.path.startsWith(wf + '/')) return;
 				vw.attachMarkdownFile(file, true).catch(e => console.error('Supernote auto-sync (create) error:', e));
 			})
 		);
@@ -763,6 +778,8 @@ export default class SupernotePlugin extends Plugin {
 			this.app.vault.on('modify', (file) => {
 				if (!this.settings.isAutoSyncMarkdownEnabled) return;
 				if (!(file instanceof TFile) || file.extension !== 'note') return;
+				const wf = this.settings.noteWatchFolder.replace(/\/$/, '');
+				if (wf && !file.path.startsWith(wf + '/')) return;
 				const existing = syncDebounceMap.get(file.path);
 				if (existing) clearTimeout(existing);
 				syncDebounceMap.set(file.path, setTimeout(() => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { installAtPolyfill } from './polyfills';
-import { App, Modal, TFile, Plugin, Editor, MarkdownView, WorkspaceLeaf, FileView, getAllTags } from 'obsidian';
+import { App, Modal, TFile, Plugin, Editor, MarkdownView, WorkspaceLeaf, FileView } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS } from './settings';
-import { SupernoteX, fetchMirrorFrame } from 'supernote-typescript';
+import { SupernoteX, fetchMirrorFrame, ILink } from 'supernote-typescript';
 import { DownloadListModal, UploadListModal } from './FileListModal';
 import { jsPDF } from 'jspdf';
 import { SupernoteWorkerMessage, SupernoteWorkerResponse } from './myworker.worker';
@@ -46,13 +46,15 @@ function dataUrlToBuffer(dataUrl: string): ArrayBuffer {
  */
 function processHashtagsAndMentions(text: string, app: App): string {
 	const tagSet = new Set<string>();
-	for (const file of app.vault.getMarkdownFiles()) {
-		const cache = app.metadataCache.getFileCache(file);
-		if (cache) {
-			for (const tag of getAllTags(cache) ?? []) {
-				tagSet.add(tag.toLowerCase());
-			}
+	try {
+		// getTags() is an undocumented MetadataCache method that returns all vault
+		// tags as Record<string, number> — much cheaper than iterating every file.
+		const allTags: Record<string, number> = (app.metadataCache as any).getTags();
+		for (const tag of Object.keys(allTags)) {
+			tagSet.add(tag.toLowerCase());
 		}
+	} catch {
+		// Vault tag lookup is best-effort; fall back to treating all #words as headings
 	}
 
 	const result = text
@@ -194,10 +196,47 @@ class VaultWriter {
 		content = this.app.fileManager.generateMarkdownLink(file, filename);
 		content += '\n';
 
+		// Emit keyword tags collected from Supernote's star/keyword feature.
+		// Each keyword text is sanitized: non-alphanumeric characters become '_'.
+		const keywordTags: string[] = [];
+		for (const key of Object.keys(sn.keywords)) {
+			for (const kw of sn.keywords[key]) {
+				const text = kw.KEYWORD.trim();
+				if (!text) continue;
+				const tag = `#${text.replace(/[^\w-]/g, '_').replace(/_+/g, '_').replace(/^_|_$/g, '')}`;
+				if (!keywordTags.includes(tag)) keywordTags.push(tag);
+			}
+		}
+		if (keywordTags.length > 0) {
+			content += keywordTags.join(' ') + '\n\n';
+		}
+
+		// Build a page-indexed map of links for quick lookup in the page loop.
+		const snLinks = sn.links ?? {};
+		const linksByPage = new Map<string, string[]>();
+		const noteCache = new Map<string, SupernoteX>();
+		for (const key of Object.keys(snLinks)) {
+			for (const link of snLinks[key]) {
+				if (!link.text) continue;
+				const text = await this.resolvePageAnchor(link, noteCache);
+				if (!linksByPage.has(link.OBJPAGE)) linksByPage.set(link.OBJPAGE, []);
+				linksByPage.get(link.OBJPAGE)!.push(`[[${text}]]`);
+			}
+		}
+
 		for (let i = 0; i < sn.pages.length; i++) {
 			content += `## Page ${i + 1}\n\n`
 			if (sn.pages[i].text !== undefined && sn.pages[i].text.length > 0) {
-				content += `${processSupernoteText(sn.pages[i].text, this.settings, this.app)}\n`;
+				try {
+					content += `${processSupernoteText(sn.pages[i].text, this.settings, this.app)}\n`;
+				} catch {
+					content += `${sn.pages[i].text}\n`;
+				}
+			}
+			// Append Supernote internal links that appear on this page.
+			const pageLinks = linksByPage.get(String(i));
+			if (pageLinks) {
+				content += pageLinks.join('\n') + '\n';
 			}
 			if (imgs) {
 				let subpath = '';
@@ -220,6 +259,32 @@ class VaultWriter {
 		} else {
 			this.app.vault.create(filename, content);
 		}
+	}
+
+	private async resolvePageAnchor(link: ILink, cache: Map<string, SupernoteX>): Promise<string> {
+		// Library already resolved same-file links; nothing to do.
+		if (link.text.includes('#')) return link.text;
+		const pageid = link.PAGEID;
+		if (!pageid || pageid === '0' || pageid === 'none') return link.text;
+
+		const targetBasename = link.text;
+		let targetNote = cache.get(targetBasename);
+		if (!targetNote) {
+			const noteFile = this.app.vault.getFiles().find(
+				f => f.extension === 'note' && f.basename === targetBasename
+			);
+			if (!noteFile) return link.text;
+			try {
+				const buffer = await this.app.vault.readBinary(noteFile);
+				targetNote = new SupernoteX(new Uint8Array(buffer));
+				cache.set(targetBasename, targetNote);
+			} catch {
+				return link.text;
+			}
+		}
+
+		const pageIndex = targetNote.pages.findIndex(p => p.PAGEID === pageid);
+		return pageIndex >= 0 ? `${link.text}#Page ${pageIndex + 1}` : link.text;
 	}
 
 	async writeImageFiles(file: TFile, sn: SupernoteX): Promise<TFile[]> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,17 @@ function dataUrlToBuffer(dataUrl: string): ArrayBuffer {
  *
  * For each `@word` token → `[[word]]`
  */
-function processHashtagsAndMentions(text: string, app: App): string {
+/**
+ * noteKeywordTags: map from lowercase-normalized key (e.g. "new_tag") to the
+ * canonical tag string with # (e.g. "#New_tag"), derived from this note's own
+ * keyword stars. Used so that brand-new tags not yet indexed in the vault are
+ * still recognised as tags rather than headings.
+ */
+function processHashtagsAndMentions(
+	text: string,
+	app: App,
+	noteKeywordTags: Map<string, string> = new Map(),
+): string {
 	const tagSet = new Set<string>();
 	try {
 		// getTags() is an undocumented MetadataCache method that returns all vault
@@ -58,8 +68,20 @@ function processHashtagsAndMentions(text: string, app: App): string {
 	}
 
 	const result = text
-		.replace(/#\s*(\w[\w-]*)/g, (_match, word) => {
-			return tagSet.has(`#${word.toLowerCase()}`) ? `#${word}` : `# ${word}`;
+		.replace(/#\s*(\w[\w-]*)(\s+\w[\w-]*)?/g, (_match, word, next) => {
+			if (next) {
+				const nextWord = next.trim();
+				const twoWordKey = `${word.toLowerCase()}_${nextWord.toLowerCase()}`;
+				// Note's own keyword tags take priority (canonical capitalisation).
+				if (noteKeywordTags.has(twoWordKey)) return noteKeywordTags.get(twoWordKey)!;
+				// Existing vault tag.
+				if (tagSet.has(`#${twoWordKey}`)) return `#${word}_${nextWord}`;
+			}
+			const singleKey = word.toLowerCase();
+			if (noteKeywordTags.has(singleKey)) return noteKeywordTags.get(singleKey)!;
+			if (tagSet.has(`#${singleKey}`)) return `#${word}${next ?? ''}`;
+			// Not a tag → Markdown heading.
+			return `# ${word}${next ?? ''}`;
 		})
 		.replace(/@(\w+)/g, '[[$1]]');
 
@@ -74,12 +96,17 @@ function processHashtagsAndMentions(text: string, app: App): string {
  * @param app - The Obsidian app instance (used for tag lookup).
  * @returns The processed text.
  */
-function processSupernoteText(text: string, settings: SupernotePluginSettings, app: App): string {
+function processSupernoteText(
+	text: string,
+	settings: SupernotePluginSettings,
+	app: App,
+	noteKeywordTags: Map<string, string> = new Map(),
+): string {
 	let processedText = text;
 	if (settings.isCustomDictionaryEnabled) {
 		processedText = replaceTextWithCustomDictionary(processedText, settings.customDictionary);
 	}
-	processedText = processHashtagsAndMentions(processedText, app);
+	processedText = processHashtagsAndMentions(processedText, app, noteKeywordTags);
 	return processedText;
 }
 
@@ -196,45 +223,66 @@ class VaultWriter {
 		content = this.app.fileManager.generateMarkdownLink(file, filename);
 		content += '\n';
 
-		// Emit keyword tags collected from Supernote's star/keyword feature.
+		// Build per-page keyword tag map and a note-level keyword lookup for OCR processing.
+		// Use the KEYWORD footer key prefix (first 4 digits, 1-indexed) for the page,
+		// matching the same format as LINKO keys. KEYWORDPAGE can be '0' (invalid).
 		// Each keyword text is sanitized: non-alphanumeric characters become '_'.
-		const keywordTags: string[] = [];
+		const keywordsByPage = new Map<number, string[]>();
+		// noteKeywordTags: lowercase-normalized → canonical "#Tag" for brand-new tags
+		// not yet in the vault so processHashtagsAndMentions can still recognise them.
+		const noteKeywordTags = new Map<string, string>();
 		for (const key of Object.keys(sn.keywords)) {
+			const pageIdx = parseInt(key.slice(0, 4)) - 1;
 			for (const kw of sn.keywords[key]) {
 				const text = kw.KEYWORD.trim();
 				if (!text) continue;
 				const tag = `#${text.replace(/[^\w-]/g, '_').replace(/_+/g, '_').replace(/^_|_$/g, '')}`;
-				if (!keywordTags.includes(tag)) keywordTags.push(tag);
+				if (!keywordsByPage.has(pageIdx)) keywordsByPage.set(pageIdx, []);
+				if (!keywordsByPage.get(pageIdx)!.includes(tag))
+					keywordsByPage.get(pageIdx)!.push(tag);
+				// Register for OCR lookup (single-word and two-word keys).
+				const parts = tag.slice(1).split('_');
+				if (parts.length === 1) noteKeywordTags.set(parts[0].toLowerCase(), tag);
+				if (parts.length === 2) noteKeywordTags.set(`${parts[0].toLowerCase()}_${parts[1].toLowerCase()}`, tag);
 			}
 		}
-		if (keywordTags.length > 0) {
-			content += keywordTags.join(' ') + '\n\n';
-		}
 
-		// Build a page-indexed map of links for quick lookup in the page loop.
+		// Build per-page link map. The LINKO key encodes the source page as its
+		// first 4 digits (1-indexed), so we use that instead of OBJPAGE.
+		// Sorting keys gives top-to-bottom link order within each page.
 		const snLinks = sn.links ?? {};
-		const linksByPage = new Map<string, string[]>();
+		const linksByPage = new Map<number, string[]>();
 		const noteCache = new Map<string, SupernoteX>();
-		for (const key of Object.keys(snLinks)) {
+		for (const key of Object.keys(snLinks).sort()) {
 			for (const link of snLinks[key]) {
 				if (!link.text) continue;
 				const text = await this.resolvePageAnchor(link, noteCache);
-				if (!linksByPage.has(link.OBJPAGE)) linksByPage.set(link.OBJPAGE, []);
-				linksByPage.get(link.OBJPAGE)!.push(`[[${text}]]`);
+				const pageIdx = parseInt(key.slice(0, 4)) - 1;
+				if (!linksByPage.has(pageIdx)) linksByPage.set(pageIdx, []);
+				linksByPage.get(pageIdx)!.push(`[[${text}]]`);
 			}
 		}
 
 		for (let i = 0; i < sn.pages.length; i++) {
 			content += `## Page ${i + 1}\n\n`
+			// Process OCR text first so we can check which keyword tags are already embedded.
+			let pageOcrText = '';
 			if (sn.pages[i].text !== undefined && sn.pages[i].text.length > 0) {
 				try {
-					content += `${processSupernoteText(sn.pages[i].text, this.settings, this.app)}\n`;
+					pageOcrText = processSupernoteText(sn.pages[i].text, this.settings, this.app, noteKeywordTags);
 				} catch {
-					content += `${sn.pages[i].text}\n`;
+					pageOcrText = sn.pages[i].text;
 				}
 			}
+			// Only emit keyword tags not already present in the OCR text.
+			const pageTags = keywordsByPage.get(i);
+			if (pageTags) {
+				const missing = pageTags.filter(tag => !pageOcrText.includes(tag));
+				if (missing.length > 0) content += missing.join(' ') + '\n\n';
+			}
+			if (pageOcrText) content += pageOcrText + '\n';
 			// Append Supernote internal links that appear on this page.
-			const pageLinks = linksByPage.get(String(i));
+			const pageLinks = linksByPage.get(i);
 			if (pageLinks) {
 				content += pageLinks.join('\n') + '\n';
 			}

--- a/src/main.ts
+++ b/src/main.ts
@@ -106,7 +106,9 @@ function processSupernoteText(
 	if (settings.isCustomDictionaryEnabled) {
 		processedText = replaceTextWithCustomDictionary(processedText, settings.customDictionary);
 	}
-	processedText = processHashtagsAndMentions(processedText, app, noteKeywordTags);
+	if (settings.isHashtagsMentionsEnabled) {
+		processedText = processHashtagsAndMentions(processedText, app, noteKeywordTags);
+	}
 	return processedText;
 }
 
@@ -234,19 +236,21 @@ class VaultWriter {
 		// noteKeywordTags: lowercase-normalized → canonical "#Tag" for brand-new tags
 		// not yet in the vault so processHashtagsAndMentions can still recognise them.
 		const noteKeywordTags = new Map<string, string>();
-		for (const key of Object.keys(sn.keywords)) {
-			const pageIdx = parseInt(key.slice(0, 4)) - 1;
-			for (const kw of sn.keywords[key]) {
-				const text = kw.KEYWORD.trim();
-				if (!text) continue;
-				const tag = `#${text.replace(/[^\w-]/g, '_').replace(/_+/g, '_').replace(/^_|_$/g, '')}`;
-				if (!keywordsByPage.has(pageIdx)) keywordsByPage.set(pageIdx, []);
-				if (!keywordsByPage.get(pageIdx)!.includes(tag))
-					keywordsByPage.get(pageIdx)!.push(tag);
-				// Register for OCR lookup (single-word and two-word keys).
-				const parts = tag.slice(1).split('_');
-				if (parts.length === 1) noteKeywordTags.set(parts[0].toLowerCase(), tag);
-				if (parts.length === 2) noteKeywordTags.set(`${parts[0].toLowerCase()}_${parts[1].toLowerCase()}`, tag);
+		if (this.settings.isKeywordsAndLinksEnabled) {
+			for (const key of Object.keys(sn.keywords)) {
+				const pageIdx = parseInt(key.slice(0, 4)) - 1;
+				for (const kw of sn.keywords[key]) {
+					const text = kw.KEYWORD.trim();
+					if (!text) continue;
+					const tag = `#${text.replace(/[^\w-]/g, '_').replace(/_+/g, '_').replace(/^_|_$/g, '')}`;
+					if (!keywordsByPage.has(pageIdx)) keywordsByPage.set(pageIdx, []);
+					if (!keywordsByPage.get(pageIdx)!.includes(tag))
+						keywordsByPage.get(pageIdx)!.push(tag);
+					// Register for OCR lookup (single-word and two-word keys).
+					const parts = tag.slice(1).split('_');
+					if (parts.length === 1) noteKeywordTags.set(parts[0].toLowerCase(), tag);
+					if (parts.length === 2) noteKeywordTags.set(`${parts[0].toLowerCase()}_${parts[1].toLowerCase()}`, tag);
+				}
 			}
 		}
 
@@ -255,14 +259,16 @@ class VaultWriter {
 		// Sorting keys gives top-to-bottom link order within each page.
 		const snLinks = sn.links ?? {};
 		const linksByPage = new Map<number, string[]>();
-		const noteCache = new Map<string, SupernoteX>();
-		for (const key of Object.keys(snLinks).sort()) {
-			for (const link of snLinks[key]) {
-				if (!link.text) continue;
-				const text = await this.resolvePageAnchor(link, noteCache);
-				const pageIdx = parseInt(key.slice(0, 4)) - 1;
-				if (!linksByPage.has(pageIdx)) linksByPage.set(pageIdx, []);
-				linksByPage.get(pageIdx)!.push(`[[${text}]]`);
+		if (this.settings.isKeywordsAndLinksEnabled) {
+			const noteCache = new Map<string, SupernoteX>();
+			for (const key of Object.keys(snLinks).sort()) {
+				for (const link of snLinks[key]) {
+					if (!link.text) continue;
+					const text = await this.resolvePageAnchor(link, noteCache);
+					const pageIdx = parseInt(key.slice(0, 4)) - 1;
+					if (!linksByPage.has(pageIdx)) linksByPage.set(pageIdx, []);
+					linksByPage.get(pageIdx)!.push(`[[${text}]]`);
+				}
 			}
 		}
 
@@ -278,16 +284,20 @@ class VaultWriter {
 				}
 			}
 			// Only emit keyword tags not already present in the OCR text.
-			const pageTags = keywordsByPage.get(i);
-			if (pageTags) {
-				const missing = pageTags.filter(tag => !pageOcrText.includes(tag));
-				if (missing.length > 0) content += missing.join(' ') + '\n\n';
+			if (this.settings.isKeywordsAndLinksEnabled) {
+				const pageTags = keywordsByPage.get(i);
+				if (pageTags) {
+					const missing = pageTags.filter(tag => !pageOcrText.includes(tag));
+					if (missing.length > 0) content += missing.join(' ') + '\n\n';
+				}
 			}
 			if (pageOcrText) content += pageOcrText + '\n';
 			// Append Supernote internal links that appear on this page.
-			const pageLinks = linksByPage.get(i);
-			if (pageLinks) {
-				content += pageLinks.join('\n') + '\n';
+			if (this.settings.isKeywordsAndLinksEnabled) {
+				const pageLinks = linksByPage.get(i);
+				if (pageLinks) {
+					content += pageLinks.join('\n') + '\n';
+				}
 			}
 			if (imgs) {
 				let subpath = '';
@@ -723,7 +733,7 @@ export default class SupernotePlugin extends Plugin {
 		this.registerEvent(
 			this.app.vault.on('create', (file) => {
 				if (!(file instanceof TFile) || file.extension !== 'note') return;
-				if (!this.settings.autoSyncMarkdown) return;
+				if (!this.settings.isAutoSyncMarkdownEnabled) return;
 				vw.attachMarkdownFile(file, true).catch(e => console.error('Supernote auto-sync (create) error:', e));
 			})
 		);
@@ -731,7 +741,7 @@ export default class SupernotePlugin extends Plugin {
 		this.registerEvent(
 			this.app.vault.on('modify', (file) => {
 				if (!(file instanceof TFile) || file.extension !== 'note') return;
-				if (!this.settings.autoSyncMarkdown) return;
+				if (!this.settings.isAutoSyncMarkdownEnabled) return;
 				const existing = syncDebounceMap.get(file.path);
 				if (existing) clearTimeout(existing);
 				syncDebounceMap.set(file.path, setTimeout(() => {

--- a/src/myworker.worker.ts
+++ b/src/myworker.worker.ts
@@ -2,6 +2,7 @@ import { installAtPolyfill } from 'polyfills';
 installAtPolyfill();
 
 import { SupernoteX, toImage } from 'supernote-typescript';
+import { encodeDataURL } from 'image-js';
 
 export { };
 
@@ -25,10 +26,10 @@ self.onmessage = async (e: MessageEvent<SupernoteWorkerMessage>) => {
             const results = await toImage(note, pageNumbers);
             // Convert canvas/images to data URLs before sending
             const dataUrls = results.map(result => {
-                if (result && typeof result.toDataURL === 'function') {
-                    return result.toDataURL();
+                if (result) {
+                    return encodeDataURL(result);
                 }
-                console.error('Result is not a canvas or does not support toDataURL');
+                console.error('Result is not a valid image');
                 return null;
             });
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,6 +10,7 @@ export interface SupernotePluginSettings extends CustomDictionarySettings {
     invertColorsWhenDark: boolean;
     showTOC: boolean;
     showExportButtons: boolean;
+    autoSyncMarkdown: boolean;
     collapseRecognizedText: boolean,
     noteImageMaxDim: number;
 }
@@ -19,6 +20,7 @@ export const DEFAULT_SETTINGS: SupernotePluginSettings = {
     invertColorsWhenDark: true,
     showTOC: true,
     showExportButtons: true,
+    autoSyncMarkdown: false,
     collapseRecognizedText: false,
     noteImageMaxDim: 800, // Sensible default for Nomad pages to be legible but not too big. Unit: px
 	...CUSTOM_DICTIONARY_DEFAULT_SETTINGS,
@@ -98,6 +100,20 @@ export class SupernoteSettingTab extends PluginSettingTab {
                     .setValue(this.plugin.settings.showExportButtons)
                     .onChange(async (value) => {
                         this.plugin.settings.showExportButtons = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
+            .setName('Auto-sync .note files to markdown')
+            .setDesc(
+                'Automatically export recognized text to a .md file whenever a .note file is added or modified in the vault.',
+            )
+            .addToggle((text) =>
+                text
+                    .setValue(this.plugin.settings.autoSyncMarkdown)
+                    .onChange(async (value) => {
+                        this.plugin.settings.autoSyncMarkdown = value;
                         await this.plugin.saveSettings();
                     }),
             );

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,6 +15,7 @@ export interface SupernotePluginSettings extends CustomDictionarySettings {
     noteImageMaxDim: number;
     isKeywordsAndLinksEnabled: boolean;
     isHashtagsMentionsEnabled: boolean;
+    markdownMirrorFolder: string;
 }
 
 export const DEFAULT_SETTINGS: SupernotePluginSettings = {
@@ -27,6 +28,7 @@ export const DEFAULT_SETTINGS: SupernotePluginSettings = {
     noteImageMaxDim: 800, // Sensible default for Nomad pages to be legible but not too big. Unit: px
     isKeywordsAndLinksEnabled: true,
     isHashtagsMentionsEnabled: true,
+    markdownMirrorFolder: '',
 	...CUSTOM_DICTIONARY_DEFAULT_SETTINGS,
 }
 
@@ -120,6 +122,20 @@ export class SupernoteSettingTab extends PluginSettingTab {
                         this.plugin.settings.isAutoSyncMarkdownEnabled = value;
                         await this.plugin.saveSettings();
                     }),
+            );
+
+        new Setting(containerEl)
+            .setName('Markdown mirror folder')
+            .setDesc(
+                'Save exported .md files in this vault folder, mirroring the .note file structure, instead of alongside each .note file. Leave empty to save alongside the note. Example: SupernoteMarkdowns',
+            )
+            .addText(text => text
+                .setPlaceholder('SupernoteMarkdowns')
+                .setValue(this.plugin.settings.markdownMirrorFolder)
+                .onChange(async (value) => {
+                    this.plugin.settings.markdownMirrorFolder = value.trim();
+                    await this.plugin.saveSettings();
+                })
             );
 
         new Setting(containerEl)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,7 @@ export interface SupernotePluginSettings extends CustomDictionarySettings {
     isKeywordsAndLinksEnabled: boolean;
     isHashtagsMentionsEnabled: boolean;
     markdownMirrorFolder: string;
+    noteWatchFolder: string;
 }
 
 export const DEFAULT_SETTINGS: SupernotePluginSettings = {
@@ -29,6 +30,7 @@ export const DEFAULT_SETTINGS: SupernotePluginSettings = {
     isKeywordsAndLinksEnabled: true,
     isHashtagsMentionsEnabled: true,
     markdownMirrorFolder: '',
+    noteWatchFolder: '',
 	...CUSTOM_DICTIONARY_DEFAULT_SETTINGS,
 }
 
@@ -110,7 +112,11 @@ export class SupernoteSettingTab extends PluginSettingTab {
                     }),
             );
 
-        new Setting(containerEl)
+        const autoSyncGroup = containerEl.createDiv();
+        autoSyncGroup.style.cssText =
+            'border: 1px solid var(--background-modifier-border); border-radius: var(--radius-m, 8px); overflow: hidden; margin-bottom: 16px;';
+
+        new Setting(autoSyncGroup)
             .setName('Auto-sync .note files to markdown')
             .setDesc(
                 'Automatically export recognized text to a .md file whenever a .note file is added or modified in the vault.',
@@ -120,9 +126,25 @@ export class SupernoteSettingTab extends PluginSettingTab {
                     .setValue(this.plugin.settings.isAutoSyncMarkdownEnabled)
                     .onChange(async (value) => {
                         this.plugin.settings.isAutoSyncMarkdownEnabled = value;
+                        watchFolderSetting.settingEl.style.display = value ? '' : 'none';
                         await this.plugin.saveSettings();
                     }),
             );
+
+        const watchFolderSetting = new Setting(autoSyncGroup)
+            .setName('Watched folder')
+            .setDesc(
+                'Only auto-sync .note files inside this vault folder. Leave empty to watch the whole vault. When set alongside a mirror folder, the watched folder prefix is stripped from the mirror path. Example: Supernote',
+            )
+            .addText(text => text
+                .setPlaceholder('Supernote')
+                .setValue(this.plugin.settings.noteWatchFolder)
+                .onChange(async (value) => {
+                    this.plugin.settings.noteWatchFolder = value.trim().replace(/\/$/, '');
+                    await this.plugin.saveSettings();
+                })
+            );
+        watchFolderSetting.settingEl.style.display = this.plugin.settings.isAutoSyncMarkdownEnabled ? '' : 'none';
 
         new Setting(containerEl)
             .setName('Markdown mirror folder')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,9 +10,11 @@ export interface SupernotePluginSettings extends CustomDictionarySettings {
     invertColorsWhenDark: boolean;
     showTOC: boolean;
     showExportButtons: boolean;
-    autoSyncMarkdown: boolean;
+    isAutoSyncMarkdownEnabled: boolean;
     collapseRecognizedText: boolean,
     noteImageMaxDim: number;
+    isKeywordsAndLinksEnabled: boolean;
+    isHashtagsMentionsEnabled: boolean;
 }
 
 export const DEFAULT_SETTINGS: SupernotePluginSettings = {
@@ -20,9 +22,11 @@ export const DEFAULT_SETTINGS: SupernotePluginSettings = {
     invertColorsWhenDark: true,
     showTOC: true,
     showExportButtons: true,
-    autoSyncMarkdown: false,
+    isAutoSyncMarkdownEnabled: false,
     collapseRecognizedText: false,
     noteImageMaxDim: 800, // Sensible default for Nomad pages to be legible but not too big. Unit: px
+    isKeywordsAndLinksEnabled: true,
+    isHashtagsMentionsEnabled: true,
 	...CUSTOM_DICTIONARY_DEFAULT_SETTINGS,
 }
 
@@ -111,9 +115,9 @@ export class SupernoteSettingTab extends PluginSettingTab {
             )
             .addToggle((text) =>
                 text
-                    .setValue(this.plugin.settings.autoSyncMarkdown)
+                    .setValue(this.plugin.settings.isAutoSyncMarkdownEnabled)
                     .onChange(async (value) => {
-                        this.plugin.settings.autoSyncMarkdown = value;
+                        this.plugin.settings.isAutoSyncMarkdownEnabled = value;
                         await this.plugin.saveSettings();
                     }),
             );
@@ -138,6 +142,28 @@ export class SupernoteSettingTab extends PluginSettingTab {
                 .setValue(this.plugin.settings.noteImageMaxDim)
                 .onChange(async (value) => {
                     this.plugin.settings.noteImageMaxDim = value;
+                    await this.plugin.saveSettings();
+                })
+            );
+
+		new Setting(containerEl)
+            .setName('Convert Supernote keywords to tags and links to Wikilinks')
+            .setDesc('In exported markdown, turn starred keywords into Obsidian tags (e.g. #My_Tag) and Supernote internal links into Wikilinks (e.g. [[note#Page 1]]).')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.isKeywordsAndLinksEnabled)
+                .onChange(async (value) => {
+                    this.plugin.settings.isKeywordsAndLinksEnabled = value;
+                    await this.plugin.saveSettings();
+                })
+            );
+
+        new Setting(containerEl)
+            .setName('Convert # and @ in recognized text to tags and Wikilinks')
+            .setDesc('In exported markdown, convert #Word into an Obsidian tag or heading, and @Word(s) into a Wikilink [[Word(s)]].')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.isHashtagsMentionsEnabled)
+                .onChange(async (value) => {
+                    this.plugin.settings.isHashtagsMentionsEnabled = value;
                     await this.plugin.saveSettings();
                 })
             );


### PR DESCRIPTION
## Markdown export: links, tags, OCR markup, auto-sync and mirror folder

This PR builds on the updated `supernote-typescript` submodule (which now parses
internal links and keyword stars) to surface those features as Obsidian-native
constructs in the exported markdown. It also fixes several bugs in the auto-sync
workflow and adds new settings to control the behaviour.

### Supernote keywords → Obsidian tags

Starred keywords from the Supernote app are emitted as Obsidian tags (e.g.
`#Supernote_Keyword`) on the correct page of the exported markdown, rather than
as a flat list at the top of the document.

- The source page is derived from the KEYWORD footer key prefix (first 4 digits,
  1-indexed), matching the LINKO key format. This is more reliable than the
  `KEYWORDPAGE` field, which can be `'0'` (invalid).
- Tags are emitted **before** the OCR text on each page but deduplicated: if the
  same tag was already embedded in the processed OCR text (see below), it is not
  repeated in the page header.
- A note-level keyword map is built at export time so that brand-new tags — not
  yet indexed in the Obsidian vault — are still recognised as tags rather than
  headings during OCR processing.

### Supernote links → Wikilinks

Internal links created via the Supernote link feature are emitted as Obsidian
Wikilinks on the correct page.

- The source page is derived from the LINKO footer key prefix (first 4 digits,
  1-indexed) rather than `OBJPAGE`, which is unreliable.
- Links within a page are ordered top-to-bottom by sorting LINKO keys
  (the key encodes the Y coordinate after the page prefix).
- **Page anchors**: for same-document links the `text` field already contains
  `#Page N` (resolved by the library). For cross-file links the plugin loads the
  target `.note` from the vault, parses it, and resolves the `PAGEID` to a page
  number — e.g. `[[other-note#Page 2]]`. A per-call cache avoids re-parsing the
  same file multiple times.
- Links with `PAGEID: 'none'` or where the target file is not in the vault
  produce a plain Wikilink without a page anchor.

### OCR markup: `#` → tags/headings, `@` → Wikilinks

A new `processHashtagsAndMentions` function post-processes the OCR text of each
page:

- `#Word` or `# Word`: checked against the Obsidian vault tag index. If the tag
  exists → inline tag (`#Word`); otherwise → Markdown heading (`# Word`). Two-word
  combinations (e.g. `# Existing Tag`) are also checked as `#existing_tag` before
  falling back to a heading. The note's own keyword stars are checked first so
  newly created tags are recognised even before they appear in the vault index.
- `@ Word(s)`: everything after the `@` on the same line becomes a Wikilink
  (`[[Word(s)]]`), supporting multi-word note names.

### Auto-sync fixes

- **Path construction bug**: the previous code used
  `` `${file.parent?.path}/${file.basename}.md` `` which produces `//name.md` for
  vault-root files (Obsidian returns `"/"` as the root folder path). The output
  path is now derived from `file.path.replace(/\.note$/i, '.md')`, which Obsidian
  always formats correctly.
- **Race condition**: when a `.note` file syncs, Obsidian fires both `'create'`
  and `'modify'` events in quick succession. Both handlers called
  `vault.create`, causing a *"File already exists"* error. The `overwrite` path
  now wraps `vault.create` in a try/catch and retries with `vault.modify` when
  the file appeared between the existence check and the create.
- `attachMarkdownFile` now properly `await`s `writeMarkdownFile` so errors
  surface rather than being silently dropped as unhandled promise rejections.
- `.catch()` handlers added to both vault event callbacks so any remaining errors
  appear in the developer console instead of as uncaught exceptions.

### Markdown mirror folder

A new optional setting lets users save all exported markdown files into a
dedicated vault folder that mirrors the `.note` file structure, instead of
placing each `.md` file alongside its `.note` file.

- Setting: **Markdown mirror folder** (text input, empty by default = save
  alongside). Example value: `SupernoteMarkdowns`.
- `ensureFolderExists` walks the path segment by segment, creating any missing
  intermediate folders (with a concurrent-creation guard).
- Works correctly for notes at the vault root and in nested subfolders.

### New settings

All new behaviours are opt-out via toggles in the plugin settings:

| Setting | Default | Description |
|---|---|---|
| `isAutoSyncMarkdownEnabled` | `false` | Auto-export markdown when a `.note` file changes |
| `isKeywordsAndLinksEnabled` | `true` | Convert keywords to tags and links to Wikilinks |
| `isHashtagsMentionsEnabled` | `true` | Convert `#` and `@` in OCR text |
| `markdownMirrorFolder` | `""` | Output folder for mirrored markdown files |
