### PR TITLE
feat: import digest highlights as Readwise-style markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ This plugin has four main features:
 
 - ⬇️  Download & Upload files directly from your device via the Supernote [Browse & Access](https://support.supernote.com/en_US/Tools-Features/wi-fi-transfer) feature. ([demo video](https://www.youtube.com/watch?v=SEkp395hbBM))
 
+- 📖 Import digest highlights from your Supernote into
+  Obsidian as Readwise-style markdown. On your Supernote,
+  open the Digest app, select all highlights, and export
+  as `.txt`. Then in Obsidian, open the command palette
+  and run "Import digest" to select your exported file.
+  Highlights are grouped by book with metadata (author,
+  year, category) and sorted by chapter, page, then
+  modification time. Output folder is configurable in
+  Settings.
+
 **Video Demo**
 
 [![Watch the video](https://img.youtube.com/vi/tEoW35fYVew/hqdefault.jpg)](https://www.youtube.com/watch?v=tEoW35fYVew)

--- a/src/digestParser.ts
+++ b/src/digestParser.ts
@@ -1,0 +1,298 @@
+export interface DigestHighlight {
+  content: string;
+  page: number;
+  chapter: string;
+}
+
+export interface DigestBook {
+  title: string;
+  author: string;
+  year: string;
+  category: string;
+  readDate: string;
+  highlights: DigestHighlight[];
+}
+
+interface ParsedBlock {
+  path: string;
+  page: number;
+  chapter: string;
+  charStart: number;
+  modifyTime: number;
+  content: string;
+}
+
+function deriveCategory(path: string): string {
+  if (path.includes("/Books/")) return "#books";
+  if (path.includes("/Articles/")) return "#articles";
+  if (
+    path.includes("/Documents/") ||
+    path.includes("/Document/")
+  ) {
+    return "#documents";
+  }
+  return "#highlights";
+}
+
+function parsePathSegments(
+  path: string,
+): { title: string; author: string; year: string } | null {
+  const fileProto = "file://";
+  const raw = path.startsWith(fileProto)
+    ? path.slice(fileProto.length)
+    : path;
+
+  const lastSlash = raw.lastIndexOf("/");
+  const filename =
+    lastSlash >= 0 ? raw.slice(lastSlash + 1) : raw;
+
+  // Strip file extension
+  const dotIdx = filename.lastIndexOf(".");
+  const base = dotIdx >= 0
+    ? filename.slice(0, dotIdx)
+    : filename;
+
+  const segments = base.split("--").map((s) => s.trim());
+
+  // No "--" delimiters: use filename as title,
+  // leave author and year empty.
+  if (segments.length < 2) {
+    return { title: base.trim(), author: '', year: '' };
+  }
+
+  const title = segments[0];
+  const author = segments.length >= 2
+    ? segments[1] : '';
+
+  let year = '';
+  if (segments.length >= 3) {
+    const editionYear = segments[2];
+    const parts = editionYear
+      .split(",").map((p) => p.trim());
+    year = parts.length >= 2
+      ? parts[parts.length - 1] : parts[0];
+  }
+
+  return { title, author, year };
+}
+
+function extractField(
+  block: string,
+  field: string,
+): string | null {
+  // Support both flat ("linkinfo.path:") and nested
+  // ("linkinfo:\n  path:") formats. For nested fields
+  // like "linkinfo.path", extract the leaf key "path".
+  const parts = field.split(".");
+  const leafKey = parts[parts.length - 1];
+  const prefix = `${leafKey}:`;
+  for (const line of block.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith(prefix)) {
+      return trimmed.slice(prefix.length).trim();
+    }
+  }
+  return null;
+}
+
+function extractContent(block: string): string | null {
+  const marker = "content:\n";
+  const idx = block.indexOf(marker);
+  if (idx < 0) return null;
+
+  const raw = block.slice(idx + marker.length);
+  const lines = raw
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  return lines.length > 0 ? lines.join(" ") : null;
+}
+
+function formatDate(timestamp: number): string {
+  const d = new Date(timestamp);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function parseChapterNumber(chapter: string): string {
+  const dash = chapter.indexOf("-");
+  return dash >= 0 ? chapter.slice(0, dash) : chapter;
+}
+
+function parseCharStart(chapter: string): number {
+  const match = chapter.match(/\[(\d+)-/);
+  return match ? parseInt(match[1], 10) : 0;
+}
+
+function parseBlock(raw: string): ParsedBlock | null {
+  const path = extractField(raw, "linkinfo.path");
+  const pageStr = extractField(raw, "linkinfo.page");
+  const chapter = extractField(
+    raw, "linkinfo.chapter",
+  );
+  const content = extractContent(raw);
+
+  if (!path || !pageStr || !content) {
+    return null;
+  }
+
+  const page = parseInt(pageStr, 10);
+  if (isNaN(page)) return null;
+
+  const charStart = chapter
+    ? parseCharStart(chapter)
+    : 0;
+
+  const modifyTimeStr = extractField(
+    raw, "modify_time.timestamp",
+  );
+  const modifyTime = modifyTimeStr
+    ? parseInt(modifyTimeStr, 10)
+    : 0;
+
+  return {
+    path, page, chapter: chapter || "",
+    charStart, modifyTime, content,
+  };
+}
+
+export function parseDigest(text: string): DigestBook[] {
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+
+  // Strip outer brackets and split on block boundaries
+  const inner = trimmed.startsWith("[")
+    ? trimmed.slice(1)
+    : trimmed;
+  const stripped = inner.endsWith("]")
+    ? inner.slice(0, -1)
+    : inner;
+
+  const rawBlocks = stripped.split("]\n\n[");
+
+  const bookMap = new Map<
+    string,
+    {
+      title: string;
+      author: string;
+      year: string;
+      category: string;
+      maxModifyTime: number;
+      highlights: (DigestHighlight & {
+        charStart: number;
+        modifyTime: number;
+      })[];
+    }
+  >();
+
+  for (const raw of rawBlocks) {
+    const parsed = parseBlock(raw);
+    if (!parsed) continue;
+
+    const meta = parsePathSegments(parsed.path);
+    if (!meta) continue;
+
+    const key = `${meta.title}\0${meta.author}`;
+    const chapterNum = parseChapterNumber(parsed.chapter);
+    const category = deriveCategory(parsed.path);
+
+    if (!bookMap.has(key)) {
+      bookMap.set(key, {
+        title: meta.title,
+        author: meta.author,
+        year: meta.year,
+        category,
+        maxModifyTime: 0,
+        highlights: [],
+      });
+    }
+
+    const entry = bookMap.get(key)!;
+    if (parsed.modifyTime > entry.maxModifyTime) {
+      entry.maxModifyTime = parsed.modifyTime;
+    }
+
+    entry.highlights.push({
+      content: parsed.content,
+      page: parsed.page,
+      chapter: chapterNum,
+      charStart: parsed.charStart,
+      modifyTime: parsed.modifyTime,
+    });
+  }
+
+  const books: DigestBook[] = [];
+  for (const entry of bookMap.values()) {
+    entry.highlights.sort((a, b) => {
+      // Sort by chapter first (if chapters exist)
+      const chA = parseInt(a.chapter, 10);
+      const chB = parseInt(b.chapter, 10);
+      const hasChA = !isNaN(chA);
+      const hasChB = !isNaN(chB);
+      if (hasChA && hasChB && chA !== chB) {
+        return chA - chB;
+      }
+      // Then by page
+      if (a.page !== b.page) return a.page - b.page;
+      // Then by modify time
+      if (a.modifyTime !== b.modifyTime) {
+        return a.modifyTime - b.modifyTime;
+      }
+      return a.charStart - b.charStart;
+    });
+
+    const readDate = entry.maxModifyTime > 0
+      ? formatDate(entry.maxModifyTime)
+      : '';
+
+    books.push({
+      title: entry.title,
+      author: entry.author,
+      year: entry.year,
+      category: entry.category,
+      readDate,
+      highlights: entry.highlights.map(
+        ({ charStart: _, modifyTime: __, ...h }) => h,
+      ),
+    });
+  }
+
+  return books;
+}
+
+export function generateDigestMarkdown(
+  book: DigestBook,
+): string {
+  const lines: string[] = [];
+
+  lines.push(`# ${book.title}`);
+  lines.push("");
+  lines.push("## Metadata");
+  if (book.author) {
+    lines.push(`- Author: [[${book.author}]]`);
+  }
+  lines.push(`- Full Title: ${book.title}`);
+  if (book.year) {
+    lines.push(`- Year: ${book.year}`);
+  }
+  lines.push(`- Category: ${book.category}`);
+  if (book.readDate) {
+    lines.push(`- Read Date: ${book.readDate}`);
+  }
+  lines.push("");
+  lines.push("## Highlights");
+
+  for (const h of book.highlights) {
+    const chNum = parseInt(h.chapter, 10);
+    const showChapter = h.chapter && chNum > 0;
+    const loc = showChapter
+      ? `Page ${h.page}, Chapter ${h.chapter}`
+      : `Page ${h.page}`;
+    lines.push(`- ${h.content} (${loc})`);
+  }
+
+  return lines.join("\n") + "\n";
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { installAtPolyfill } from './polyfills';
-import { App, Modal, TFile, Plugin, Editor, MarkdownView, WorkspaceLeaf, FileView } from 'obsidian';
+import { App, Modal, Notice, TFile, Plugin, Editor, MarkdownView, WorkspaceLeaf, FileView } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS } from './settings';
 import { SupernoteX, fetchMirrorFrame } from 'supernote-typescript';
 import { DownloadListModal, UploadListModal } from './FileListModal';
@@ -7,6 +7,10 @@ import { jsPDF } from 'jspdf';
 import { SupernoteWorkerMessage, SupernoteWorkerResponse } from './myworker.worker';
 import Worker from 'myworker.worker';
 import { replaceTextWithCustomDictionary } from './customDictionary';
+import {
+    parseDigest,
+    generateDigestMarkdown,
+} from './digestParser';
 
 function generateTimestamp(): string {
 	const date = new Date();
@@ -549,10 +553,106 @@ export default class SupernotePlugin extends Plugin {
 				return false;
 			},
 		});
+
+		this.addCommand({
+			id: 'import-digest',
+			name: 'Import digest',
+			callback: async () => {
+				const input =
+					document.createElement('input');
+				input.type = 'file';
+				input.accept = '.txt';
+				input.addEventListener(
+					'change',
+					async () => {
+						const file =
+							input.files?.[0];
+						if (!file) return;
+						try {
+							const text =
+								await file.text();
+							const books =
+								parseDigest(text);
+							if (
+								books.length === 0
+							) {
+								new ErrorModal(
+									this.app,
+									new Error(
+										'No highlights'
+										+ ' found in'
+										+ ' digest'
+										+ ' file',
+									),
+								).open();
+								return;
+							}
+							await this
+								.importDigestBooks(
+									books,
+								);
+						} catch (err: any) {
+							new ErrorModal(
+								this.app,
+								err,
+							).open();
+						}
+					},
+				);
+				input.click();
+			},
+		});
 	}
 
 	onunload() {
 
+	}
+
+	async importDigestBooks(
+		books: import('./digestParser').DigestBook[],
+	) {
+		const folder =
+			this.settings.digestOutputFolder
+			|| 'Supernote Digests';
+
+		// Ensure output folder exists
+		if (
+			!this.app.vault
+				.getAbstractFileByPath(folder)
+		) {
+			await this.app.vault
+				.createFolder(folder);
+		}
+
+		let imported = 0;
+		for (const book of books) {
+			const markdown =
+				generateDigestMarkdown(book);
+			const sanitized = book.title
+				.replace(/[\\/:*?"<>|]/g, '-');
+			const filepath =
+				`${folder}/${sanitized}.md`;
+
+			const existing =
+				this.app.vault
+					.getFileByPath(filepath);
+			if (existing) {
+				await this.app.vault.modify(
+					existing,
+					markdown,
+				);
+			} else {
+				await this.app.vault.create(
+					filepath,
+					markdown,
+				);
+			}
+			imported++;
+		}
+
+		new Notice(
+			`Imported ${imported} book(s) from digest`,
+		);
 	}
 
 	async activateView() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,6 +12,7 @@ export interface SupernotePluginSettings extends CustomDictionarySettings {
     showExportButtons: boolean;
     collapseRecognizedText: boolean,
     noteImageMaxDim: number;
+    digestOutputFolder: string;
 }
 
 export const DEFAULT_SETTINGS: SupernotePluginSettings = {
@@ -21,6 +22,7 @@ export const DEFAULT_SETTINGS: SupernotePluginSettings = {
     showExportButtons: true,
     collapseRecognizedText: false,
     noteImageMaxDim: 800, // Sensible default for Nomad pages to be legible but not too big. Unit: px
+    digestOutputFolder: 'Supernote Digests',
 	...CUSTOM_DICTIONARY_DEFAULT_SETTINGS,
 }
 
@@ -122,6 +124,25 @@ export class SupernoteSettingTab extends PluginSettingTab {
                 .setValue(this.plugin.settings.noteImageMaxDim)
                 .onChange(async (value) => {
                     this.plugin.settings.noteImageMaxDim = value;
+                    await this.plugin.saveSettings();
+                })
+            );
+
+        new Setting(containerEl)
+            .setName('Digest output folder')
+            .setDesc(
+                'Folder in your vault where imported digest'
+                + ' highlights will be saved. One file per'
+                + ' book/document.',
+            )
+            .addText(text => text
+                .setPlaceholder('Supernote Digests')
+                .setValue(
+                    this.plugin.settings.digestOutputFolder,
+                )
+                .onChange(async (value) => {
+                    this.plugin.settings
+                        .digestOutputFolder = value;
                     await this.plugin.saveSettings();
                 })
             );


### PR DESCRIPTION
📢 things to highlight with this PR:

1: it's ai-generated.
2: don't feel any obligation to merge (literally zero hard feelings :smiling), i just figured i'd contribute to your upstream incase others would find it useful as SuperNotes' "digest" feature is literally why I purchased the device over other e-ink devices because I saw your plugin existed and assumed it had this functionality and if it didn't i was just going to fork your amazing plugin ❤️

(Thank so much for your amazing work on this plugin! ❤️)

3: if you want, I could record a demo similar to the ones in the README to demonstrate the functionality. 

## Summary

Add a new "Import digest" command that converts Supernote digest `.txt` exports into [Readwise](https://github.com/readwiseio/obsidian-readwise)-style Obsidian markdown files.


<img width="1941" height="501" alt="image" src="https://github.com/user-attachments/assets/c4970cdd-8040-481a-a222-db57b754f973" />


### How to use

1. On your Supernote, open the Digest app
2. Select all highlights and export as `.txt`
3. In Obsidian, open the command palette and run **Import digest**
4. Select your exported digest `.txt` file

Output folder is configurable in Settings (default: `Supernote Digests`).

### Digest file format

The digest export is a series of blocks, each representing a single highlight. The schema is this block repeated:

```txt
[
linkinfo:
  path: file://Document/Books/Non-Fiction/The Origins of Efficiency -- Brian Potter -- 1, 2025 -- Stripe Press -- isbn13 9781953953520.epub
  page: 1
  chapter: 15-0[528-587]
  size: 5555786
identity:
  unique_id: 8e169189632f4a357312d853c2102300
create_time:
  timestamp: 1781640656835
modify_time:
  timestamp: 1781640656835
content:
  they tend to converge on a common form: continuous processes
]
```

### Sorting

The digest output appears to be unsorted, so the plugin sorts highlights by chapter (if it exists -- articles may not have chapters), then page, then modify time.

Confirmed that SuperNote digests are NOT unsorted, but rather sorting is based on page alone (which is often not what you want) this is a limitation of the SuperNote partner app digest sorting functionality. 

<img width="1776" height="250" alt="image" src="https://github.com/user-attachments/assets/c8391034-e531-492c-9426-f38b541f540a" />

### Output format

The output format is inspired by [Readwise's Obsidian plugin](https://github.com/readwiseio/obsidian-readwise). One markdown file per book/document:

```md
# The Origins of Efficiency

## Metadata
- Author: [[Brian Potter]]
- Full Title: The Origins of Efficiency
- Year: 2025
- Category: #books

## Highlights
- Children don't dream of growing up to be efficiency experts. (Page 1, Chapter 6)
- This perspective, while perhaps not entirely mistaken, misses the larger picture... (Page 1, Chapter 6)
...
```

### Design decisions

- **Metadata extraction**: Title, author, and year are parsed from the `--`-delimited filename in the path. Category is derived from the directory structure (`/Books/` → `#books`, `/Articles/` → `#articles`).
- **Idempotent imports**: Re-importing the same digest overwrites existing files. Users are encouraged not to modify the generated files directly but instead link to them and annotate elsewhere.
- **Configurable output folder**: Defaults to `Supernote Digests`, configurable in plugin settings.

### Testing

Tested locally via [BRAT - Beta Reviewer's Auto-update Tool for Obsidian](https://tfthacker.com/brat-plugins) ([GitHub](https://github.com/TfTHacker/obsidian42-brat)).

I did test overwriting behavior (just edited an imported digest manually to delete the highlights section) then re-imported the digest

Changing the import location / folder name

<img width="1981" height="289" alt="image" src="https://github.com/user-attachments/assets/bbb4d889-9dfc-4ebf-b170-6283b1434e00" />


#### Things I have NOT tested

- what if you make digest changes on the SuperNote (presumably, it just overwrites everything again, hence why I chose a simple "overwrite" import strategy instead of merges)

- digests can contain handwritten annotations. I did not test these. I think they just get dropped.


Have a great rest of your day! 👋 