### PR TITLE
Update supernote-typescript to v0.4.0, fix file-picker click area, harden dev setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# Development setup
+
+`src/main.ts` and `src/myworker.worker.ts` import from `supernote-typescript`, but
+`package.json`'s `dependencies.supernote` entry resolves to a stale pinned commit
+(see `package-lock.json`) from before the package was renamed from `supernote` to
+`supernote-typescript`. A plain `npm install` alone will never satisfy that import —
+`tsc` fails with `Cannot find module 'supernote-typescript'`.
+
+The real dependency lives as a git submodule at `supernote-typescript/` (see
+`.gitmodules`) and must be built and linked in manually. Run `./scripts/build` to do
+all of this:
+
+1. `git submodule init && git submodule update`
+2. Install + build the submodule (`npm run build` there, i.e. `tsc`)
+3. Link it into this project's `node_modules/supernote-typescript`
+
+`scripts/build` prefers real `npm link`, but falls back to a direct
+`node_modules/supernote-typescript` symlink when the global npm prefix isn't
+writable (common in sandboxes/CI without root). If you ever hand-roll this step:
+create the symlink **after** `npm install`, not before — plain `npm install` prunes
+symlinks it doesn't recognize as npm-linked.
+
+The submodule's `v8-profiler-next` devDependency (used only by its test suite, not
+its build) needs a native toolchain to compile. If that's unavailable, install with
+`--ignore-scripts` — the library build itself doesn't need it, only `npm test` does.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,30 +7,41 @@ edits to the library and the plugin can happen together without publishing to np
 first. Run `./scripts/build` to set it up and build everything:
 
 1. `git submodule init && git submodule update`
-2. Install + build the submodule (`npm run build` there, i.e. `tsc`)
-3. `npm install` for this project, then symlink
-   `node_modules/supernote-typescript -> ../supernote-typescript` by hand (npm has
-   no declared dependency to link automatically, since none exists in
-   `package.json`)
-4. Build this project
+2. Install + build the submodule (`npm run build` there, i.e. `tsc`, producing
+   `supernote-typescript/lib/`)
+3. `npm install` and build this project
 
-Two things trip this up if you hand-roll it instead of using the script:
+`tsconfig.json`'s `compilerOptions.paths` and `esbuild.config.mjs`'s `alias` both
+point the `supernote-typescript` import specifier straight at the submodule
+directory (compiled `lib/` for TS, the package directory for esbuild). **Don't
+route this through a `node_modules/supernote-typescript` symlink, `npm link`, or a
+`file:supernote-typescript` dependency** — all three were tried and abandoned:
 
-- **Order matters**: the symlink must be created *after* `npm install`, not before.
-  Plain `npm install` prunes symlinks in `node_modules` that it doesn't recognize as
-  declared dependencies.
-- **Don't switch this to `npm link` or a `file:` dependency.** `npm link` needs
-  write access to the global npm prefix, which sandboxes/CI/some setups don't have.
-  A `file:supernote-typescript` dependency seems cleaner, but npm's default
-  (symlink) mode for local directory dependencies also installs the *entire*
-  devDependency tree of the linked package into this project (jest, eslint,
-  prettier, and a native module requiring a C++ toolchain) — confirmed by testing,
-  it took root `node_modules` from ~280 packages to ~750. The manual symlink avoids
-  that entirely: it's a real live symlink (submodule rebuilds show up immediately,
-  no reinstall needed) with none of the extra weight.
+- A plain symlink at `node_modules/supernote-typescript` gets reached through and
+  wiped by any subsequent `npm install` in this project, even one unrelated to the
+  submodule (npm's arborist treats anything inside `node_modules/` as part of the
+  tree it manages/prunes). Confirmed repeatedly: the submodule's own
+  `node_modules` — `image-js`, `color`, `fs-extra`, etc. — would vanish after a
+  routine root-level `npm install`, breaking the build in confusing ways (missing
+  exports, wrong versions) that look like upstream API breaks but aren't. Pointing
+  `paths`/`alias` at the submodule directly, instead of through anything living
+  inside `node_modules/`, avoids this: npm's install never sees or touches it.
+- `npm link` needs write access to the global npm prefix, which sandboxes/CI/some
+  setups don't have.
+- A `file:supernote-typescript` dependency's default (symlink) install mode also
+  installs the *entire* devDependency tree of the linked package into this project
+  (jest, eslint, prettier, a native module requiring a C++ toolchain) — confirmed
+  by testing, it took root `node_modules` from ~280 packages to ~750.
 
 The submodule's `v8-profiler-next` devDependency (used only by its own test suite,
 not its build) needs a native toolchain to compile. If that's unavailable, install
 with `--ignore-scripts` — the library build itself doesn't need it, only
 `npm test` (inside `supernote-typescript/`) does. `scripts/build` does this
 automatically.
+
+Root `package.json` also carries its own `image-js` dependency, matched to
+whatever major version the submodule currently uses (`^1.7.0` as of
+supernote-typescript v0.4.0) — used to encode `Image` objects that
+`supernote-typescript` hands back (`encode`/`encodeDataURL`; the `Image` class
+itself dropped its `toBuffer`/`toDataURL` instance methods in image-js v1). Bump
+both together when updating the submodule.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,25 +1,36 @@
 # Development setup
 
-`src/main.ts` and `src/myworker.worker.ts` import from `supernote-typescript`, but
-`package.json`'s `dependencies.supernote` entry resolves to a stale pinned commit
-(see `package-lock.json`) from before the package was renamed from `supernote` to
-`supernote-typescript`. A plain `npm install` alone will never satisfy that import —
-`tsc` fails with `Cannot find module 'supernote-typescript'`.
-
-The real dependency lives as a git submodule at `supernote-typescript/` (see
-`.gitmodules`) and must be built and linked in manually. Run `./scripts/build` to do
-all of this:
+`src/main.ts` and `src/myworker.worker.ts` import from `supernote-typescript`. It's
+intentionally **not** an npm dependency in `package.json` — it's developed alongside
+this plugin as a git submodule at `supernote-typescript/` (see `.gitmodules`), so
+edits to the library and the plugin can happen together without publishing to npm
+first. Run `./scripts/build` to set it up and build everything:
 
 1. `git submodule init && git submodule update`
 2. Install + build the submodule (`npm run build` there, i.e. `tsc`)
-3. Link it into this project's `node_modules/supernote-typescript`
+3. `npm install` for this project, then symlink
+   `node_modules/supernote-typescript -> ../supernote-typescript` by hand (npm has
+   no declared dependency to link automatically, since none exists in
+   `package.json`)
+4. Build this project
 
-`scripts/build` prefers real `npm link`, but falls back to a direct
-`node_modules/supernote-typescript` symlink when the global npm prefix isn't
-writable (common in sandboxes/CI without root). If you ever hand-roll this step:
-create the symlink **after** `npm install`, not before — plain `npm install` prunes
-symlinks it doesn't recognize as npm-linked.
+Two things trip this up if you hand-roll it instead of using the script:
 
-The submodule's `v8-profiler-next` devDependency (used only by its test suite, not
-its build) needs a native toolchain to compile. If that's unavailable, install with
-`--ignore-scripts` — the library build itself doesn't need it, only `npm test` does.
+- **Order matters**: the symlink must be created *after* `npm install`, not before.
+  Plain `npm install` prunes symlinks in `node_modules` that it doesn't recognize as
+  declared dependencies.
+- **Don't switch this to `npm link` or a `file:` dependency.** `npm link` needs
+  write access to the global npm prefix, which sandboxes/CI/some setups don't have.
+  A `file:supernote-typescript` dependency seems cleaner, but npm's default
+  (symlink) mode for local directory dependencies also installs the *entire*
+  devDependency tree of the linked package into this project (jest, eslint,
+  prettier, and a native module requiring a C++ toolchain) — confirmed by testing,
+  it took root `node_modules` from ~280 packages to ~750. The manual symlink avoids
+  that entirely: it's a real live symlink (submodule rebuilds show up immediately,
+  no reinstall needed) with none of the extra weight.
+
+The submodule's `v8-profiler-next` devDependency (used only by its own test suite,
+not its build) needs a native toolchain to compile. If that's unavailable, install
+with `--ignore-scripts` — the library build itself doesn't need it, only
+`npm test` (inside `supernote-typescript/`) does. `scripts/build` does this
+automatically.

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,7 +1,11 @@
 import esbuild from "esbuild";
 import process from "process";
+import path from "path";
+import { fileURLToPath } from "url";
 import builtins from "builtin-modules";
 import inlineWorkerPlugin from "esbuild-plugin-inline-worker";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const banner =
 `/*
@@ -18,7 +22,12 @@ const context = await esbuild.context({
 	},
 	entryPoints: ["src/main.ts"],
 	alias: {
-		'supernote-typescript': 'supernote-typescript'
+		// supernote-typescript is a git submodule developed alongside this
+		// plugin, not an npm dependency (see CLAUDE.md) - point straight at
+		// it rather than through a node_modules symlink, which npm install
+		// prunes/reaches through and deletes the submodule's own
+		// node_modules.
+		'supernote-typescript': path.join(__dirname, 'supernote-typescript'),
 	},
 	bundle: true,
 	plugins: [inlineWorkerPlugin()],

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,20 +11,20 @@
 			"dependencies": {
 				"esbuild-plugin-inline-worker": "^0.1.1",
 				"fast-png": "^7.0.1",
-				"image-js": "^0.35.6",
+				"image-js": "^1.7.0",
 				"jspdf": "^2.5.2"
 			},
 			"devDependencies": {
 				"@types/color": "^3.0.6",
 				"@types/jest": "^29.5.12",
-				"@types/node": "^20.0.0",
+				"@types/node": "20.19.43",
 				"@typescript-eslint/eslint-plugin": "5.29.0",
 				"@typescript-eslint/parser": "5.29.0",
 				"builtin-modules": "3.3.0",
 				"esbuild": "^0.17.3",
 				"obsidian": "latest",
 				"tslib": "2.4.0",
-				"typescript": "4.7.4"
+				"typescript": "6.0.3"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -600,14 +600,6 @@
 			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
 			"dev": true
 		},
-		"node_modules/@swiftcarrot/color-fns": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@swiftcarrot/color-fns/-/color-fns-3.2.0.tgz",
-			"integrity": "sha512-6SCpc4LwmGGqWHpBY9WaBzJwPF4nfgvFfejOX7Ub0kTehJysFkLUAvGID8zEx39n0pGlfr9pTiQE/7/buC7X5w==",
-			"dependencies": {
-				"@babel/runtime": "^7.10.3"
-			}
-		},
 		"node_modules/@types/codemirror": {
 			"version": "5.60.8",
 			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
@@ -688,13 +680,13 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.17.18",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.18.tgz",
-			"integrity": "sha512-9kS0opXVV3dJ+C7HPhXfDlOdMu4cjJSZhlSxlDK39IxVRxBbuiYjCkLYSO9d5UYqTd4DApxRK9T1xJiTAkfA0w==",
+			"version": "20.19.43",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+			"integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.19.2"
+				"undici-types": "~6.21.0"
 			}
 		},
 		"node_modules/@types/pako": {
@@ -953,6 +945,16 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1040,10 +1042,11 @@
 				"node": ">= 0.6.0"
 			}
 		},
-		"node_modules/blob-util": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
-			"integrity": "sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ=="
+		"node_modules/binary-search": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
+			"integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==",
+			"license": "CC0-1.0"
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -1068,6 +1071,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/bresenham-zingl": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/bresenham-zingl/-/bresenham-zingl-0.2.5.tgz",
+			"integrity": "sha512-0TCrPvavRM/3Os9QIUDhe8jpAQXgEYjsVO+9IKnkC8cdzorDX5fMRfr3neEFGjcfRItEswHvIvPrqQzCalRYkw==",
+			"license": "MIT"
 		},
 		"node_modules/btoa": {
 			"version": "1.2.1",
@@ -1102,11 +1111,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/canny-edge-detector": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/canny-edge-detector/-/canny-edge-detector-1.0.0.tgz",
-			"integrity": "sha512-SpewmkHDE1PbJ1/AVAcpvZKOufYpUXT0euMvhb5C4Q83Q9XEOmSXC+yR7jl3F4Ae1Ev6OtQKbFgdcPrOdHjzQg=="
 		},
 		"node_modules/canvg": {
 			"version": "3.0.10",
@@ -1151,6 +1155,12 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/cheminfo-types": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/cheminfo-types/-/cheminfo-types-1.15.0.tgz",
+			"integrity": "sha512-shv45WN2u0yN9EHH1bisNrv+fy4Cw+eLM5lOoriP67mePrwbHZ1kJqg90C8GEU7K1A8gJsicEoVZHcuBbuul/w==",
+			"license": "MIT"
+		},
 		"node_modules/ci-info": {
 			"version": "3.9.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -1183,6 +1193,12 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
+		},
+		"node_modules/colord": {
+			"version": "2.9.3",
+			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+			"license": "MIT"
 		},
 		"node_modules/commondir": {
 			"version": "1.0.1",
@@ -1239,7 +1255,7 @@
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
 			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -1258,6 +1274,16 @@
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true,
 			"peer": true
+		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/diff-sequences": {
 			"version": "29.6.3",
@@ -1592,11 +1618,12 @@
 			}
 		},
 		"node_modules/fast-bmp": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/fast-bmp/-/fast-bmp-2.0.1.tgz",
-			"integrity": "sha512-MOSG2rHYJCjIfL3/Llseuj39yl5U3d3XLtWFLFm5ZSTublGEXyvNcwi4Npyv6nzDPRSbAP53rvVRUswgftWCcQ==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/fast-bmp/-/fast-bmp-4.0.1.tgz",
+			"integrity": "sha512-+KtMijJj+uA8Sl6EXAnhza7US7EXSY5Z9NeiJwT1wopVUksyLMXL5iFmn9FjY8FdkstOkpJI9RuEVXkGpIPSwg==",
+			"license": "MIT",
 			"dependencies": {
-				"iobuffer": "^5.1.0"
+				"iobuffer": "^6.0.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -1635,25 +1662,13 @@
 			}
 		},
 		"node_modules/fast-jpeg": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/fast-jpeg/-/fast-jpeg-1.0.1.tgz",
-			"integrity": "sha512-nyoYDzmdxgLOBfEhJGwYRsRLqGKziG/wic0SMct17dTVHkseTPvNwHCfihE47tcpGA1cTJO2MNsYYHezmkuA6w==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/fast-jpeg/-/fast-jpeg-3.0.1.tgz",
+			"integrity": "sha512-1r4CO4rgRY1CeqaHlXVBPhdGC+rbNwWFJvV9s3HTUC+svqTE7hC1cEH9srp5MPgAmhDdsZ/WtU3WGM8zVobFCA==",
+			"license": "MIT",
 			"dependencies": {
-				"iobuffer": "^2.1.0",
-				"tiff": "^2.0.0"
-			}
-		},
-		"node_modules/fast-jpeg/node_modules/iobuffer": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-2.1.0.tgz",
-			"integrity": "sha512-0XZfU0STJ6NVHBZdMRPjF7jtkDEC5f4AxM/n5DSZOu11SQ+7tAl1csuEnEPoSPYWdaGZ/HOfn5Q837IEHddL2w=="
-		},
-		"node_modules/fast-jpeg/node_modules/tiff": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/tiff/-/tiff-2.1.0.tgz",
-			"integrity": "sha512-Q4zLT4+Csn/ZhFVacYCAl+w/1J51NW/m2y2yx7Qxp/bsHYOEsK7+5JOID2kfk+EvsaF0LbA6ccAkqiuXOmAbYw==",
-			"dependencies": {
-				"iobuffer": "^2.1.0"
+				"iobuffer": "^6.0.0",
+				"tiff": "^7.1.0"
 			}
 		},
 		"node_modules/fast-json-stable-stringify": {
@@ -1670,11 +1685,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/fast-list": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/fast-list/-/fast-list-1.0.3.tgz",
-			"integrity": "sha512-Lm56Ci3EqefHNdIneRFuzhpPcpVVBz9fgqVmG3UQIxAefJv1mEYsZ1WQLTWqmdqeGEwbI2t6fbZgp9TqTYARuA=="
-		},
 		"node_modules/fast-png": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fast-png/-/fast-png-7.0.1.tgz",
@@ -1685,12 +1695,6 @@
 				"iobuffer": "^6.0.0",
 				"pako": "^2.1.0"
 			}
-		},
-		"node_modules/fast-png/node_modules/iobuffer": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-6.0.1.tgz",
-			"integrity": "sha512-SZWYkWNfjIXIBYSDpXDYIgshqtbOPsi4lviawAEceR1Kqk+sHDlcQjWrzNQsii80AyBY0q5c8HCTNjqo74ul+Q==",
-			"license": "MIT"
 		},
 		"node_modules/fastq": {
 			"version": "1.17.1",
@@ -1710,7 +1714,8 @@
 		"node_modules/fft.js": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/fft.js/-/fft.js-4.0.4.tgz",
-			"integrity": "sha512-f9c00hphOgeQTlDyavwTtu6RiK8AIFjD6+jvXkNkpeQ7rirK3uFWVpalkoS4LAwbdX7mfZ8aoBfFVQX1Re/8aw=="
+			"integrity": "sha512-f9c00hphOgeQTlDyavwTtu6RiK8AIFjD6+jvXkNkpeQ7rirK3uFWVpalkoS4LAwbdX7mfZ8aoBfFVQX1Re/8aw==",
+			"license": "MIT"
 		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
@@ -1801,6 +1806,27 @@
 			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
 			"dev": true,
 			"peer": true
+		},
+		"node_modules/follow-redirects": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
@@ -1907,11 +1933,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/has-own": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-own/-/has-own-1.0.1.tgz",
-			"integrity": "sha512-RDKhzgQTQfMaLvIFhjahU+2gGnRBK6dYOd5Gd9BzkmnBneOCRYjRC003RIMrdAbH52+l+CnMS4bBCXGer8tEhg=="
-		},
 		"node_modules/html2canvas": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
@@ -1926,6 +1947,20 @@
 				"node": ">=8.0.0"
 			}
 		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/ignore": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -1936,50 +1971,45 @@
 			}
 		},
 		"node_modules/image-js": {
-			"version": "0.35.6",
-			"resolved": "https://registry.npmjs.org/image-js/-/image-js-0.35.6.tgz",
-			"integrity": "sha512-2qRaowXOBUIT7Ia842BUFDoBo/Jr0FHlbfssx/awbQUtc399kJWfFf0xE5hIG62ybaQiwutL2e1ocUzGtYxASw==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/image-js/-/image-js-1.7.0.tgz",
+			"integrity": "sha512-/i72uwbYaSetVaLYPi3lHqr71/4O5RqWkEq4h/p5DM3FR0SSe5Jj57u6xk6sMVOurDBmTrvbm+FeinKnqLwIMA==",
 			"license": "MIT",
 			"dependencies": {
-				"@swiftcarrot/color-fns": "^3.2.0",
-				"blob-util": "^2.0.2",
-				"canny-edge-detector": "^1.0.0",
-				"fast-bmp": "^2.0.1",
-				"fast-jpeg": "^1.0.1",
-				"fast-list": "^1.0.3",
-				"fast-png": "^6.1.0",
-				"has-own": "^1.0.1",
+				"bresenham-zingl": "^0.2.5",
+				"colord": "^2.9.3",
+				"fast-bmp": "^4.0.1",
+				"fast-jpeg": "^3.0.1",
+				"fast-png": "^8.0.0",
 				"image-type": "^4.1.0",
-				"is-array-type": "^1.0.0",
-				"is-integer": "^1.0.7",
-				"jpeg-js": "^0.4.3",
+				"jpeg-js": "^0.4.4",
 				"js-priority-queue": "^0.1.5",
-				"js-quantities": "^1.7.6",
 				"median-quickselect": "^1.0.1",
-				"ml-convolution": "0.2.0",
-				"ml-disjoint-set": "^1.0.0",
-				"ml-matrix": "^6.8.0",
-				"ml-matrix-convolution": "0.4.3",
-				"ml-regression": "^5.0.0",
-				"monotone-chain-convex-hull": "^1.0.0",
-				"new-array": "^1.0.0",
+				"ml-affine-transform": "^1.0.3",
+				"ml-convolution": "^2.0.0",
+				"ml-matrix": "^6.12.1",
+				"ml-ransac": "^1.0.0",
+				"ml-regression-multivariate-linear": "^2.0.4",
+				"ml-regression-polynomial-2d": "^1.0.0",
+				"ml-spectra-processing": "^14.18.2",
 				"robust-point-in-polygon": "^1.0.3",
-				"tiff": "^5.0.2",
-				"web-worker-manager": "^0.2.0"
+				"ssim.js": "^3.5.0",
+				"tiff": "^7.1.3",
+				"ts-pattern": "^5.9.0",
+				"uint8-base64": "^1.0.0"
 			},
-			"engines": {
-				"node": ">= 16.0.0"
+			"optionalDependencies": {
+				"skia-canvas": "^3.0.8"
 			}
 		},
 		"node_modules/image-js/node_modules/fast-png": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
-			"integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/fast-png/-/fast-png-8.0.0.tgz",
+			"integrity": "sha512-gCysNasJ8KEMgfdYIKd/wTDo6ENK1PWT0RJO7O+0pgmuHPw2O6tA1WvdxFRJoLf9V8yFYpG0FA1YgI8X97OhJA==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/pako": "^2.0.3",
-				"iobuffer": "^5.3.2",
-				"pako": "^2.1.0"
+				"fflate": "^0.8.2",
+				"iobuffer": "^6.0.1"
 			}
 		},
 		"node_modules/image-type": {
@@ -2039,19 +2069,16 @@
 			"peer": true
 		},
 		"node_modules/iobuffer": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.3.2.tgz",
-			"integrity": "sha512-kO3CjNfLZ9t+tHxAMd+Xk4v3D/31E91rMs1dHrm7ikEQrlZ8mLDbQ4z3tZfDM48zOkReas2jx8MWSAmN9+c8Fw=="
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-6.0.1.tgz",
+			"integrity": "sha512-SZWYkWNfjIXIBYSDpXDYIgshqtbOPsi4lviawAEceR1Kqk+sHDlcQjWrzNQsii80AyBY0q5c8HCTNjqo74ul+Q==",
+			"license": "MIT"
 		},
 		"node_modules/is-any-array": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-2.0.1.tgz",
-			"integrity": "sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ=="
-		},
-		"node_modules/is-array-type": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-array-type/-/is-array-type-1.0.0.tgz",
-			"integrity": "sha512-LLwKQdMAO/XUkq4XTed1VYqwR2OahiwkBg+yUtZT88LXX4MLXP28qGsVfSNVP8X0wc7fzDhcZD3nns/IK8UfKw=="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-3.0.0.tgz",
+			"integrity": "sha512-o4h+tylWykC4BD1vaejp6gDxoM13bwW8FGuNs4yIKpj8xbBJcRxJx8vZpq0dCr7ZDEfeKjmsi/euolKhX6f/ww==",
+			"license": "MIT"
 		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
@@ -2060,17 +2087,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-finite": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-			"integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
-			"engines": {
-				"node": ">=0.10.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-glob": {
@@ -2083,14 +2099,6 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-integer": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
-			"integrity": "sha512-RPQc/s9yBHSvpi+hs9dYiJ2cuFeU6x3TyyIp8O2H6SKEltIvJOzRj9ToyvcStDvPR/pS4rxgr1oBFajQjZ2Szg==",
-			"dependencies": {
-				"is-finite": "^1.0.0"
 			}
 		},
 		"node_modules/is-number": {
@@ -2205,11 +2213,6 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/js-priority-queue/-/js-priority-queue-0.1.5.tgz",
 			"integrity": "sha512-2dPmJT4GbXUpob7AZDR1wFMKz3Biy6oW69mwt5PTtdeoOgDin1i0p5gUV9k0LFeUxDpwkfr+JGMZDpcprjiY5w=="
-		},
-		"node_modules/js-quantities": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/js-quantities/-/js-quantities-1.8.0.tgz",
-			"integrity": "sha512-swDw9RJpXACAWR16vAKoSojAsP6NI7cZjjnjKqhOyZSdybRUdmPr071foD3fejUKSU2JMHz99hflWkRWvfLTpQ=="
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
@@ -2356,7 +2359,8 @@
 		"node_modules/median-quickselect": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/median-quickselect/-/median-quickselect-1.0.1.tgz",
-			"integrity": "sha512-/QL9ptNuLsdA68qO+2o10TKCyu621zwwTFdLvtu8rzRNKsn8zvuGoq/vDxECPyELFG8wu+BpyoMR9BnsJqfVZQ=="
+			"integrity": "sha512-/QL9ptNuLsdA68qO+2o10TKCyu621zwwTFdLvtu8rzRNKsn8zvuGoq/vDxECPyELFG8wu+BpyoMR9BnsJqfVZQ==",
+			"license": "ISC"
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -2394,203 +2398,162 @@
 				"node": "*"
 			}
 		},
-		"node_modules/ml-array-max": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/ml-array-max/-/ml-array-max-1.2.4.tgz",
-			"integrity": "sha512-BlEeg80jI0tW6WaPyGxf5Sa4sqvcyY6lbSn5Vcv44lp1I2GR6AWojfUvLnGTNsIXrZ8uqWmo8VcG1WpkI2ONMQ==",
+		"node_modules/ml-affine-transform": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/ml-affine-transform/-/ml-affine-transform-1.0.3.tgz",
+			"integrity": "sha512-uv13li9HOGuMdSKL+QEdaV25emO9kt17LzGCD+FLQrBsrU8p/r/3kS/GJ7xI+f3/aWghkBK733x0yBG6EwKFJA==",
+			"license": "MIT",
 			"dependencies": {
-				"is-any-array": "^2.0.0"
+				"ml-matrix": "^6.10.4"
+			}
+		},
+		"node_modules/ml-array-max": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ml-array-max/-/ml-array-max-2.0.0.tgz",
+			"integrity": "sha512-QQZ4kENwpWmyNb98UXRDFXrmtIXuXtt1+bSbda/2KA85+F+rrJP8hZk6QOkCQXM2Th9mUDYdq/PNByPdT9ID4A==",
+			"license": "MIT",
+			"dependencies": {
+				"is-any-array": "^3.0.0"
 			}
 		},
 		"node_modules/ml-array-median": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/ml-array-median/-/ml-array-median-1.1.6.tgz",
 			"integrity": "sha512-V6bV6bTPFRX8v5CaAx/7fuRXC39LLTHfPSVZZafdNaqNz2PFL5zEA7gesjv8dMXh+gwPeUMtB5QPovlTBaa4sw==",
+			"license": "MIT",
 			"dependencies": {
 				"is-any-array": "^2.0.0",
 				"median-quickselect": "^1.0.1"
 			}
 		},
+		"node_modules/ml-array-median/node_modules/is-any-array": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-2.0.1.tgz",
+			"integrity": "sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ==",
+			"license": "MIT"
+		},
 		"node_modules/ml-array-min": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/ml-array-min/-/ml-array-min-1.2.3.tgz",
-			"integrity": "sha512-VcZ5f3VZ1iihtrGvgfh/q0XlMobG6GQ8FsNyQXD3T+IlstDv85g8kfV0xUG1QPRO/t21aukaJowDzMTc7j5V6Q==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ml-array-min/-/ml-array-min-2.0.0.tgz",
+			"integrity": "sha512-GRj6Ky6sW9vGL6yIjgsHmXZ9YgrdmcQ8nCxPqEGeKc6dkfYg1XDYxGFxADUjNuZyoCd5PUscWAS4N+cFaX6hFg==",
+			"license": "MIT",
 			"dependencies": {
-				"is-any-array": "^2.0.0"
+				"is-any-array": "^3.0.0"
 			}
 		},
 		"node_modules/ml-array-rescale": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/ml-array-rescale/-/ml-array-rescale-1.3.7.tgz",
-			"integrity": "sha512-48NGChTouvEo9KBctDfHC3udWnQKNKEWN0ziELvY3KG25GR5cA8K8wNVzracsqSW1QEkAXjTNx+ycgAv06/1mQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ml-array-rescale/-/ml-array-rescale-2.0.0.tgz",
+			"integrity": "sha512-2GGtKfSno94/kIloWGvpp/U5Q5vLvLrza+SAaGsLeo6Xj4mEbA6Gqx+oTfZFkxnd1grT2X007HfJNs3T5BsiVg==",
+			"license": "MIT",
 			"dependencies": {
-				"is-any-array": "^2.0.0",
-				"ml-array-max": "^1.2.4",
-				"ml-array-min": "^1.2.3"
+				"is-any-array": "^3.0.0",
+				"ml-array-max": "^2.0.0",
+				"ml-array-min": "^2.0.0"
 			}
 		},
 		"node_modules/ml-convolution": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/ml-convolution/-/ml-convolution-0.2.0.tgz",
-			"integrity": "sha512-km5f81jFVnEWG0eFEKAwt00X3xGUIAcUqZZlUk+w0q2sZOz1vkEYhIKOXAlmaEi9rnrTknxW//Ttm399zPzDPg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ml-convolution/-/ml-convolution-2.0.0.tgz",
+			"integrity": "sha512-ExW6zVmN2YGuyO3aBiS1ymybme3nVgv2ccCfynSdgtW5sNp4DOHnfow4K/ErTDMQ1s9tINjv7kvzjnVhQHXJBA==",
+			"license": "MIT",
 			"dependencies": {
 				"fft.js": "^4.0.3",
 				"next-power-of-two": "^1.0.0"
 			}
 		},
-		"node_modules/ml-disjoint-set": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/ml-disjoint-set/-/ml-disjoint-set-1.0.0.tgz",
-			"integrity": "sha512-UcEzgvRzVhsKpT66syfdhaK8R+av6GxDFmU37t+6WClT/kHDIN6OMRfO7OPwQIV8+L8FSc2E6lNKpvdqf6OgLw=="
-		},
-		"node_modules/ml-distance-euclidean": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ml-distance-euclidean/-/ml-distance-euclidean-2.0.0.tgz",
-			"integrity": "sha512-yC9/2o8QF0A3m/0IXqCTXCzz2pNEzvmcE/9HFKOZGnTjatvBbsn4lWYJkxENkA4Ug2fnYl7PXQxnPi21sgMy/Q=="
-		},
-		"node_modules/ml-fft": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/ml-fft/-/ml-fft-1.3.5.tgz",
-			"integrity": "sha512-laAATDyUuWPbIlX57thIds41wqFLsB+Zl7i1yrLRo/4CFg+hFaF9Xle8InblQseyiaVtt1KSlDG+6lgUMPOj3g=="
-		},
-		"node_modules/ml-kernel": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ml-kernel/-/ml-kernel-3.0.0.tgz",
-			"integrity": "sha512-R+ZR0Kl5xJ7vnxtlDqjZ26xVk7mAw7ctK4NlzRHviBFXxp7keC9+hWirMOdzi2DOQA0t6CaRwjElZ6SdirOmow==",
-			"dependencies": {
-				"ml-distance-euclidean": "^2.0.0",
-				"ml-kernel-gaussian": "^2.0.2",
-				"ml-kernel-polynomial": "^2.0.1",
-				"ml-kernel-sigmoid": "^1.0.1",
-				"ml-matrix": "^6.1.2"
-			}
-		},
-		"node_modules/ml-kernel-gaussian": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/ml-kernel-gaussian/-/ml-kernel-gaussian-2.0.2.tgz",
-			"integrity": "sha512-5MBrH2g9MBO53I6mcyXvMhyOLsmO2w21+26A1ZV/vYoxqpsov2PWkT8bhdFCEe0kgDupmAb6u81iOID/rhnarA==",
-			"dependencies": {
-				"ml-distance-euclidean": "^2.0.0"
-			}
-		},
-		"node_modules/ml-kernel-polynomial": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ml-kernel-polynomial/-/ml-kernel-polynomial-2.0.1.tgz",
-			"integrity": "sha512-aGDNRPHDiKeJmBxB0L9wTxKNLfp5JytbdRIo5K+FTcmFjkWDe3YZPo6R6wBB5mxaJ5eqTRawzeV4RoIWHbakyQ=="
-		},
-		"node_modules/ml-kernel-sigmoid": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/ml-kernel-sigmoid/-/ml-kernel-sigmoid-1.0.1.tgz",
-			"integrity": "sha512-mSbYOSbNQ7GsUAGrHuUHNsLgM3bZGpXkotw/FBdKZD9YMXfVOgQb1LvvvVeSlOR/ZdmX23qqaV0RnKSYWBF8og=="
-		},
 		"node_modules/ml-matrix": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/ml-matrix/-/ml-matrix-6.11.0.tgz",
-			"integrity": "sha512-7jr9NmFRkaUxbKslfRu3aZOjJd2LkSitCGv+QH9PF0eJoEG7jIpjXra1Vw8/kgao8+kHCSsJONG6vfWmXQ+/Eg==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ml-matrix/-/ml-matrix-6.14.0.tgz",
+			"integrity": "sha512-5W31+w+6jIm05l85N3Ik04fl+5LfN1lyJLBrEM/r/j7YmvwRclcUyQGXGFWXnN7ASzVjsAnAa3FUXrduAt168A==",
+			"license": "MIT",
 			"dependencies": {
-				"is-any-array": "^2.0.1",
-				"ml-array-rescale": "^1.3.7"
+				"is-any-array": "^3.0.0",
+				"ml-array-rescale": "^2.0.0"
 			}
 		},
-		"node_modules/ml-matrix-convolution": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/ml-matrix-convolution/-/ml-matrix-convolution-0.4.3.tgz",
-			"integrity": "sha512-B4AATOjxDw4J0oVcoeYHsXrhMr31x9SWhVKZjWucDU+brwXLR0enMdqb1OuRy/REdpL5/iSshA46sS2B1dO2OQ==",
+		"node_modules/ml-random": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/ml-random/-/ml-random-0.5.0.tgz",
+			"integrity": "sha512-zLJBmNb34LOz+vN6BD8l3aYm/VWYWbmAunrLMPs4dHf4gTl8BWlhil72j56HubPg86zrXioIs4qoHq7Topy6tw==",
+			"license": "MIT",
 			"dependencies": {
-				"ml-fft": "1.3.5",
-				"ml-stat": "^1.2.0"
+				"ml-xsadd": "^2.0.0"
 			}
 		},
-		"node_modules/ml-regression": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/ml-regression/-/ml-regression-5.0.0.tgz",
-			"integrity": "sha512-mBn0LpfEWV3Dk0dj+8PRNUqIHvO87rUY0PmCUTYv3MKfECx7TtlKyeacJeOBLZ4YAVixX8U5hn4HwRL6TpTYaw==",
+		"node_modules/ml-ransac": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ml-ransac/-/ml-ransac-1.0.0.tgz",
+			"integrity": "sha512-fGi45s7T5+BEqdb5JqZC699w2riy6j0tzuZ2ZP63xavRa/yVKQIbUbj4XiE4XMr9T7HSiq1D9y0uybiyikDPvA==",
+			"license": "MIT",
 			"dependencies": {
-				"ml-kernel": "^3.0.0",
-				"ml-matrix": "^6.1.2",
-				"ml-regression-base": "^2.0.1",
-				"ml-regression-exponential": "^2.0.0",
-				"ml-regression-multivariate-linear": "^2.0.2",
-				"ml-regression-polynomial": "^2.0.0",
-				"ml-regression-power": "^2.0.0",
-				"ml-regression-robust-polynomial": "^2.0.0",
-				"ml-regression-simple-linear": "^2.0.2",
-				"ml-regression-theil-sen": "^2.0.0"
+				"ml-array-median": "^1.1.6",
+				"ml-matrix": "^6.10.4",
+				"ml-random": "^0.5.0"
 			}
 		},
 		"node_modules/ml-regression-base": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/ml-regression-base/-/ml-regression-base-2.1.6.tgz",
-			"integrity": "sha512-yTckvEc8szc6VrUTJSgAClShvCoPZdNt8pmyRe8aGsIWGjg6bYFotp9mDUwAB0snvKAbQWd6A4trL/PDCASLug==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/ml-regression-base/-/ml-regression-base-4.0.1.tgz",
+			"integrity": "sha512-kYJWRIfB88JDUN+QWBsOlI0dP5tMo/XPxqVU0Xjn6B0rfzPptUnON9xPNnMVEm43DkM621j9v6+Ln9vCk3N93A==",
+			"license": "MIT",
 			"dependencies": {
-				"is-any-array": "^2.0.0"
-			}
-		},
-		"node_modules/ml-regression-exponential": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/ml-regression-exponential/-/ml-regression-exponential-2.1.0.tgz",
-			"integrity": "sha512-6ZgGbzIkXnONfGGUU0LjIb9qb35WzVqdAFSX8vFr8UEhgXhfgEws9pGrBJu19VBEh7ZTtttcPObI3aoBscq4Kg==",
-			"dependencies": {
-				"ml-regression-base": "^2.1.3",
-				"ml-regression-simple-linear": "^2.0.3"
+				"cheminfo-types": "^1.15.0",
+				"is-any-array": "^3.0.0"
 			}
 		},
 		"node_modules/ml-regression-multivariate-linear": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/ml-regression-multivariate-linear/-/ml-regression-multivariate-linear-2.0.4.tgz",
 			"integrity": "sha512-/vShPAlP+mB7P2mC5TuXwObSJNl/UBI71/bszt9ilTg6yLKy6btDLpAYyJNa6t+JnL5a7q+Yy4dCltfpvqXRIw==",
+			"license": "MIT",
 			"dependencies": {
 				"ml-matrix": "^6.10.1"
 			}
 		},
-		"node_modules/ml-regression-polynomial": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/ml-regression-polynomial/-/ml-regression-polynomial-2.2.0.tgz",
-			"integrity": "sha512-WxFsEmi6oLxgq9TeaVoAA+vVUJFp1kGarX6WWClR8OmlanoIW5iLMnaeXfQcYuH8xNq4R1Cax2N9hYYmeWWkLg==",
+		"node_modules/ml-regression-polynomial-2d": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ml-regression-polynomial-2d/-/ml-regression-polynomial-2d-1.0.0.tgz",
+			"integrity": "sha512-r34kaawZKMwjORIdzpa/o5fnjlTXkkaLJ3B4vvFNeKlvEGPtApqFxbDRmw07e2CjUH2MhGIChpMeXp/XB3Iogg==",
+			"license": "MIT",
 			"dependencies": {
-				"ml-matrix": "^6.8.0",
-				"ml-regression-base": "^2.1.3"
+				"cheminfo-types": "^1.7.3",
+				"is-any-array": "^2.0.1",
+				"ml-matrix": "^6.11.0",
+				"ml-regression-base": "^4.0.0"
 			}
 		},
-		"node_modules/ml-regression-power": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ml-regression-power/-/ml-regression-power-2.0.0.tgz",
-			"integrity": "sha512-u8O9Fy45+OeYm/4ZBcNDn5w3w+MHc6kZz/AWSJIwmJcyjz6PRkTZnNfgGYdVKwKKDlAOS7G/AFvMKSTWRNO4RQ==",
-			"dependencies": {
-				"ml-regression-base": "^2.0.1",
-				"ml-regression-simple-linear": "^2.0.2"
-			}
-		},
-		"node_modules/ml-regression-robust-polynomial": {
+		"node_modules/ml-regression-polynomial-2d/node_modules/is-any-array": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ml-regression-robust-polynomial/-/ml-regression-robust-polynomial-2.0.1.tgz",
-			"integrity": "sha512-WkxA224Cil1G3Ug/T1O8H/2IDADlca21oC5WDplcM+gQRTqtueT/Su4ubH70tG6s79XHM046HfO8xQSpDQxqqg==",
+			"resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-2.0.1.tgz",
+			"integrity": "sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ==",
+			"license": "MIT"
+		},
+		"node_modules/ml-spectra-processing": {
+			"version": "14.30.0",
+			"resolved": "https://registry.npmjs.org/ml-spectra-processing/-/ml-spectra-processing-14.30.0.tgz",
+			"integrity": "sha512-nwO3LMPH3FA+zaXU6lmRecS5gvWjS+nvrcnZIDpv8Gp3sKA3GiWmShdJf/LEXRQQgrt62JYvhixEbjcA1SYCYg==",
+			"license": "MIT",
 			"dependencies": {
-				"ml-matrix": "^6.8.0",
-				"ml-regression-base": "^2.1.3"
+				"binary-search": "^1.3.6",
+				"cheminfo-types": "^1.15.0",
+				"fft.js": "^4.0.4",
+				"is-any-array": "^3.0.0",
+				"ml-matrix": "^6.14.0",
+				"ml-xsadd": "^3.0.1"
 			}
 		},
-		"node_modules/ml-regression-simple-linear": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/ml-regression-simple-linear/-/ml-regression-simple-linear-2.0.5.tgz",
-			"integrity": "sha512-7DBYru8GvWLaYo4LUF9vU2DjzHuM6i6WGnVbEP9wq8nUFUZ2DlwN46m8Z/hNhTSR7+3T+RvhaSY+OqdBpaz8zw==",
-			"dependencies": {
-				"ml-regression-base": "^2.0.1"
-			}
+		"node_modules/ml-spectra-processing/node_modules/ml-xsadd": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ml-xsadd/-/ml-xsadd-3.0.1.tgz",
+			"integrity": "sha512-Fz2q6dwgzGM8wYKGArTUTZDGa4lQFA2Vi6orjGeTVRy22ZnQFKlJuwS9n8NRviqz1KHAHAzdKJwbnYhdo38uYg==",
+			"license": "MIT"
 		},
-		"node_modules/ml-regression-theil-sen": {
+		"node_modules/ml-xsadd": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ml-regression-theil-sen/-/ml-regression-theil-sen-2.0.0.tgz",
-			"integrity": "sha512-RO//tYzo69XbWDO5LIPdGp8ef1MSTPPJY0bXNlmOLMSay7YR9FQqtNgqn29T9DSYTa863VAafRlCeXwDQNXkBw==",
-			"dependencies": {
-				"ml-array-median": "^1.1.1",
-				"ml-regression-base": "^2.0.1"
-			}
-		},
-		"node_modules/ml-stat": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/ml-stat/-/ml-stat-1.3.3.tgz",
-			"integrity": "sha512-F6plydFIKFZA+7j/pRsRrfRu4nwsruQvYD9QxHWc4hFUdASVznsKUL2hgAwgMVizY/P0+b1L9bVQexKES5y/uw=="
+			"resolved": "https://registry.npmjs.org/ml-xsadd/-/ml-xsadd-2.0.0.tgz",
+			"integrity": "sha512-VoAYUqmPRmzKbbqRejjqceGFp3VF81Qe8XXFGU0UXLxB7Mf4GGvyGq5Qn3k4AiQgDEV6WzobqlPOd+j0+m6IrA==",
+			"license": "MIT"
 		},
 		"node_modules/moment": {
 			"version": "2.29.4",
@@ -2601,16 +2564,11 @@
 				"node": "*"
 			}
 		},
-		"node_modules/monotone-chain-convex-hull": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/monotone-chain-convex-hull/-/monotone-chain-convex-hull-1.1.0.tgz",
-			"integrity": "sha512-iZGaoO2qtqIWaAfscTtsH2LolE06U4JzTw8AgtjT/yzYIA0aoAHDdwBtsesnQXfVRvS375Wu0Y1+FqdI5Y22GA=="
-		},
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
@@ -2619,15 +2577,11 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/new-array": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/new-array/-/new-array-1.0.0.tgz",
-			"integrity": "sha512-K5AyFYbuHZ4e/ti52y7k18q8UHsS78FlRd85w2Fmsd6AkuLipDihPflKC0p3PN5i8II7+uHxo+CtkLiJDfmS5A=="
-		},
 		"node_modules/next-power-of-two": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/next-power-of-two/-/next-power-of-two-1.0.0.tgz",
-			"integrity": "sha512-+z6QY1SxkDk6CQJAeaIZKmcNubBCRP7J8DMQUBglz/sSkNsZoJ1kULjqk9skNPPplzs4i9PFhYrvNDdtQleF/A=="
+			"integrity": "sha512-+z6QY1SxkDk6CQJAeaIZKmcNubBCRP7J8DMQUBglz/sSkNsZoJ1kULjqk9skNPPplzs4i9PFhYrvNDdtQleF/A==",
+			"license": "MIT"
 		},
 		"node_modules/obsidian": {
 			"version": "1.5.7-1",
@@ -2729,6 +2683,13 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/parenthesis": {
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
+			"integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw==",
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
@@ -3101,6 +3062,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/skia-canvas": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/skia-canvas/-/skia-canvas-3.0.8.tgz",
+			"integrity": "sha512-FSYKxp8Ng2vOeeOBiyPhnn6ui6FirPJXMyjk4PKl8N/OWzVrkMawUgY9zubIWHMdYtyWFn0gfX3QlRwg6HBmdg==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"detect-libc": "^2.1.1",
+				"follow-redirects": "^1.15.11",
+				"https-proxy-agent": "^7.0.6",
+				"string-split-by": "^1.0.0"
+			}
+		},
 		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3109,6 +3084,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/ssim.js": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/ssim.js/-/ssim.js-3.5.0.tgz",
+			"integrity": "sha512-Aj6Jl2z6oDmgYFFbQqK7fght19bXdOxY7Tj03nF+03M9gCBAjeIiO8/PlEGMfKDwYpw4q6iBqVq2YuREorGg/g==",
+			"license": "MIT"
 		},
 		"node_modules/stack-utils": {
 			"version": "2.0.6",
@@ -3139,6 +3120,16 @@
 			"optional": true,
 			"engines": {
 				"node": ">=0.1.14"
+			}
+		},
+		"node_modules/string-split-by": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
+			"integrity": "sha512-KaJKY+hfpzNyet/emP81PJA9hTVSfxNLS9SFTWxdCnnW1/zOOwiV248+EfoX7IQFcBaOp4G5YE6xTJMF+pLg6A==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"parenthesis": "^3.1.5"
 			}
 		},
 		"node_modules/strip-ansi": {
@@ -3214,12 +3205,13 @@
 			"peer": true
 		},
 		"node_modules/tiff": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/tiff/-/tiff-5.0.3.tgz",
-			"integrity": "sha512-R0WckwRGhawWDNdha8iPQCjHyOiaEEmfFjhmalUVCIEELsON7Y/XO3eeGmBkoCXQp0Gg2nmTozN92Z4hlwbsow==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/tiff/-/tiff-7.1.3.tgz",
+			"integrity": "sha512-YEEq3fT++2pdta/9P/vGG4QRMdZQoe6W6JNaWnIi6NvAsbeNITwFCtmWwL/BZvOi+uo2I3ohyOkD3sZfme+c6g==",
+			"license": "MIT",
 			"dependencies": {
-				"iobuffer": "^5.0.4",
-				"pako": "^2.0.4"
+				"fflate": "^0.8.2",
+				"iobuffer": "^6.0.0"
 			}
 		},
 		"node_modules/to-regex-range": {
@@ -3234,6 +3226,12 @@
 			"engines": {
 				"node": ">=8.0"
 			}
+		},
+		"node_modules/ts-pattern": {
+			"version": "5.9.0",
+			"resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz",
+			"integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==",
+			"license": "MIT"
 		},
 		"node_modules/tslib": {
 			"version": "2.4.0",
@@ -3299,22 +3297,29 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
+		"node_modules/uint8-base64": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/uint8-base64/-/uint8-base64-1.0.0.tgz",
+			"integrity": "sha512-B6ZJfEZL2FAhbIyZZ7WlQq8MPq1X1P1DUA//LsSv/vB4r+Dao5/BPoxgw2t+t1XyvoSfBkE7zI4SYsnGj7BmlQ==",
+			"license": "MIT"
+		},
 		"node_modules/undici-types": {
-			"version": "6.19.8",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3344,11 +3349,6 @@
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/web-worker-manager": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/web-worker-manager/-/web-worker-manager-0.2.0.tgz",
-			"integrity": "sha512-WmGabA4GLth1ju9VLm/oMDcPMhMngHoBSdY1OMhrEJvNsPl7z2p+7RBOXjEi5zlP0dK+Shd3Wm+BdD5WZrNYBA=="
 		},
 		"node_modules/which": {
 			"version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
 				"esbuild-plugin-inline-worker": "^0.1.1",
 				"fast-png": "^7.0.1",
 				"image-js": "^0.35.6",
-				"jspdf": "^2.5.2",
-				"supernote": "github:philips/supernote-typescript"
+				"jspdf": "^2.5.2"
 			},
 			"devDependencies": {
 				"@types/color": "^3.0.6",
@@ -39,111 +38,28 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.24.2",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-			"integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/highlight": "^7.24.2",
-				"picocolors": "^1.0.0"
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/highlight": {
-			"version": "7.24.2",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
-			"integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.22.20",
-				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0",
-				"picocolors": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
-		},
-		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/@babel/runtime": {
@@ -174,15 +90,6 @@
 				"@codemirror/state": "^6.4.0",
 				"style-mod": "^4.1.0",
 				"w3c-keyname": "^2.2.4"
-			}
-		},
-		"node_modules/@emnapi/runtime": {
-			"version": "0.45.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-0.45.0.tgz",
-			"integrity": "sha512-Txumi3td7J4A/xTTwlssKieHKTGl3j4A1tglBx72auZ49YK7ePY6XZricgIg9mnZT4xPfA+UPCUdnhRuEFDL+w==",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
@@ -610,437 +517,6 @@
 			"integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/@img/sharp-darwin-arm64": {
-			"version": "0.33.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.2.tgz",
-			"integrity": "sha512-itHBs1rPmsmGF9p4qRe++CzCgd+kFYktnsoR1sbIAfsRMrJZau0Tt1AH9KVnufc2/tU02Gf6Ibujx+15qRE03w==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"glibc": ">=2.26",
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-darwin-arm64": "1.0.1"
-			}
-		},
-		"node_modules/@img/sharp-darwin-x64": {
-			"version": "0.33.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.2.tgz",
-			"integrity": "sha512-/rK/69Rrp9x5kaWBjVN07KixZanRr+W1OiyKdXcbjQD6KbW+obaTeBBtLUAtbBsnlTTmWthw99xqoOS7SsySDg==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"glibc": ">=2.26",
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-darwin-x64": "1.0.1"
-			}
-		},
-		"node_modules/@img/sharp-libvips-darwin-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.1.tgz",
-			"integrity": "sha512-kQyrSNd6lmBV7O0BUiyu/OEw9yeNGFbQhbxswS1i6rMDwBBSX+e+rPzu3S+MwAiGU3HdLze3PanQ4Xkfemgzcw==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"macos": ">=11",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-darwin-x64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.1.tgz",
-			"integrity": "sha512-eVU/JYLPVjhhrd8Tk6gosl5pVlvsqiFlt50wotCvdkFGf+mDNBJxMh+bvav+Wt3EBnNZWq8Sp2I7XfSjm8siog==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"macos": ">=10.13",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linux-arm": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.1.tgz",
-			"integrity": "sha512-FtdMvR4R99FTsD53IA3LxYGghQ82t3yt0ZQ93WMZ2xV3dqrb0E8zq4VHaTOuLEAuA83oDawHV3fd+BsAPadHIQ==",
-			"cpu": [
-				"arm"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"glibc": ">=2.28",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linux-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.1.tgz",
-			"integrity": "sha512-bnGG+MJjdX70mAQcSLxgeJco11G+MxTz+ebxlz8Y3dxyeb3Nkl7LgLI0mXupoO+u1wRNx/iRj5yHtzA4sde1yA==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"glibc": ">=2.26",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linux-s390x": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.1.tgz",
-			"integrity": "sha512-3+rzfAR1YpMOeA2zZNp+aYEzGNWK4zF3+sdMxuCS3ey9HhDbJ66w6hDSHDMoap32DueFwhhs3vwooAB2MaK4XQ==",
-			"cpu": [
-				"s390x"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"glibc": ">=2.28",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linux-x64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.1.tgz",
-			"integrity": "sha512-3NR1mxFsaSgMMzz1bAnnKbSAI+lHXVTqAHgc1bgzjHuXjo4hlscpUxc0vFSAPKI3yuzdzcZOkq7nDPrP2F8Jgw==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"glibc": ">=2.26",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.1.tgz",
-			"integrity": "sha512-5aBRcjHDG/T6jwC3Edl3lP8nl9U2Yo8+oTl5drd1dh9Z1EBfzUKAJFUDTDisDjUwc7N4AjnPGfCA3jl3hY8uDg==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"musl": ">=1.2.2",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linuxmusl-x64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.1.tgz",
-			"integrity": "sha512-dcT7inI9DBFK6ovfeWRe3hG30h51cBAP5JXlZfx6pzc/Mnf9HFCQDLtYf4MCBjxaaTfjCCjkBxcy3XzOAo5txw==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"musl": ">=1.2.2",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-linux-arm": {
-			"version": "0.33.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.2.tgz",
-			"integrity": "sha512-Fndk/4Zq3vAc4G/qyfXASbS3HBZbKrlnKZLEJzPLrXoJuipFNNwTes71+Ki1hwYW5lch26niRYoZFAtZVf3EGA==",
-			"cpu": [
-				"arm"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"glibc": ">=2.28",
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-arm": "1.0.1"
-			}
-		},
-		"node_modules/@img/sharp-linux-arm64": {
-			"version": "0.33.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.2.tgz",
-			"integrity": "sha512-pz0NNo882vVfqJ0yNInuG9YH71smP4gRSdeL09ukC2YLE6ZyZePAlWKEHgAzJGTiOh8Qkaov6mMIMlEhmLdKew==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"glibc": ">=2.26",
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-arm64": "1.0.1"
-			}
-		},
-		"node_modules/@img/sharp-linux-s390x": {
-			"version": "0.33.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.2.tgz",
-			"integrity": "sha512-MBoInDXDppMfhSzbMmOQtGfloVAflS2rP1qPcUIiITMi36Mm5YR7r0ASND99razjQUpHTzjrU1flO76hKvP5RA==",
-			"cpu": [
-				"s390x"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"glibc": ">=2.28",
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-s390x": "1.0.1"
-			}
-		},
-		"node_modules/@img/sharp-linux-x64": {
-			"version": "0.33.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.2.tgz",
-			"integrity": "sha512-xUT82H5IbXewKkeF5aiooajoO1tQV4PnKfS/OZtb5DDdxS/FCI/uXTVZ35GQ97RZXsycojz/AJ0asoz6p2/H/A==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"glibc": ">=2.26",
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-x64": "1.0.1"
-			}
-		},
-		"node_modules/@img/sharp-linuxmusl-arm64": {
-			"version": "0.33.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.2.tgz",
-			"integrity": "sha512-F+0z8JCu/UnMzg8IYW1TMeiViIWBVg7IWP6nE0p5S5EPQxlLd76c8jYemG21X99UzFwgkRo5yz2DS+zbrnxZeA==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"musl": ">=1.2.2",
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linuxmusl-arm64": "1.0.1"
-			}
-		},
-		"node_modules/@img/sharp-linuxmusl-x64": {
-			"version": "0.33.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.2.tgz",
-			"integrity": "sha512-+ZLE3SQmSL+Fn1gmSaM8uFusW5Y3J9VOf+wMGNnTtJUMUxFhv+P4UPaYEYT8tqnyYVaOVGgMN/zsOxn9pSsO2A==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"musl": ">=1.2.2",
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linuxmusl-x64": "1.0.1"
-			}
-		},
-		"node_modules/@img/sharp-wasm32": {
-			"version": "0.33.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.2.tgz",
-			"integrity": "sha512-fLbTaESVKuQcpm8ffgBD7jLb/CQLcATju/jxtTXR1XCLwbOQt+OL5zPHSDMmp2JZIeq82e18yE0Vv7zh6+6BfQ==",
-			"cpu": [
-				"wasm32"
-			],
-			"optional": true,
-			"dependencies": {
-				"@emnapi/runtime": "^0.45.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-win32-ia32": {
-			"version": "0.33.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.2.tgz",
-			"integrity": "sha512-okBpql96hIGuZ4lN3+nsAjGeggxKm7hIRu9zyec0lnfB8E7Z6p95BuRZzDDXZOl2e8UmR4RhYt631i7mfmKU8g==",
-			"cpu": [
-				"ia32"
-			],
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-win32-x64": {
-			"version": "0.33.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.2.tgz",
-			"integrity": "sha512-E4magOks77DK47FwHUIGH0RYWSgRBfGdK56kIHSVeB9uIS4pPFr4N2kIVsXdQQo4LzOsENKV5KAhRlRL7eMAdg==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-				"npm": ">=9.6.5",
-				"pnpm": ">=7.1.0",
-				"yarn": ">=3.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
 		},
 		"node_modules/@jest/expect-utils": {
 			"version": "29.7.0",
@@ -1690,22 +1166,11 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/color": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-			"integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-			"dependencies": {
-				"color-convert": "^2.0.1",
-				"color-string": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=12.5.0"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -1716,16 +1181,8 @@
 		"node_modules/color-name": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-		},
-		"node_modules/color-string": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-			"dependencies": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
 		},
 		"node_modules/commondir": {
 			"version": "1.0.1",
@@ -1801,14 +1258,6 @@
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/detect-libc": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-			"integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
-			"engines": {
-				"node": ">=8"
-			}
 		},
 		"node_modules/diff-sequences": {
 			"version": "29.6.3",
@@ -2353,19 +1802,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2452,7 +1888,8 @@
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true
 		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
@@ -2616,11 +2053,6 @@
 			"resolved": "https://registry.npmjs.org/is-array-type/-/is-array-type-1.0.0.tgz",
 			"integrity": "sha512-LLwKQdMAO/XUkq4XTed1VYqwR2OahiwkBg+yUtZT88LXX4MLXP28qGsVfSNVP8X0wc7fzDhcZD3nns/IK8UfKw=="
 		},
-		"node_modules/is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2783,7 +2215,8 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
@@ -2818,17 +2251,6 @@
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/jsonfile": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
 		},
 		"node_modules/jspdf": {
 			"version": "2.5.2",
@@ -2899,6 +2321,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
 			"dependencies": {
 				"yallist": "^4.0.0"
 			},
@@ -3352,10 +2775,11 @@
 			"optional": true
 		},
 		"node_modules/picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-			"dev": true
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -3643,6 +3067,7 @@
 			"version": "7.6.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
 			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -3651,45 +3076,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/sharp": {
-			"version": "0.33.2",
-			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.2.tgz",
-			"integrity": "sha512-WlYOPyyPDiiM07j/UO+E720ju6gtNtHjEGg5vovUk1Lgxyjm2LFO+37Nt/UI3MMh2l6hxTWQWi7qk3cXJTutcQ==",
-			"hasInstallScript": true,
-			"dependencies": {
-				"color": "^4.2.3",
-				"detect-libc": "^2.0.2",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"libvips": ">=8.15.1",
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-darwin-arm64": "0.33.2",
-				"@img/sharp-darwin-x64": "0.33.2",
-				"@img/sharp-libvips-darwin-arm64": "1.0.1",
-				"@img/sharp-libvips-darwin-x64": "1.0.1",
-				"@img/sharp-libvips-linux-arm": "1.0.1",
-				"@img/sharp-libvips-linux-arm64": "1.0.1",
-				"@img/sharp-libvips-linux-s390x": "1.0.1",
-				"@img/sharp-libvips-linux-x64": "1.0.1",
-				"@img/sharp-libvips-linuxmusl-arm64": "1.0.1",
-				"@img/sharp-libvips-linuxmusl-x64": "1.0.1",
-				"@img/sharp-linux-arm": "0.33.2",
-				"@img/sharp-linux-arm64": "0.33.2",
-				"@img/sharp-linux-s390x": "0.33.2",
-				"@img/sharp-linux-x64": "0.33.2",
-				"@img/sharp-linuxmusl-arm64": "0.33.2",
-				"@img/sharp-linuxmusl-x64": "0.33.2",
-				"@img/sharp-wasm32": "0.33.2",
-				"@img/sharp-win32-ia32": "0.33.2",
-				"@img/sharp-win32-x64": "0.33.2"
 			}
 		},
 		"node_modules/shebang-command": {
@@ -3713,14 +3099,6 @@
 			"peer": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-			"dependencies": {
-				"is-arrayish": "^0.3.1"
 			}
 		},
 		"node_modules/slash": {
@@ -3796,16 +3174,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/supernote": {
-			"version": "0.1.0",
-			"resolved": "git+ssh://git@github.com/philips/supernote-typescript.git#3b36edf49daf3f95a62da5b37eeaa9b8fb64c6c3",
-			"license": "GPL-3.0-or-later",
-			"dependencies": {
-				"color": "^4.2.3",
-				"fs-extra": "^10.1.0",
-				"sharp": "^0.33.2"
-			}
-		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3871,7 +3239,7 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-			"devOptional": true
+			"dev": true
 		},
 		"node_modules/tsutils": {
 			"version": "3.21.0",
@@ -3950,14 +3318,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4016,7 +3376,8 @@
 		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -15,19 +15,19 @@
 	"devDependencies": {
 		"@types/color": "^3.0.6",
 		"@types/jest": "^29.5.12",
-		"@types/node": "^20.0.0",
+		"@types/node": "20.19.43",
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",
 		"builtin-modules": "3.3.0",
 		"esbuild": "^0.17.3",
 		"obsidian": "latest",
 		"tslib": "2.4.0",
-		"typescript": "4.7.4"
+		"typescript": "6.0.3"
 	},
 	"dependencies": {
 		"esbuild-plugin-inline-worker": "^0.1.1",
 		"fast-png": "^7.0.1",
-		"image-js": "^0.35.6",
+		"image-js": "^1.7.0",
 		"jspdf": "^2.5.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
 		"esbuild-plugin-inline-worker": "^0.1.1",
 		"fast-png": "^7.0.1",
 		"image-js": "^0.35.6",
-		"jspdf": "^2.5.2",
-		"supernote": "github:philips/supernote-typescript"
+		"jspdf": "^2.5.2"
 	}
 }

--- a/scripts/build
+++ b/scripts/build
@@ -13,12 +13,11 @@ npm install --include=dev || npm install --include=dev --ignore-scripts
 npm run build
 cd ..
 
-# supernote-typescript isn't in package.json (it's not published to npm; the
-# whole point of the submodule is to develop it alongside this plugin), so
-# npm install doesn't know about it. Symlink it in ourselves, after install:
-# npm prunes symlinks it doesn't recognize as declared dependencies, so this
-# has to happen after, not before.
+# supernote-typescript isn't in package.json (it's not published to npm - the
+# whole point of the submodule is to develop it alongside this plugin).
+# tsconfig.json and esbuild.config.mjs both point at it directly rather than
+# a node_modules symlink: npm install reaches through symlinks it finds
+# there and deletes the submodule's own node_modules, which broke this
+# script in exactly that way before this comment existed.
 npm install --include=dev
-ln -sfn ../supernote-typescript node_modules/supernote-typescript
-
 npm run build

--- a/scripts/build
+++ b/scripts/build
@@ -1,13 +1,32 @@
 #!/bin/sh
+set -e
 
 git submodule init
 git submodule update
+
 cd supernote-typescript/
 git clean -x -f -d
-npm install --include=dev
+# v8-profiler-next (test-only) needs a native toolchain to compile; if that's
+# not available, fall back to --ignore-scripts. The library build itself
+# (tsc) doesn't need it, only `npm test` does.
+npm install --include=dev || npm install --include=dev --ignore-scripts
 npm run build
-npm link
-cd ..
-npm link supernote-typescript/
-npm install --include=dev
+
+# `npm link` needs write access to the global npm prefix (e.g. /usr/local/lib
+# /node_modules), which sandboxed/CI environments often don't have. Fall back
+# to linking supernote-typescript/ directly into this project's node_modules.
+if npm link 2>/dev/null; then
+    cd ..
+    npm link supernote-typescript/
+    npm install --include=dev
+else
+    echo "npm link unavailable (no write access to global npm prefix)," \
+        "falling back to a direct node_modules symlink" >&2
+    cd ..
+    npm install --include=dev
+    # Must run after npm install: plain `npm install` prunes symlinks it
+    # doesn't recognize as linked, so this can't happen earlier in the order.
+    ln -sfn ../supernote-typescript node_modules/supernote-typescript
+fi
+
 npm run build

--- a/scripts/build
+++ b/scripts/build
@@ -11,22 +11,14 @@ git clean -x -f -d
 # (tsc) doesn't need it, only `npm test` does.
 npm install --include=dev || npm install --include=dev --ignore-scripts
 npm run build
+cd ..
 
-# `npm link` needs write access to the global npm prefix (e.g. /usr/local/lib
-# /node_modules), which sandboxed/CI environments often don't have. Fall back
-# to linking supernote-typescript/ directly into this project's node_modules.
-if npm link 2>/dev/null; then
-    cd ..
-    npm link supernote-typescript/
-    npm install --include=dev
-else
-    echo "npm link unavailable (no write access to global npm prefix)," \
-        "falling back to a direct node_modules symlink" >&2
-    cd ..
-    npm install --include=dev
-    # Must run after npm install: plain `npm install` prunes symlinks it
-    # doesn't recognize as linked, so this can't happen earlier in the order.
-    ln -sfn ../supernote-typescript node_modules/supernote-typescript
-fi
+# supernote-typescript isn't in package.json (it's not published to npm; the
+# whole point of the submodule is to develop it alongside this plugin), so
+# npm install doesn't know about it. Symlink it in ourselves, after install:
+# npm prunes symlinks it doesn't recognize as declared dependencies, so this
+# has to happen after, not before.
+npm install --include=dev
+ln -sfn ../supernote-typescript node_modules/supernote-typescript
 
 npm run build

--- a/src/FileListModal.ts
+++ b/src/FileListModal.ts
@@ -48,7 +48,7 @@ export abstract class FileListModal extends SuggestModal<SupernoteFile> {
             const data: SupernoteResponse = JSON.parse(match[1]);
             this.files = data.fileList;
         } catch (err) {
-            new Notice(`Failed to load files: ${err.message}`);
+            new Notice(`Failed to load files: ${err instanceof Error ? err.message : String(err)}`);
             this.close();
         }
     }
@@ -133,7 +133,7 @@ export class DownloadListModal extends FileListModal {
                     view.editor.replaceSelection(link);
                 }
             } catch (err) {
-                new Notice(`Failed to download file: ${err.message}`);
+                new Notice(`Failed to download file: ${err instanceof Error ? err.message : String(err)}`);
             }
         }
     }
@@ -231,7 +231,7 @@ export class UploadListModal extends FileListModal {
                 new Notice(`Successfully uploaded ${uploadFilename} to Supernote`);
                 this.close();
             } catch (err) {
-                new Notice(`Upload failed: ${err.message}`);
+                new Notice(`Upload failed: ${err instanceof Error ? err.message : String(err)}`);
                 console.error('Upload error:', err);
             }
         } else if (file.isDirectory) {

--- a/src/FileListModal.ts
+++ b/src/FileListModal.ts
@@ -63,13 +63,13 @@ export abstract class FileListModal extends SuggestModal<SupernoteFile> {
     }
 
     renderSuggestion(file: SupernoteFile, el: HTMLElement) {
-        const container = el.createDiv({ cls: "suggestion-item" });
-
-        // Add directory icon or file icon
-        const iconEl = container.createSpan({ cls: "suggestion-icon" });
+        // `el` is already the `.suggestion-item` row created by SuggestModal;
+        // rendering into a nested `.suggestion-item` div collapses the
+        // clickable/hoverable area to just the icon in some themes.
+        const iconEl = el.createSpan({ cls: "suggestion-icon" });
         iconEl.textContent = file.isDirectory ? "📁" : "📄";
 
-        const contentEl = container.createDiv({ cls: "suggestion-content" });
+        const contentEl = el.createDiv({ cls: "suggestion-content" });
         contentEl.createDiv({ text: file.name, cls: "suggestion-title" });
 
         if (!file.isDirectory) {
@@ -168,16 +168,15 @@ export class UploadListModal extends FileListModal {
 
     override renderSuggestion(file: SupernoteFile, el: HTMLElement) {
         if (file.name === '[UPLOAD HERE]') {
-            el.createDiv({ cls: "suggestion-item upload-here" }, container => {
-                container.createSpan({
-                    cls: "suggestion-icon",
-                    text: "⬆️"
-                });
-                const content = container.createDiv({ cls: "suggestion-content" });
-                content.createDiv({
-                    cls: "suggestion-title",
-                    text: "Upload to current directory"
-                });
+            el.addClass("upload-here");
+            el.createSpan({
+                cls: "suggestion-icon",
+                text: "⬆️"
+            });
+            const content = el.createDiv({ cls: "suggestion-content" });
+            content.createDiv({
+                cls: "suggestion-title",
+                text: "Upload to current directory"
             });
         } else {
             super.renderSuggestion(file, el);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { installAtPolyfill } from './polyfills';
-import { App, Modal, TFile, Plugin, Editor, MarkdownView, WorkspaceLeaf, FileView } from 'obsidian';
+import { App, Modal, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS } from './settings';
 import { SupernoteX, fetchMirrorFrame } from 'supernote-typescript';
 import { DownloadListModal, UploadListModal } from './FileListModal';
@@ -261,7 +261,7 @@ let vw: VaultWriter;
 export const VIEW_TYPE_SUPERNOTE = "supernote-view";
 
 export class SupernoteView extends FileView {
-	file: TFile;
+	declare file: TFile;
 	settings: SupernotePluginSettings;
 	constructor(leaf: WorkspaceLeaf, settings: SupernotePluginSettings) {
 		super(leaf);
@@ -400,7 +400,7 @@ export class SupernoteView extends FileView {
 }
 
 export default class SupernotePlugin extends Plugin {
-	settings: SupernotePluginSettings;
+	settings!: SupernotePluginSettings;
 
 	async onload() {
         // Install polyfills before any other code runs
@@ -447,7 +447,7 @@ export default class SupernotePlugin extends Plugin {
 		this.addCommand({
 			id: 'insert-supernote-screen-mirror-image',
 			name: 'Insert a Supernote screen mirroring image as attachment',
-			editorCallback: async (editor: Editor, view: MarkdownView) => {
+			editorCallback: async (editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
 				// generate a unique filename for the mirror based on the current note path
 				let ts = generateTimestamp();
 				const f = this.app.workspace.activeEditor?.file?.basename || '';
@@ -611,7 +611,6 @@ class DirectConnectErrorModal extends Modal {
 
 class ErrorModal extends Modal {
 	error: Error;
-	settings: SupernotePluginSettings;
 
 	constructor(app: App, error: Error) {
 		super(app);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { installAtPolyfill } from './polyfills';
 import { App, Modal, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS } from './settings';
 import { SupernoteX, fetchMirrorFrame } from 'supernote-typescript';
+import { encode } from 'image-js';
 import { DownloadListModal, UploadListModal } from './FileListModal';
 import { jsPDF } from 'jspdf';
 import { SupernoteWorkerMessage, SupernoteWorkerResponse } from './myworker.worker';
@@ -459,7 +460,7 @@ export default class SupernotePlugin extends Plugin {
 					}
 					let image = await fetchMirrorFrame(`${this.settings.directConnectIP}:8080`);
 
-					const file = await this.app.vault.createBinary(filename, image.toBuffer());
+					const file = await this.app.vault.createBinary(filename, encode(image).buffer as ArrayBuffer);
 					const path = this.app.workspace.activeEditor?.file?.path;
 					if (!path) {
 						throw new Error("Active file path is null")

--- a/src/myworker.worker.ts
+++ b/src/myworker.worker.ts
@@ -2,6 +2,7 @@ import { installAtPolyfill } from 'polyfills';
 installAtPolyfill();
 
 import { SupernoteX, toImage } from 'supernote-typescript';
+import { encodeDataURL } from 'image-js';
 
 export { };
 
@@ -24,13 +25,7 @@ self.onmessage = async (e: MessageEvent<SupernoteWorkerMessage>) => {
         if (type === 'convert') {
             const results = await toImage(note, pageNumbers);
             // Convert canvas/images to data URLs before sending
-            const dataUrls = results.map(result => {
-                if (result && typeof result.toDataURL === 'function') {
-                    return result.toDataURL();
-                }
-                console.error('Result is not a canvas or does not support toDataURL');
-                return null;
-            });
+            const dataUrls = results.map(result => encodeDataURL(result));
 
             self.postMessage({
                 type: 'result',

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -2,7 +2,7 @@
 // This is necessary for SuperNote devices with old WebView versions.
 export function installAtPolyfill() {
     if (!Array.prototype.at) {
-        const at = function(n: number) {
+        const at = function(this: ArrayLike<unknown>, n: number) {
             // ToInteger() abstract op
             n = Math.trunc(n) || 0;
             // Allow negative indexing from the end
@@ -25,7 +25,9 @@ export function installAtPolyfill() {
         Array.prototype.at = at;
         typedArrays.forEach(TypedArray => {
             if (TypedArray) {
-                TypedArray.prototype.at = at;
+                // A single polyfill implementation can't statically match every
+                // typed array's distinct `at` return type (number vs bigint).
+                TypedArray.prototype.at = at as typeof TypedArray.prototype.at;
             }
         });
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,29 +1,32 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "baseUrl": "./src/",
     "paths": {
-      "supernote-typescript": ["../supernote-typescript/src/"]
+      // supernote-typescript is a git submodule (see CLAUDE.md), not an npm
+      // dependency - point at its compiled output directly rather than a
+      // node_modules symlink, which npm install prunes/reaches through and
+      // deletes the submodule's own node_modules.
+      "supernote-typescript": ["../supernote-typescript/lib"]
     },
     "inlineSourceMap": true,
     "inlineSources": true,
     "module": "ESNext",
-    "target": "ES6",
+    "target": "ES2022",
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "noImplicitAny": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "isolatedModules": true,
     "strictNullChecks": true,
     "lib": [
       "DOM",
-      "ES5",
-      "ES6",
-      "ES7",
+      "ES2022",
       "DOM.Iterable"
     ]
   },
-  "exclude": [
-    "supernote-typescript/tests/*.ts"
+  "include": [
+    "src/**/*.ts"
   ]
 }


### PR DESCRIPTION
## Summary

- **Fix unclickable suggestion rows in the device file picker** (#60): `renderSuggestion()` was nesting a second `.suggestion-item` div inside the row element `SuggestModal` already provides, collapsing the hoverable/clickable area to a sliver in themes like Minimal.
- **Update supernote-typescript to v0.4.0**, dropping its `v8-profiler-next` native devDependency (needed a C++ toolchain to install). This pulled in a few required changes:
  - Bump `typescript` to 6.0.3 and `@types/node` to match (v0.4.0's source needs syntax 4.7.4 can't parse).
  - `image-js` (a supernote-typescript dependency) jumped 0.35→1.7, replacing `Image.toBuffer()`/`.toDataURL()` instance methods with standalone `encode()`/`encodeDataURL()` functions. Updated call sites and bumped root's own `image-js` dependency to match.
  - Fix a batch of type-safety gaps the newer TypeScript now catches (`catch(err)` typed as `unknown`, uninitialized class fields, an Obsidian `editorCallback` signature change, a dead unused field).
- **Stop routing the submodule through a `node_modules` symlink.** `tsconfig.json` (`paths`) and `esbuild.config.mjs` (`alias`) now point straight at the submodule directory. The symlink was a landmine: any subsequent root `npm install` reached through it and silently deleted the submodule's own `node_modules`, surfacing later as confusing "missing export" errors that looked like upstream API breaks but weren't. Verified the new setup survives a plain `npm install`.
- **Harden `scripts/build`** to fall back to `--ignore-scripts` when the submodule's native devDependency can't compile (sandboxes/CI without a C++ toolchain).

See `CLAUDE.md` (new) for the full dependency-management rationale.

## Test plan

- [x] `./scripts/build` succeeds from a fully clean `node_modules` (both root and submodule)
- [x] `npm run build` type-checks and bundles with no errors
- [x] Submodule's own test suite passes (`npm test` in `supernote-typescript/`: 14/14)
- [x] Confirmed a plain root `npm install` no longer wipes the submodule's `node_modules`
- [x] Manual click-test of the device file picker in Obsidian (CSS/DOM fix, not covered by the above)