### PR TITLE
Add CI workflow for linting and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+      - run: ./scripts/build
+
+  test-submodule:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+      - name: Install supernote-typescript dependencies
+        working-directory: supernote-typescript
+        run: npm install --include=dev || npm install --include=dev --ignore-scripts
+      - name: Lint supernote-typescript
+        working-directory: supernote-typescript
+        run: npm run lint
+      - name: Test supernote-typescript
+        working-directory: supernote-typescript
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+		"lint": "eslint src --ext .ts",
 		"version": "node version-bump.mjs && git add manifest.json versions.json",
 		"push-android": "adb push main.js /sdcard/Documents/SupernoteTest/.obsidian/plugins/supernote"
 	},

--- a/src/FileListModal.ts
+++ b/src/FileListModal.ts
@@ -23,7 +23,7 @@ interface SupernoteResponse {
 export abstract class FileListModal extends SuggestModal<SupernoteFile> {
     settings: SupernotePluginSettings;
     files: SupernoteFile[] = [];
-    currentPath: string = '/';
+    currentPath = '/';
 
     constructor(app: App, plugin: SupernotePlugin) {
         super(app);

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,12 +62,7 @@ export class WorkerPool {
 
     private processChunk(worker: Worker, note: SupernoteX, pageNumbers: number[]): Promise<any[]> {
         return new Promise((resolve, reject) => {
-            const startTime = Date.now();
-
             worker.onmessage = (e: MessageEvent<SupernoteWorkerResponse>) => {
-                const duration = Date.now() - startTime;
-                //console.log(`Processed pages ${pageNumbers.join(',')} in ${duration}ms`);
-
                 if (e.data.error) {
                     reject(new Error(e.data.error));
                 } else {
@@ -190,9 +185,9 @@ class VaultWriter {
 			converter.terminate();
 		}
 
-		let imgs: TFile[] = [];
+		const imgs: TFile[] = [];
 		for (let i = 0; i < images.length; i++) {
-			let filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}-${i}.png`);
+			const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}-${i}.png`);
 			const buffer = dataUrlToBuffer(images[i]);
 			imgs.push(await this.app.vault.createBinary(filename, buffer));
 		}
@@ -201,14 +196,14 @@ class VaultWriter {
 
 	async attachMarkdownFile(file: TFile) {
 		const note = await this.app.vault.readBinary(file);
-		let sn = new SupernoteX(new Uint8Array(note));
+		const sn = new SupernoteX(new Uint8Array(note));
 
 		this.writeMarkdownFile(file, sn, null);
 	}
 
 	async attachNoteFiles(file: TFile) {
 		const note = await this.app.vault.readBinary(file);
-		let sn = new SupernoteX(new Uint8Array(note));
+		const sn = new SupernoteX(new Uint8Array(note));
 
 		const imgs = await this.writeImageFiles(file, sn);
 		this.writeMarkdownFile(file, sn, imgs);
@@ -216,7 +211,7 @@ class VaultWriter {
 
 	async exportToPDF(file: TFile) {
 		const note = await this.app.vault.readBinary(file);
-		let sn = new SupernoteX(new Uint8Array(note));
+		const sn = new SupernoteX(new Uint8Array(note));
 
 		// Create PDF document
 		const pdf = new jsPDF({
@@ -252,7 +247,7 @@ class VaultWriter {
 		}
 
 		// Generate filename and save
-		let filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}.pdf`);
+		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}.pdf`);
 		const pdfOutput = pdf.output('arraybuffer');
 		await this.app.vault.createBinary(filename, pdfOutput);
 	}
@@ -286,7 +281,7 @@ export class SupernoteView extends FileView {
 		container.createEl("h1", { text: file.name });
 
 		const note = await this.app.vault.readBinary(file);
-		let sn = new SupernoteX(new Uint8Array(note));
+		const sn = new SupernoteX(new Uint8Array(note));
 		let images: string[] = [];
 
 		const converter = new ImageConverter();
@@ -332,7 +327,7 @@ export class SupernoteView extends FileView {
 			atoc.createEl("h2", { text: "Table of contents" });
 			const ul = container.createEl("ul");
 			for (let i = 0; i < images.length; i++) {
-				const a = container.createEl("li").createEl("a");
+				const a = ul.createEl("li").createEl("a");
 				a.href = `#page${i + 1}`
 				a.text = `Page ${i + 1}`
 			}
@@ -450,7 +445,7 @@ export default class SupernotePlugin extends Plugin {
 			name: 'Insert a Supernote screen mirroring image as attachment',
 			editorCallback: async (editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
 				// generate a unique filename for the mirror based on the current note path
-				let ts = generateTimestamp();
+				const ts = generateTimestamp();
 				const f = this.app.workspace.activeEditor?.file?.basename || '';
 				const filename = await this.app.fileManager.getAvailablePathForAttachment(`supernote-mirror-${f}-${ts}.png`);
 
@@ -458,7 +453,7 @@ export default class SupernotePlugin extends Plugin {
 					if (this.settings.directConnectIP.length == 0) {
 						throw new Error("IP is unset, please set in Supernote plugin settings")
 					}
-					let image = await fetchMirrorFrame(`${this.settings.directConnectIP}:8080`);
+					const image = await fetchMirrorFrame(`${this.settings.directConnectIP}:8080`);
 
 					const file = await this.app.vault.createBinary(filename, encode(image).buffer as ArrayBuffer);
 					const path = this.app.workspace.activeEditor?.file?.path;


### PR DESCRIPTION
Adds .github/workflows/ci.yml with three jobs: eslint on the plugin source, a full build (submodule + tsc typecheck + esbuild bundle) via scripts/build, and lint+test of the supernote-typescript submodule.

Also fixes the pre-existing lint errors this surfaced (prefer-const, unused vars, a trivial type annotation) so the new lint gate starts green, including a real bug where TOC <li> elements were appended to the page container instead of the <ul> that was created for them.