### PR TITLE
pdf.js note view: canvas rendering, selectable text, find-in-note, zoom/pan, drag-out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
 			"dependencies": {
 				"esbuild-plugin-inline-worker": "^0.1.1",
 				"fast-png": "^7.0.1",
-				"image-js": "^1.7.0",
-				"jspdf": "^2.5.2"
+				"image-js": "^1.7.0"
 			},
 			"devDependencies": {
 				"@types/color": "^3.0.6",
@@ -58,17 +57,6 @@
 			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"dev": true,
 			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/runtime": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.1.tgz",
-			"integrity": "sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -694,13 +682,6 @@
 			"resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.3.tgz",
 			"integrity": "sha512-bq0hMV9opAcrmE0Byyo0fY3Ew4tgOevJmQ9grUhpXQhYfyLJ1Kqg3P33JT5fdbT2AjeAjR51zqqVjAL/HMkx7Q=="
 		},
-		"node_modules/@types/raf": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
-			"integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
-			"license": "MIT",
-			"optional": true
-		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -1013,34 +994,12 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/atob": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-			"license": "(MIT OR Apache-2.0)",
-			"bin": {
-				"atob": "bin/atob.js"
-			},
-			"engines": {
-				"node": ">= 4.5.0"
-			}
-		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/base64-arraybuffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-			"integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">= 0.6.0"
-			}
 		},
 		"node_modules/binary-search": {
 			"version": "1.3.6",
@@ -1078,18 +1037,6 @@
 			"integrity": "sha512-0TCrPvavRM/3Os9QIUDhe8jpAQXgEYjsVO+9IKnkC8cdzorDX5fMRfr3neEFGjcfRItEswHvIvPrqQzCalRYkw==",
 			"license": "MIT"
 		},
-		"node_modules/btoa": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-			"integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
-			"license": "(MIT OR Apache-2.0)",
-			"bin": {
-				"btoa": "bin/btoa.js"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
 		"node_modules/builtin-modules": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -1111,33 +1058,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/canvg": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
-			"integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@babel/runtime": "^7.12.5",
-				"@types/raf": "^3.4.0",
-				"core-js": "^3.8.3",
-				"raf": "^3.4.1",
-				"regenerator-runtime": "^0.13.7",
-				"rgbcolor": "^1.0.1",
-				"stackblur-canvas": "^2.0.0",
-				"svg-pathdata": "^6.0.3"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/canvg/node_modules/regenerator-runtime": {
-			"version": "0.13.11",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-			"license": "MIT",
-			"optional": true
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
@@ -1213,18 +1133,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/core-js": {
-			"version": "3.40.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.40.0.tgz",
-			"integrity": "sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/core-js"
-			}
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1239,16 +1147,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/css-line-break": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-			"integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"utrie": "^1.0.2"
 			}
 		},
 		"node_modules/debug": {
@@ -1318,13 +1216,6 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
-		},
-		"node_modules/dompurify": {
-			"version": "2.5.8",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
-			"integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
-			"license": "(MPL-2.0 OR Apache-2.0)",
-			"optional": true
 		},
 		"node_modules/esbuild": {
 			"version": "0.17.3",
@@ -1933,20 +1824,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/html2canvas": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-			"integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"css-line-break": "^2.1.0",
-				"text-segmentation": "^1.0.3"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
 		"node_modules/https-proxy-agent": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -2254,24 +2131,6 @@
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/jspdf": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
-			"integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.23.2",
-				"atob": "^2.1.2",
-				"btoa": "^1.2.1",
-				"fflate": "^0.8.1"
-			},
-			"optionalDependencies": {
-				"canvg": "^3.0.6",
-				"core-js": "^3.6.0",
-				"dompurify": "^2.5.4",
-				"html2canvas": "^1.0.0-rc.5"
-			}
 		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
@@ -2728,13 +2587,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-			"license": "MIT",
-			"optional": true
-		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2884,26 +2736,11 @@
 				}
 			]
 		},
-		"node_modules/raf": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-			"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"performance-now": "^2.1.0"
-			}
-		},
 		"node_modules/react-is": {
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
 			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
 			"dev": true
-		},
-		"node_modules/regenerator-runtime": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
 		},
 		"node_modules/regexpp": {
 			"version": "3.2.0",
@@ -2935,16 +2772,6 @@
 			"engines": {
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/rgbcolor": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
-			"integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
-			"license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
-			"optional": true,
-			"engines": {
-				"node": ">= 0.8.15"
 			}
 		},
 		"node_modules/rimraf": {
@@ -3112,16 +2939,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/stackblur-canvas": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
-			"integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=0.1.14"
-			}
-		},
 		"node_modules/string-split-by": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
@@ -3175,26 +2992,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/svg-pathdata": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
-			"integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/text-segmentation": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-			"integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"utrie": "^1.0.2"
 			}
 		},
 		"node_modules/text-table": {
@@ -3331,16 +3128,6 @@
 			"peer": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
-			}
-		},
-		"node_modules/utrie": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-			"integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"base64-arraybuffer": "^1.0.2"
 			}
 		},
 		"node_modules/w3c-keyname": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
 	"dependencies": {
 		"esbuild-plugin-inline-worker": "^0.1.1",
 		"fast-png": "^7.0.1",
-		"image-js": "^1.7.0",
-		"jspdf": "^2.5.2"
+		"image-js": "^1.7.0"
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { installAtPolyfill } from './polyfills';
-import { App, Modal, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, loadPdfJs } from 'obsidian';
+import { App, Modal, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, loadPdfJs, Scope, SearchComponent } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS } from './settings';
 import { SupernoteX, fetchMirrorFrame } from 'supernote-typescript';
 import { encode } from 'image-js';
@@ -260,15 +260,73 @@ class VaultWriter {
 	}
 }
 
+// Renders a pdf.js text layer into `container`, preferring the modern
+// `TextLayer` class (pdf.js >=3.4) and falling back to the older
+// `renderTextLayer()` function on earlier bundles. Obsidian's `loadPdfJs()`
+// only promises the core pdfjsLib, not a pinned version, so neither API is
+// guaranteed — if neither exists, pages still render, they just lose
+// selectable text and find-in-note for that session.
+async function renderTextLayer(pdfjsLib: any, textContent: any, container: HTMLElement, viewport: any): Promise<boolean> {
+	container.empty();
+
+	if (typeof pdfjsLib.TextLayer === 'function') {
+		const textLayer = new pdfjsLib.TextLayer({ textContentSource: textContent, container, viewport });
+		await textLayer.render();
+		return true;
+	}
+
+	if (typeof pdfjsLib.renderTextLayer === 'function') {
+		const task = pdfjsLib.renderTextLayer({ textContentSource: textContent, container, viewport });
+		await task.promise;
+		return true;
+	}
+
+	return false;
+}
+
+type PageRenderState = {
+	pdfPage: any;
+	baseScale: number;
+	pageContainer: HTMLElement;
+	canvasWrap: HTMLElement;
+	canvas: HTMLCanvasElement;
+	textLayerDiv: HTMLElement;
+	text: string;
+	spans: HTMLSpanElement[];
+};
+
+type FindMatch = {
+	pageIndex: number;
+	spanIndex: number;
+};
+
 let vw: VaultWriter;
 export const VIEW_TYPE_SUPERNOTE = "supernote-view";
 
 export class SupernoteView extends FileView {
 	declare file: TFile;
 	settings: SupernotePluginSettings;
+
+	private pdfjsLib: any;
+	private pageStates: PageRenderState[] = [];
+
+	private zoomScale = 1;
+	private renderedZoomScale = 1;
+	private zoomDebounceTimer: number | undefined;
+	private zoomLabelEl: HTMLElement | null = null;
+
+	private findBarEl: HTMLElement | null = null;
+	private findInput: SearchComponent | null = null;
+	private findMatchCountEl: HTMLElement | null = null;
+	private findMatches: FindMatch[] = [];
+	private findMatchCursor = -1;
+
 	constructor(leaf: WorkspaceLeaf, settings: SupernotePluginSettings) {
 		super(leaf);
 		this.settings = settings;
+		// Documented pattern (obsidian.d.ts View.scope) for registering hotkeys
+		// that are only active while this view has focus.
+		this.scope = new Scope(this.app.scope);
 	}
 
 	getViewType() {
@@ -282,10 +340,35 @@ export class SupernoteView extends FileView {
 		return this.file.basename;
 	}
 
+	async onOpen(): Promise<void> {
+		this.scope?.register(['Mod'], 'f', (evt) => {
+			evt.preventDefault();
+			this.toggleFindBar();
+			return false;
+		});
+
+		// Ctrl/Cmd+scroll to zoom; plain scroll keeps paging through the note as
+		// before. contentEl persists across file loads (onLoadFile only rebuilds
+		// its children), so this only needs registering once.
+		this.registerDomEvent(this.contentEl, 'wheel', (evt: WheelEvent) => {
+			if (!(evt.ctrlKey || evt.metaKey)) return;
+			evt.preventDefault();
+			const factor = evt.deltaY < 0 ? 1.1 : 1 / 1.1;
+			this.setZoom(this.zoomScale * factor);
+		}, { passive: false });
+	}
+
 	async onLoadFile(file: TFile): Promise<void> {
-		const container = this.containerEl.children[1];
+		const container = this.contentEl;
 		container.empty();
 		container.createEl("h1", { text: file.name });
+
+		window.clearTimeout(this.zoomDebounceTimer);
+		this.pageStates = [];
+		this.zoomScale = 1;
+		this.renderedZoomScale = 1;
+		this.findMatches = [];
+		this.findMatchCursor = -1;
 
 		const note = await this.app.vault.readBinary(file);
 		const sn = new SupernoteX(new Uint8Array(note));
@@ -304,8 +387,8 @@ export class SupernoteView extends FileView {
 		// and file-backed, but `loadPdfJs()` exposes the underlying pdfjsLib it uses,
 		// so pages can be rendered here without ever writing a file to the vault.
 		const pdf = buildNotePdf(sn, images, this.settings);
-		const pdfjsLib = await loadPdfJs();
-		const pdfDoc = await pdfjsLib.getDocument({ data: pdf.output('arraybuffer') }).promise;
+		this.pdfjsLib = await loadPdfJs();
+		const pdfDoc = await this.pdfjsLib.getDocument({ data: pdf.output('arraybuffer') }).promise;
 
 		if (this.settings.showExportButtons) {
 			const exportNoteBtn = container.createEl("p").createEl("button", {
@@ -336,6 +419,9 @@ export class SupernoteView extends FileView {
 			});
 		}
 
+		this.buildZoomBar(container);
+		this.buildFindBar(container);
+
 		if (images.length > 1 && this.settings.showTOC) {
 			const atoc = container.createEl("a");
 			atoc.id = "toc";
@@ -348,13 +434,14 @@ export class SupernoteView extends FileView {
 			}
 		}
 
+		const pagesEl = container.createEl("div", { cls: 'supernote-pages' });
+
 		for (let i = 0; i < images.length; i++) {
 			const imageDataUrl = images[i];
 
-			const pageContainer = container.createEl("div", {
+			const pageContainer = pagesEl.createEl("div", {
 				cls: 'page-container',
 			})
-			pageContainer.setAttr('style', 'max-width: ' + this.settings.noteImageMaxDim + 'px;')
 
 			if (images.length > 1 && this.settings.showTOC) {
 				const a = pageContainer.createEl("a");
@@ -386,21 +473,42 @@ export class SupernoteView extends FileView {
 			// instead of dropping in the raw page image.
 			const pdfPage = await pdfDoc.getPage(i + 1);
 			const unscaledViewport = pdfPage.getViewport({ scale: 1 });
-			const scale = this.settings.noteImageMaxDim / Math.max(unscaledViewport.width, unscaledViewport.height);
-			const viewport = pdfPage.getViewport({ scale });
+			const baseScale = this.settings.noteImageMaxDim / Math.max(unscaledViewport.width, unscaledViewport.height);
 
-			const canvas = pageContainer.createEl("canvas");
-			canvas.width = viewport.width;
-			canvas.height = viewport.height;
+			const canvasWrap = pageContainer.createEl("div", { cls: 'supernote-canvas-wrap' });
+			const canvas = canvasWrap.createEl("canvas");
 			if (this.settings.invertColorsWhenDark) {
 				canvas.addClass("supernote-invert-dark");
 			}
-			canvas.setAttr('style', 'max-height: ' + this.settings.noteImageMaxDim + 'px; max-width: 100%;')
 
-			const canvasContext = canvas.getContext("2d");
-			if (canvasContext) {
-				await pdfPage.render({ canvasContext, viewport }).promise;
-			}
+			// Canvas doesn't get native image drag-out the way <img> did; wire it up
+			// manually against the same page PNG the canvas is rendered from. This
+			// is best-effort — worth confirming it actually reproduces useful
+			// drag-and-drop behavior in a real vault, since the pre-canvas <img>
+			// drag may not have produced a proper vault attachment link either.
+			canvas.draggable = true;
+			canvas.addEventListener('dragstart', (evt) => {
+				if (!evt.dataTransfer) return;
+				evt.dataTransfer.setData('text/uri-list', imageDataUrl);
+				evt.dataTransfer.setData('text/plain', imageDataUrl);
+				evt.dataTransfer.setDragImage(canvas, 0, 0);
+			});
+
+			const textLayerDiv = canvasWrap.createEl("div", { cls: 'textLayer' });
+
+			const state: PageRenderState = {
+				pdfPage,
+				baseScale,
+				pageContainer,
+				canvasWrap,
+				canvas,
+				textLayerDiv,
+				text: '',
+				spans: [],
+			};
+			this.pageStates.push(state);
+
+			await this.renderPage(state, baseScale * this.zoomScale);
 
 			// Create a button to save image to vault
 			if (this.settings.showExportButtons) {
@@ -418,7 +526,195 @@ export class SupernoteView extends FileView {
 		}
 	}
 
-	async onClose() { }
+	private async renderPage(state: PageRenderState, scale: number): Promise<void> {
+		const viewport = state.pdfPage.getViewport({ scale });
+
+		state.canvas.width = viewport.width;
+		state.canvas.height = viewport.height;
+		state.canvasWrap.setCssStyles({ width: `${viewport.width}px`, height: `${viewport.height}px` });
+
+		const canvasContext = state.canvas.getContext("2d");
+		if (canvasContext) {
+			await state.pdfPage.render({ canvasContext, viewport }).promise;
+		}
+
+		const textContent = await state.pdfPage.getTextContent();
+		state.text = textContent.items.map((item: any) => ('str' in item ? item.str : '')).join('');
+
+		const hasTextLayer = await renderTextLayer(this.pdfjsLib, textContent, state.textLayerDiv, viewport);
+		state.spans = hasTextLayer ? Array.from(state.textLayerDiv.querySelectorAll('span')) : [];
+	}
+
+	private buildZoomBar(container: HTMLElement) {
+		const zoomBar = container.createEl('div', { cls: 'supernote-zoom-bar' });
+		const zoomOutBtn = zoomBar.createEl('button', { text: '−', cls: 'clickable-icon', attr: { 'aria-label': 'Zoom out' } });
+		this.zoomLabelEl = zoomBar.createEl('span', { cls: 'supernote-zoom-label', text: '100%' });
+		const zoomInBtn = zoomBar.createEl('button', { text: '+', cls: 'clickable-icon', attr: { 'aria-label': 'Zoom in' } });
+		const zoomResetBtn = zoomBar.createEl('button', { text: 'Reset zoom', cls: 'clickable-icon' });
+
+		zoomOutBtn.addEventListener('click', () => this.setZoom(this.zoomScale / 1.25));
+		zoomInBtn.addEventListener('click', () => this.setZoom(this.zoomScale * 1.25));
+		zoomResetBtn.addEventListener('click', () => this.setZoom(1));
+	}
+
+	private setZoom(newScale: number) {
+		this.zoomScale = Math.min(5, Math.max(0.25, newScale));
+		this.zoomLabelEl?.setText(`${Math.round(this.zoomScale * 100)}%`);
+
+		// Instant CSS-scale feedback while the user is still zooming; the real
+		// re-render (crisp at the new resolution, text layer repositioned) is
+		// debounced below so rapid wheel/button input doesn't thrash pdf.js.
+		const instantFactor = this.zoomScale / this.renderedZoomScale;
+		for (const state of this.pageStates) {
+			state.canvasWrap.setCssStyles({ transform: `scale(${instantFactor})`, transformOrigin: 'top left' });
+		}
+
+		window.clearTimeout(this.zoomDebounceTimer);
+		this.zoomDebounceTimer = window.setTimeout(() => this.commitZoom(), 200);
+	}
+
+	private async commitZoom(): Promise<void> {
+		const targetZoom = this.zoomScale;
+		for (const state of this.pageStates) {
+			await this.renderPage(state, state.baseScale * targetZoom);
+			state.canvasWrap.setCssStyles({ transform: '', transformOrigin: '' });
+		}
+		this.renderedZoomScale = targetZoom;
+	}
+
+	private buildFindBar(container: HTMLElement) {
+		const bar = container.createEl('div', { cls: 'supernote-find-bar' });
+		bar.hide();
+		this.findBarEl = bar;
+
+		this.findInput = new SearchComponent(bar);
+		this.findInput.setPlaceholder('Find in note…');
+		this.findInput.onChange((value) => this.runFind(value));
+
+		this.findMatchCountEl = bar.createEl('span', { cls: 'supernote-find-count' });
+
+		const prevBtn = bar.createEl('button', { text: '↑', cls: 'clickable-icon', attr: { 'aria-label': 'Previous match' } });
+		const nextBtn = bar.createEl('button', { text: '↓', cls: 'clickable-icon', attr: { 'aria-label': 'Next match' } });
+		const closeBtn = bar.createEl('button', { text: '✕', cls: 'clickable-icon', attr: { 'aria-label': 'Close find bar' } });
+
+		prevBtn.addEventListener('click', () => this.stepFind(-1));
+		nextBtn.addEventListener('click', () => this.stepFind(1));
+		closeBtn.addEventListener('click', () => this.closeFindBar());
+
+		bar.addEventListener('keydown', (evt: KeyboardEvent) => {
+			if (evt.key === 'Escape') {
+				evt.preventDefault();
+				this.closeFindBar();
+			} else if (evt.key === 'Enter') {
+				evt.preventDefault();
+				this.stepFind(evt.shiftKey ? -1 : 1);
+			}
+		});
+	}
+
+	private toggleFindBar() {
+		if (!this.findBarEl) return;
+		if (this.findBarEl.isShown()) {
+			this.closeFindBar();
+			return;
+		}
+		this.findBarEl.show();
+		this.findInput?.inputEl.focus();
+		this.findInput?.inputEl.select();
+	}
+
+	private closeFindBar() {
+		this.clearFindHighlights();
+		this.findBarEl?.hide();
+	}
+
+	private clearFindHighlights() {
+		for (const state of this.pageStates) {
+			for (const span of state.spans) {
+				span.removeClass('supernote-find-match');
+				span.removeClass('supernote-find-match-current');
+			}
+		}
+		this.findMatches = [];
+		this.findMatchCursor = -1;
+		this.findMatchCountEl?.setText('');
+	}
+
+	// Maps a character offset within state.text back to the span that contains
+	// it. Assumes pdf.js's text layer renders one span per text-content item in
+	// order, which holds for the common case; a mismatch here just means a
+	// match highlights the wrong span rather than crashing.
+	private findSpanForOffset(state: PageRenderState, offset: number): number {
+		let cumulative = 0;
+		for (let i = 0; i < state.spans.length; i++) {
+			const len = state.spans[i].textContent?.length ?? 0;
+			if (offset < cumulative + len) return i;
+			cumulative += len;
+		}
+		return -1;
+	}
+
+	private runFind(query: string) {
+		this.clearFindHighlights();
+		if (!query) return;
+
+		const lowerQuery = query.toLowerCase();
+		for (let pageIndex = 0; pageIndex < this.pageStates.length; pageIndex++) {
+			const state = this.pageStates[pageIndex];
+			const lowerText = state.text.toLowerCase();
+
+			let searchStart = 0;
+			while (true) {
+				const matchOffset = lowerText.indexOf(lowerQuery, searchStart);
+				if (matchOffset === -1) break;
+
+				const spanIndex = this.findSpanForOffset(state, matchOffset);
+				if (spanIndex !== -1) {
+					this.findMatches.push({ pageIndex, spanIndex });
+					state.spans[spanIndex].addClass('supernote-find-match');
+				}
+				searchStart = matchOffset + lowerQuery.length;
+			}
+		}
+
+		if (this.findMatches.length > 0) {
+			this.findMatchCursor = 0;
+			this.highlightCurrentMatch();
+		}
+		this.updateFindCount();
+	}
+
+	private stepFind(direction: 1 | -1) {
+		if (this.findMatches.length === 0) return;
+		this.findMatchCursor = (this.findMatchCursor + direction + this.findMatches.length) % this.findMatches.length;
+		this.highlightCurrentMatch();
+		this.updateFindCount();
+	}
+
+	private highlightCurrentMatch() {
+		for (const state of this.pageStates) {
+			for (const span of state.spans) {
+				span.removeClass('supernote-find-match-current');
+			}
+		}
+
+		const match = this.findMatches[this.findMatchCursor];
+		if (!match) return;
+
+		const state = this.pageStates[match.pageIndex];
+		const span = state.spans[match.spanIndex];
+		span.addClass('supernote-find-match-current');
+		state.pageContainer.scrollIntoView({ block: 'center', behavior: 'smooth' });
+	}
+
+	private updateFindCount() {
+		if (!this.findMatchCountEl) return;
+		this.findMatchCountEl.setText(this.findMatches.length === 0 ? 'No matches' : `${this.findMatchCursor + 1}/${this.findMatches.length}`);
+	}
+
+	async onClose() {
+		window.clearTimeout(this.zoomDebounceTimer);
+	}
 }
 
 export default class SupernotePlugin extends Plugin {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { installAtPolyfill } from './polyfills';
-import { App, Modal, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView } from 'obsidian';
+import { App, Modal, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, loadPdfJs } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS } from './settings';
 import { SupernoteX, fetchMirrorFrame } from 'supernote-typescript';
 import { encode } from 'image-js';
@@ -34,6 +34,35 @@ function dataUrlToBuffer(dataUrl: string): ArrayBuffer {
         bytes[i] = binaryString.charCodeAt(i);
     }
     return bytes.buffer;
+}
+
+// Assembles a searchable PDF (page image plus an invisible OCR text layer) from
+// already-rendered page images. Shared by the vault "Attach as PDF" export and the
+// in-memory pdf.js preview in SupernoteView, so both stay byte-for-byte consistent.
+function buildNotePdf(sn: SupernoteX, images: string[], settings: SupernotePluginSettings): jsPDF {
+    const pdf = new jsPDF({
+        orientation: 'portrait',
+        unit: 'px',
+        format: [sn.pageWidth, sn.pageHeight]
+    });
+
+    for (let i = 0; i < images.length; i++) {
+        if (i > 0) {
+            pdf.addPage();
+        }
+
+        if (sn.pages[i].text !== undefined && sn.pages[i].text.length > 0) {
+            pdf.setFontSize(100);
+            pdf.setTextColor(0, 0, 0, 0); // Transparent text
+            pdf.text(processSupernoteText(sn.pages[i].text, settings), 20, 20, { maxWidth: sn.pageWidth });
+            pdf.setTextColor(0, 0, 0, 1);
+        }
+
+        // Add image first
+        pdf.addImage(images[i], 'PNG', 0, 0, sn.pageWidth, sn.pageHeight);
+    }
+
+    return pdf;
 }
 
 /**
@@ -213,13 +242,6 @@ class VaultWriter {
 		const note = await this.app.vault.readBinary(file);
 		const sn = new SupernoteX(new Uint8Array(note));
 
-		// Create PDF document
-		const pdf = new jsPDF({
-			orientation: 'portrait',
-			unit: 'px',
-			format: [sn.pageWidth, sn.pageHeight] // A4 size in pixels
-		});
-
 		// Convert note pages to images
 		const converter = new ImageConverter();
 		let images: string[] = [];
@@ -229,22 +251,7 @@ class VaultWriter {
 			converter.terminate();
 		}
 
-		// Add each page to PDF
-		for (let i = 0; i < images.length; i++) {
-			if (i > 0) {
-				pdf.addPage();
-			}
-
-			if (sn.pages[i].text !== undefined && sn.pages[i].text.length > 0) {
-				pdf.setFontSize(100);
-				pdf.setTextColor(0, 0, 0, 0); // Transparent text
-				pdf.text(processSupernoteText(sn.pages[i].text, this.settings), 20, 20, { maxWidth: sn.pageWidth });
-				pdf.setTextColor(0, 0, 0, 1);
-			}
-
-			// Add image first
-			pdf.addImage(images[i], 'PNG', 0, 0, sn.pageWidth, sn.pageHeight);
-		}
+		const pdf = buildNotePdf(sn, images, this.settings);
 
 		// Generate filename and save
 		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}.pdf`);
@@ -291,6 +298,14 @@ export class SupernoteView extends FileView {
 			// Clean up the worker when done
 			converter.terminate();
 		}
+
+		// Build the same searchable PDF as "Attach as PDF" and hand it straight to
+		// pdf.js as an in-memory ArrayBuffer — Obsidian's own PDF viewer is internal
+		// and file-backed, but `loadPdfJs()` exposes the underlying pdfjsLib it uses,
+		// so pages can be rendered here without ever writing a file to the vault.
+		const pdf = buildNotePdf(sn, images, this.settings);
+		const pdfjsLib = await loadPdfJs();
+		const pdfDoc = await pdfjsLib.getDocument({ data: pdf.output('arraybuffer') }).promise;
 
 		if (this.settings.showExportButtons) {
 			const exportNoteBtn = container.createEl("p").createEl("button", {
@@ -367,14 +382,25 @@ export class SupernoteView extends FileView {
 				}
 			}
 
-			// Show the img of the page
-			const imgElement = pageContainer.createEl("img");
-			imgElement.src = imageDataUrl;
+			// Render the page through pdf.js against the in-memory PDF built above,
+			// instead of dropping in the raw page image.
+			const pdfPage = await pdfDoc.getPage(i + 1);
+			const unscaledViewport = pdfPage.getViewport({ scale: 1 });
+			const scale = this.settings.noteImageMaxDim / Math.max(unscaledViewport.width, unscaledViewport.height);
+			const viewport = pdfPage.getViewport({ scale });
+
+			const canvas = pageContainer.createEl("canvas");
+			canvas.width = viewport.width;
+			canvas.height = viewport.height;
 			if (this.settings.invertColorsWhenDark) {
-				imgElement.addClass("supernote-invert-dark");
+				canvas.addClass("supernote-invert-dark");
 			}
-			imgElement.setAttr('style', 'max-height: ' + this.settings.noteImageMaxDim + 'px;')
-			imgElement.draggable = true;
+			canvas.setAttr('style', 'max-height: ' + this.settings.noteImageMaxDim + 'px; max-width: 100%;')
+
+			const canvasContext = canvas.getContext("2d");
+			if (canvasContext) {
+				await pdfPage.render({ canvasContext, viewport }).promise;
+			}
 
 			// Create a button to save image to vault
 			if (this.settings.showExportButtons) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -695,6 +695,17 @@ export class SupernoteView extends FileView {
 		this.thumbSidebarEl?.toggle(this.thumbnailsVisible);
 		this.thumbToggleBtn?.toggleClass('is-active', this.thumbnailsVisible);
 		if (this.thumbnailsVisible) this.updateThumbSidebarOffset();
+
+		// Showing/hiding the sidebar changes how much horizontal room pagesEl
+		// actually has, but that's an internal flex redistribution within
+		// contentEl, not a change to contentEl's own box — the ResizeObserver
+		// driving auto-refit on window/pane resize never fires for it. Without
+		// this, a page already fit to the full width just sits there too wide
+		// once the sidebar eats into that space, spilling into horizontal
+		// scroll instead of shrinking to match.
+		if (this.fitWidthEnabled) {
+			this.applyFitWidth();
+		}
 	}
 
 	// The thumbnail sidebar is sticky below the header, not at top:0 like the

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { installAtPolyfill } from './polyfills';
-import { App, Modal, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, loadPdfJs, Scope, SearchComponent } from 'obsidian';
+import { App, Modal, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, loadPdfJs, Scope, SearchComponent, setIcon } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS } from './settings';
 import { SupernoteX, fetchMirrorFrame } from 'supernote-typescript';
 import { encode } from 'image-js';
@@ -656,7 +656,8 @@ export class SupernoteView extends FileView {
 
 		if (pageCount > 1) {
 			const thumbGroup = toolbar.createEl('div', { cls: 'supernote-toolbar-group' });
-			this.thumbToggleBtn = thumbGroup.createEl('button', { text: 'Thumbnails', cls: 'clickable-icon', attr: { 'aria-label': 'Toggle page thumbnails' } });
+			this.thumbToggleBtn = thumbGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Toggle page thumbnails' } });
+			setIcon(this.thumbToggleBtn, 'layout-list');
 			this.thumbToggleBtn.addEventListener('click', () => this.toggleThumbnails());
 		}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,9 @@
 import { installAtPolyfill } from './polyfills';
 import { App, Modal, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, loadPdfJs, Scope, SearchComponent, setIcon } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS } from './settings';
-import { SupernoteX, fetchMirrorFrame } from 'supernote-typescript';
+import { SupernoteX, fetchMirrorFrame, toPdf } from 'supernote-typescript';
 import { encode } from 'image-js';
 import { DownloadListModal, UploadListModal } from './FileListModal';
-import { jsPDF } from 'jspdf';
 import { SupernoteWorkerMessage, SupernoteWorkerResponse } from './myworker.worker';
 import Worker from 'myworker.worker';
 import { replaceTextWithCustomDictionary } from './customDictionary';
@@ -36,105 +35,12 @@ function dataUrlToBuffer(dataUrl: string): ArrayBuffer {
     return bytes.buffer;
 }
 
-// Assembles a searchable PDF (page image plus an invisible OCR text layer) from
-// already-rendered page images. Shared by the vault "Attach as PDF" export and the
-// in-memory pdf.js preview in SupernoteView, so both stay byte-for-byte consistent.
-type NotePage = SupernoteX['pages'][number];
-
-// supernote-typescript's recognitionElements carry a per-word bounding box
-// (page.recognitionElements[].words[].['bounding-box']), but those units are
-// noticeably smaller than page pixels — word heights come out ~8-20 units
-// regardless of whether the note's native page is 1404x1872 or 1920x2560 px,
-// which only makes sense if recognition runs against a downscaled canvas.
-// This constant is an approximation, not a documented Supernote constant:
-// fitting it against supernote-typescript's own test fixtures (checked out
-// as a submodule here), scale 13.5 puts recognized-word extents at ~93-96%
-// of tests/input/rtr.note's page dimensions with no words landing outside
-// the page — the closest fit found among a few fixtures tried. If the note
-// view's "Text" mode shows words drifting away from the handwriting they
-// came from, tune this first.
-const RECOGNITION_BOX_SCALE = 13.5;
-
-// Matches supernote-typescript's own _extractText/_extractParagraphs decode
-// step (src/parsing.ts) for recognized labels.
-function decodeRecognizedLabel(label: string): string {
-    return decodeURIComponent(escape(label));
-}
-
-// Draws each recognized word as invisible text positioned directly over the
-// handwriting it was recognized from, instead of one flowed block — this is
-// what lets a PDF viewer (or this plugin's own find-in-note) land on the
-// right word in the right place rather than just confirming the word exists
-// somewhere on the page.
-function drawPositionedRecognizedText(pdf: jsPDF, page: NotePage): boolean {
-    const elements = page.recognitionElements ?? [];
-    let drewAny = false;
-
-    pdf.setTextColor(0, 0, 0, 0); // Transparent text
-
-    for (const element of elements) {
-        if (element.type !== 'Text') continue;
-
-        for (const word of element.words ?? []) {
-            const box = word['bounding-box'];
-            const label = word.label?.trim();
-            if (!box || !label) continue;
-
-            const x = box.x * RECOGNITION_BOX_SCALE;
-            const y = box.y * RECOGNITION_BOX_SCALE;
-            const width = box.width * RECOGNITION_BOX_SCALE;
-            const height = box.height * RECOGNITION_BOX_SCALE;
-            // No page-bounds cutoff here: with an approximate scale factor,
-            // legitimate words (especially on the last couple of lines,
-            // where y is largest) can land right at or just past the
-            // computed page edge. Drawing invisible text slightly outside
-            // the page is harmless — PDF viewers simply don't render past
-            // the MediaBox — but dropping the word entirely was silently
-            // losing whole bottom lines.
-            if (width <= 0 || height <= 0) continue;
-
-            // jsPDF's unit:'px' only applies to coordinates; setFontSize is
-            // always in points (72/in vs. px's 96/in), hence the 0.75 factor.
-            pdf.setFontSize(height * 0.75);
-            // y is the text baseline in jsPDF, not the box's top.
-            pdf.text(decodeRecognizedLabel(label), x, y + height, { maxWidth: Math.max(width, 1) });
-            drewAny = true;
-        }
-    }
-
-    pdf.setTextColor(0, 0, 0, 1);
-    return drewAny;
-}
-
-function buildNotePdf(sn: SupernoteX, images: string[], settings: SupernotePluginSettings): jsPDF {
-    const pdf = new jsPDF({
-        orientation: 'portrait',
-        unit: 'px',
-        format: [sn.pageWidth, sn.pageHeight]
-    });
-
-    for (let i = 0; i < images.length; i++) {
-        if (i > 0) {
-            pdf.addPage();
-        }
-
-        const page = sn.pages[i];
-        const positioned = drawPositionedRecognizedText(pdf, page);
-
-        // Fall back to one flowed invisible block when there's no per-word
-        // position data, so text still exists somewhere for search/copy.
-        if (!positioned && page.text !== undefined && page.text.length > 0) {
-            pdf.setFontSize(100);
-            pdf.setTextColor(0, 0, 0, 0); // Transparent text
-            pdf.text(processSupernoteText(page.text, settings), 20, 20, { maxWidth: sn.pageWidth });
-            pdf.setTextColor(0, 0, 0, 1);
-        }
-
-        // Add image first
-        pdf.addImage(images[i], 'PNG', 0, 0, sn.pageWidth, sn.pageHeight);
-    }
-
-    return pdf;
+// Uint8Array.buffer isn't safe to hand to APIs wanting a plain ArrayBuffer
+// when the array is a view over a larger/offset buffer (not guaranteed for
+// pdf-lib's PDFDocument.save() output, so don't assume it). This always
+// returns a buffer sized to exactly this array's bytes.
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
 }
 
 /**
@@ -314,21 +220,14 @@ class VaultWriter {
 		const note = await this.app.vault.readBinary(file);
 		const sn = new SupernoteX(new Uint8Array(note));
 
-		// Convert note pages to images
-		const converter = new ImageConverter();
-		let images: string[] = [];
-		try {
-			images = await converter.convertToImages(sn);
-		} finally {
-			converter.terminate();
-		}
-
-		const pdf = buildNotePdf(sn, images, this.settings);
+		// toPdf() rasterizes internally (via the library's own toImage), so no
+		// separate ImageConverter pass is needed here like the other export
+		// paths — this is the only consumer of the PDF bytes.
+		const pdfBytes = await toPdf(sn);
 
 		// Generate filename and save
 		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}.pdf`);
-		const pdfOutput = pdf.output('arraybuffer');
-		await this.app.vault.createBinary(filename, pdfOutput);
+		await this.app.vault.createBinary(filename, toArrayBuffer(pdfBytes));
 	}
 }
 
@@ -517,12 +416,16 @@ export class SupernoteView extends FileView {
 		}
 
 		// Build the same searchable PDF as "Attach as PDF" and hand it straight to
-		// pdf.js as an in-memory ArrayBuffer — Obsidian's own PDF viewer is internal
+		// pdf.js as an in-memory byte array — Obsidian's own PDF viewer is internal
 		// and file-backed, but `loadPdfJs()` exposes the underlying pdfjsLib it uses,
 		// so pages can be rendered here without ever writing a file to the vault.
-		const pdf = buildNotePdf(sn, images, this.settings);
+		// toPdf() rasterizes internally, separately from the `images` above (which
+		// exist for the thumbnail sidebar, save-to-vault, and drag-out) — a small
+		// duplicated render pass, traded for not having to thread pre-rendered
+		// images through the library's PDF builder.
+		const pdfBytes = await toPdf(sn);
 		this.pdfjsLib = await loadPdfJs();
-		const pdfDoc = await this.pdfjsLib.getDocument({ data: pdf.output('arraybuffer') }).promise;
+		const pdfDoc = await this.pdfjsLib.getDocument({ data: pdfBytes }).promise;
 
 		if (this.settings.showExportButtons) {
 			const exportNoteBtn = container.createEl("p").createEl("button", {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { installAtPolyfill } from './polyfills';
 import { App, Modal, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, loadPdfJs, Scope, SearchComponent, setIcon } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS } from './settings';
-import { SupernoteX, fetchMirrorFrame, toPdf } from 'supernote-typescript';
+import { SupernoteX, fetchMirrorFrame, extractPageRenderData, createPdfContext, addPdfPage } from 'supernote-typescript';
 import { encode } from 'image-js';
 import { DownloadListModal, UploadListModal } from './FileListModal';
 import { SupernoteWorkerMessage, SupernoteWorkerResponse } from './myworker.worker';
@@ -43,6 +43,31 @@ function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
     return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
 }
 
+// Reimplements supernote-typescript's toPdf() convenience wrapper, but
+// rendering pages across this plugin's existing Web Worker pool instead of
+// one at a time on the main thread — using the library's worker-parallel
+// split (createPdfContext/addPdfPage/extractPageRenderData) added for
+// exactly this purpose. Assembly (createPdfContext/addPdfPage/pdfDoc.save())
+// still runs on the main thread regardless, since pdf-lib's objects aren't
+// structured-clone-safe.
+async function toPdfParallel(sn: SupernoteX): Promise<Uint8Array> {
+    const pageNumbers = Array.from({ length: sn.pages.length }, (_, i) => i + 1);
+
+    const pool = new WorkerPool();
+    let pngBuffers: Uint8Array[];
+    try {
+        pngBuffers = await pool.renderPdfPages(sn, pageNumbers);
+    } finally {
+        pool.terminate();
+    }
+
+    const ctx = await createPdfContext();
+    for (let i = 0; i < sn.pages.length; i++) {
+        await addPdfPage(ctx, sn.pages[i], pngBuffers[i]);
+    }
+    return ctx.pdfDoc.save();
+}
+
 /**
  * Processes the Supernote text based on the provided settings.
  * 
@@ -58,6 +83,20 @@ function processSupernoteText(text: string, settings: SupernotePluginSettings): 
 	return processedText;
 }
 
+// Splits pageNumbers into at most `workerCount` chunks. Callers that then map
+// chunks[i] -> workers[i % workers.length] are guaranteed each worker gets at
+// most one chunk (chunks.length <= workers.length), so processing chunks
+// concurrently via Promise.all never has two in-flight calls fighting over
+// the same worker's onmessage handler.
+function chunkPageNumbers(pageNumbers: number[], workerCount: number): number[][] {
+    const chunkSize = Math.ceil(pageNumbers.length / workerCount);
+    const chunks: number[][] = [];
+    for (let i = 0; i < pageNumbers.length; i += chunkSize) {
+        chunks.push(pageNumbers.slice(i, i + chunkSize));
+    }
+    return chunks;
+}
+
 export class WorkerPool {
     private workers: Worker[];
 
@@ -70,9 +109,9 @@ export class WorkerPool {
     private processChunk(worker: Worker, note: SupernoteX, pageNumbers: number[]): Promise<any[]> {
         return new Promise((resolve, reject) => {
             worker.onmessage = (e: MessageEvent<SupernoteWorkerResponse>) => {
-                if (e.data.error) {
+                if (e.data.type === 'error') {
                     reject(new Error(e.data.error));
-                } else {
+                } else if (e.data.type === 'result') {
                     resolve(e.data.images);
                 }
             };
@@ -95,13 +134,7 @@ export class WorkerPool {
     async processPages(note: SupernoteX, allPageNumbers: number[]): Promise<any[]> {
         //console.time('Total processing time');
 
-        // Split pages into chunks based on number of workers
-        const chunkSize = Math.ceil(allPageNumbers.length / this.workers.length);
-        const chunks: number[][] = [];
-
-        for (let i = 0; i < allPageNumbers.length; i += chunkSize) {
-            chunks.push(allPageNumbers.slice(i, i + chunkSize));
-        }
+        const chunks = chunkPageNumbers(allPageNumbers, this.workers.length);
 
         //console.log(`Processing ${allPageNumbers.length} pages in ${chunks.length} chunks`);
 
@@ -114,6 +147,48 @@ export class WorkerPool {
 
         //console.timeEnd('Total processing time');
         return results.flat();
+    }
+
+    private renderPdfPage(worker: Worker, pageRenderData: ReturnType<typeof extractPageRenderData>): Promise<Uint8Array> {
+        return new Promise((resolve, reject) => {
+            worker.onmessage = (e: MessageEvent<SupernoteWorkerResponse>) => {
+                if (e.data.type === 'error') {
+                    reject(new Error(e.data.error));
+                } else if (e.data.type === 'pdfPageResult') {
+                    resolve(e.data.pngBytes);
+                }
+            };
+
+            worker.onerror = (error) => {
+                console.error('Worker error:', error);
+                reject(error);
+            };
+
+            const message: SupernoteWorkerMessage = { type: 'renderPdfPage', pageRenderData };
+            worker.postMessage(message);
+        });
+    }
+
+    // Renders each page number to PNG bytes (via extractPageRenderData +
+    // toImage + encodePng, all off-main-thread) in parallel across the pool.
+    // Pages assigned to the same worker render sequentially (one postMessage
+    // round trip at a time), same safety reasoning as chunkPageNumbers above
+    // — only different *workers* run concurrently with each other.
+    async renderPdfPages(note: SupernoteX, allPageNumbers: number[]): Promise<Uint8Array[]> {
+        const chunks = chunkPageNumbers(allPageNumbers, this.workers.length);
+
+        const chunkResults = await Promise.all(
+            chunks.map(async (chunk, index) => {
+                const worker = this.workers[index % this.workers.length];
+                const pages: Uint8Array[] = [];
+                for (const pageNumber of chunk) {
+                    pages.push(await this.renderPdfPage(worker, extractPageRenderData(note, pageNumber)));
+                }
+                return pages;
+            })
+        );
+
+        return chunkResults.flat();
     }
 
     terminate() {
@@ -220,10 +295,8 @@ class VaultWriter {
 		const note = await this.app.vault.readBinary(file);
 		const sn = new SupernoteX(new Uint8Array(note));
 
-		// toPdf() rasterizes internally (via the library's own toImage), so no
-		// separate ImageConverter pass is needed here like the other export
-		// paths — this is the only consumer of the PDF bytes.
-		const pdfBytes = await toPdf(sn);
+		// Renders pages across the Worker pool in parallel; see toPdfParallel().
+		const pdfBytes = await toPdfParallel(sn);
 
 		// Generate filename and save
 		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}.pdf`);
@@ -428,11 +501,11 @@ export class SupernoteView extends FileView {
 		// pdf.js as an in-memory byte array — Obsidian's own PDF viewer is internal
 		// and file-backed, but `loadPdfJs()` exposes the underlying pdfjsLib it uses,
 		// so pages can be rendered here without ever writing a file to the vault.
-		// toPdf() rasterizes internally, separately from the `images` above (which
-		// exist for the thumbnail sidebar, save-to-vault, and drag-out) — a small
-		// duplicated render pass, traded for not having to thread pre-rendered
-		// images through the library's PDF builder.
-		const pdfBytes = await toPdf(sn);
+		// toPdfParallel() rasterizes on its own Worker pool, separately from the
+		// `images` above (which exist for the thumbnail sidebar, save-to-vault,
+		// and drag-out) — a small duplicated render pass, traded for not having
+		// to thread pre-rendered images through the library's PDF builder.
+		const pdfBytes = await toPdfParallel(sn);
 		this.pdfjsLib = await loadPdfJs();
 		const pdfDoc = await this.pdfjsLib.getDocument({ data: pdfBytes }).promise;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { installAtPolyfill } from './polyfills';
 import { App, Modal, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, loadPdfJs, Scope, SearchComponent, setIcon } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS } from './settings';
-import { SupernoteX, fetchMirrorFrame, extractPageRenderData, createPdfContext, addPdfPage } from 'supernote-typescript';
+import { SupernoteX, fetchMirrorFrame, createPdfContext, addPdfPage } from 'supernote-typescript';
 import { encode } from 'image-js';
 import { DownloadListModal, UploadListModal } from './FileListModal';
 import { SupernoteWorkerMessage, SupernoteWorkerResponse } from './myworker.worker';
@@ -43,27 +43,17 @@ function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
     return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
 }
 
-// Reimplements supernote-typescript's toPdf() convenience wrapper, but
-// rendering pages across this plugin's existing Web Worker pool instead of
-// one at a time on the main thread — using the library's worker-parallel
-// split (createPdfContext/addPdfPage/extractPageRenderData) added for
-// exactly this purpose. Assembly (createPdfContext/addPdfPage/pdfDoc.save())
-// still runs on the main thread regardless, since pdf-lib's objects aren't
-// structured-clone-safe.
-async function toPdfParallel(sn: SupernoteX): Promise<Uint8Array> {
-    const pageNumbers = Array.from({ length: sn.pages.length }, (_, i) => i + 1);
-
-    const pool = new WorkerPool();
-    let pngBuffers: Uint8Array[];
-    try {
-        pngBuffers = await pool.renderPdfPages(sn, pageNumbers);
-    } finally {
-        pool.terminate();
-    }
-
+// Assembles a PDF from pages already rasterized elsewhere (the `images`
+// array from ImageConverter, used for thumbnails/save-to-vault/drag-out),
+// instead of rasterizing a second time. addPdfPage() accepts pre-encoded PNG
+// bytes directly, so this just needs to decode the data URLs already sitting
+// in memory back to bytes (a cheap base64 decode, not a re-render) and hand
+// them to the library's own createPdfContext/addPdfPage assembly.
+async function assemblePdfFromImages(sn: SupernoteX, images: string[]): Promise<Uint8Array> {
     const ctx = await createPdfContext();
     for (let i = 0; i < sn.pages.length; i++) {
-        await addPdfPage(ctx, sn.pages[i], pngBuffers[i]);
+        const pngBytes = new Uint8Array(dataUrlToBuffer(images[i]));
+        await addPdfPage(ctx, sn.pages[i], pngBytes);
     }
     return ctx.pdfDoc.save();
 }
@@ -147,48 +137,6 @@ export class WorkerPool {
 
         //console.timeEnd('Total processing time');
         return results.flat();
-    }
-
-    private renderPdfPage(worker: Worker, pageRenderData: ReturnType<typeof extractPageRenderData>): Promise<Uint8Array> {
-        return new Promise((resolve, reject) => {
-            worker.onmessage = (e: MessageEvent<SupernoteWorkerResponse>) => {
-                if (e.data.type === 'error') {
-                    reject(new Error(e.data.error));
-                } else if (e.data.type === 'pdfPageResult') {
-                    resolve(e.data.pngBytes);
-                }
-            };
-
-            worker.onerror = (error) => {
-                console.error('Worker error:', error);
-                reject(error);
-            };
-
-            const message: SupernoteWorkerMessage = { type: 'renderPdfPage', pageRenderData };
-            worker.postMessage(message);
-        });
-    }
-
-    // Renders each page number to PNG bytes (via extractPageRenderData +
-    // toImage + encodePng, all off-main-thread) in parallel across the pool.
-    // Pages assigned to the same worker render sequentially (one postMessage
-    // round trip at a time), same safety reasoning as chunkPageNumbers above
-    // — only different *workers* run concurrently with each other.
-    async renderPdfPages(note: SupernoteX, allPageNumbers: number[]): Promise<Uint8Array[]> {
-        const chunks = chunkPageNumbers(allPageNumbers, this.workers.length);
-
-        const chunkResults = await Promise.all(
-            chunks.map(async (chunk, index) => {
-                const worker = this.workers[index % this.workers.length];
-                const pages: Uint8Array[] = [];
-                for (const pageNumber of chunk) {
-                    pages.push(await this.renderPdfPage(worker, extractPageRenderData(note, pageNumber)));
-                }
-                return pages;
-            })
-        );
-
-        return chunkResults.flat();
     }
 
     terminate() {
@@ -295,8 +243,18 @@ class VaultWriter {
 		const note = await this.app.vault.readBinary(file);
 		const sn = new SupernoteX(new Uint8Array(note));
 
-		// Renders pages across the Worker pool in parallel; see toPdfParallel().
-		const pdfBytes = await toPdfParallel(sn);
+		// Rasterizes across the Worker pool in parallel (same pass the other
+		// export paths use), then assembles the PDF from those images rather
+		// than rendering a second time.
+		const converter = new ImageConverter();
+		let images: string[] = [];
+		try {
+			images = await converter.convertToImages(sn);
+		} finally {
+			converter.terminate();
+		}
+
+		const pdfBytes = await assemblePdfFromImages(sn, images);
 
 		// Generate filename and save
 		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}.pdf`);
@@ -329,6 +287,8 @@ async function renderTextLayer(pdfjsLib: any, textContent: any, container: HTMLE
 }
 
 type PageRenderState = {
+	pageNumber: number;
+	// Fetched lazily — see SupernoteView.ensureTextLayer(). null until then.
 	pdfPage: any;
 	baseScale: number;
 	nativeWidth: number;
@@ -337,6 +297,12 @@ type PageRenderState = {
 	canvasWrap: HTMLElement;
 	canvas: HTMLCanvasElement;
 	textLayerDiv: HTMLElement;
+	// Decoded once from the already-rasterized page image and reused for
+	// every zoom redraw (see drawPageImage()) — no pdf.js/decode work on the
+	// zoom-critical path.
+	imageBitmap: ImageBitmap | null;
+	// Guards ensureTextLayer()'s one-time (per page) work.
+	textLayerLoaded: boolean;
 	text: string;
 	spans: HTMLSpanElement[];
 };
@@ -367,6 +333,15 @@ export class SupernoteView extends FileView {
 	private fitWidthDebounceTimer: number | undefined;
 	private resizeObserver: ResizeObserver | null = null;
 
+	// The combined PDF (image + invisible RTR text per page) is assembled
+	// and loaded into pdf.js in the background, not awaited before the first
+	// paint — pages are visible immediately from their own rasterized image
+	// (see drawPageImage()), which doesn't depend on this at all. Only the
+	// text layer (selection/search) needs it, and only when a given page is
+	// actually loaded — see ensureTextLayer()/pageObserver.
+	private pdfDocPromise: Promise<any> | null = null;
+	private pageObserver: IntersectionObserver | null = null;
+
 	private layerMode: 'image' | 'text' = 'image';
 	private imageModeBtn: HTMLElement | null = null;
 	private textModeBtn: HTMLElement | null = null;
@@ -385,6 +360,7 @@ export class SupernoteView extends FileView {
 	private findMatchCountEl: HTMLElement | null = null;
 	private findMatches: FindMatch[] = [];
 	private findMatchCursor = -1;
+	private findRequestId = 0;
 
 	constructor(leaf: WorkspaceLeaf, settings: SupernotePluginSettings) {
 		super(leaf);
@@ -472,6 +448,20 @@ export class SupernoteView extends FileView {
 			this.fitWidthDebounceTimer = window.setTimeout(() => this.applyFitWidth(), 150);
 		});
 		this.resizeObserver.observe(this.contentEl);
+
+		// Loads each page's selectable text lazily, only once it's about to
+		// scroll into view (rootMargin prefetches a screen ahead/behind so it
+		// feels instant by the time you actually get there) — for a long note,
+		// building N pages' worth of text-layer DOM upfront is real, mostly
+		// wasted work if you only ever look at the first few. Re-observes
+		// fresh page containers each file load; see onLoadFile().
+		this.pageObserver = new IntersectionObserver((entries) => {
+			for (const entry of entries) {
+				if (!entry.isIntersecting) continue;
+				const state = this.pageStates.find((s) => s.pageContainer === entry.target);
+				if (state) void this.ensureTextLayer(state);
+			}
+		}, { root: this.contentEl, rootMargin: '100% 0px' });
 	}
 
 	async onLoadFile(file: TFile): Promise<void> {
@@ -479,11 +469,16 @@ export class SupernoteView extends FileView {
 		container.empty();
 
 		window.clearTimeout(this.zoomDebounceTimer);
+		this.pageObserver?.disconnect();
 		this.pageStates = [];
 		this.zoomScale = 1;
 		this.renderedZoomScale = 1;
 		this.findMatches = [];
 		this.findMatchCursor = -1;
+		// Invalidates any in-flight runFind() from a file the user just
+		// navigated away from, so it can't resolve later and touch this one's
+		// (unrelated) pageStates.
+		this.findRequestId++;
 
 		const note = await this.app.vault.readBinary(file);
 		const sn = new SupernoteX(new Uint8Array(note));
@@ -497,17 +492,16 @@ export class SupernoteView extends FileView {
 			converter.terminate();
 		}
 
-		// Build the same searchable PDF as "Attach as PDF" and hand it straight to
-		// pdf.js as an in-memory byte array — Obsidian's own PDF viewer is internal
-		// and file-backed, but `loadPdfJs()` exposes the underlying pdfjsLib it uses,
-		// so pages can be rendered here without ever writing a file to the vault.
-		// toPdfParallel() rasterizes on its own Worker pool, separately from the
-		// `images` above (which exist for the thumbnail sidebar, save-to-vault,
-		// and drag-out) — a small duplicated render pass, traded for not having
-		// to thread pre-rendered images through the library's PDF builder.
-		const pdfBytes = await toPdfParallel(sn);
-		this.pdfjsLib = await loadPdfJs();
-		const pdfDoc = await this.pdfjsLib.getDocument({ data: pdfBytes }).promise;
+		// Kicked off now but not awaited: pages are visible immediately from
+		// their own rasterized image (drawPageImage(), no pdf.js involved at
+		// all), so there's no reason to block the first paint on assembling a
+		// PDF and loading it into pdf.js. Only the text layer (selection/
+		// search) needs this, lazily, per page — see ensureTextLayer().
+		this.pdfDocPromise = (async () => {
+			const pdfBytes = await assemblePdfFromImages(sn, images);
+			this.pdfjsLib = await loadPdfJs();
+			return this.pdfjsLib.getDocument({ data: pdfBytes }).promise;
+		})();
 
 		if (this.settings.showExportButtons) {
 			const exportNoteBtn = container.createEl("p").createEl("button", {
@@ -551,18 +545,17 @@ export class SupernoteView extends FileView {
 		this.pagesEl = body.createEl("div", { cls: 'supernote-pages' });
 		this.pagesEl.toggleClass('supernote-mode-text', this.layerMode === 'text');
 
+		// Same for every page in a note (sn.pageWidth/pageHeight are note-level,
+		// not per-page) — computed once from data already in memory, no pdf.js
+		// or rasterization needed just to know how big to lay pages out.
+		const baseScale = this.settings.noteImageMaxDim / Math.max(sn.pageWidth, sn.pageHeight);
+
 		for (let i = 0; i < images.length; i++) {
 			const imageDataUrl = images[i];
 
 			const pageContainer = this.pagesEl.createEl("div", {
 				cls: 'page-container',
 			})
-
-			// Render the page through pdf.js against the in-memory PDF built above,
-			// instead of dropping in the raw page image.
-			const pdfPage = await pdfDoc.getPage(i + 1);
-			const unscaledViewport = pdfPage.getViewport({ scale: 1 });
-			const baseScale = this.settings.noteImageMaxDim / Math.max(unscaledViewport.width, unscaledViewport.height);
 
 			const canvasWrap = pageContainer.createEl("div", { cls: 'supernote-canvas-wrap' });
 			const canvas = canvasWrap.createEl("canvas");
@@ -586,20 +579,30 @@ export class SupernoteView extends FileView {
 			const textLayerDiv = canvasWrap.createEl("div", { cls: 'textLayer' });
 
 			const state: PageRenderState = {
-				pdfPage,
+				pageNumber: i + 1,
+				pdfPage: null,
 				baseScale,
-				nativeWidth: unscaledViewport.width,
-				nativeHeight: unscaledViewport.height,
+				nativeWidth: sn.pageWidth,
+				nativeHeight: sn.pageHeight,
 				pageContainer,
 				canvasWrap,
 				canvas,
 				textLayerDiv,
+				imageBitmap: null,
+				textLayerLoaded: false,
 				text: '',
 				spans: [],
 			};
 			this.pageStates.push(state);
 
-			await this.renderPage(state, baseScale * this.zoomScale);
+			// Decodes the same PNG already sitting in `images[i]` — no pdf.js,
+			// no re-rasterization. Cached on the state and reused for every
+			// zoom redraw (drawPageImage()).
+			const blob = new Blob([dataUrlToBuffer(imageDataUrl)], { type: 'image/png' });
+			state.imageBitmap = await createImageBitmap(blob);
+			this.drawPageImage(state, baseScale * this.zoomScale);
+
+			this.pageObserver?.observe(pageContainer);
 
 			// Create a button to save image to vault
 			if (this.settings.showExportButtons) {
@@ -622,23 +625,56 @@ export class SupernoteView extends FileView {
 		this.updateCurrentPageIndicator();
 	}
 
-	private async renderPage(state: PageRenderState, scale: number): Promise<void> {
-		const viewport = state.pdfPage.getViewport({ scale });
+	// Draws the page's own already-decoded bitmap at the given scale — no
+	// pdf.js involved. Synchronous (drawImage from an ImageBitmap doesn't
+	// need awaiting), so redrawing on every zoom tick is cheap; pdf.js's own
+	// pdfPage.render() had to redecode the embedded PDF image every time.
+	private drawPageImage(state: PageRenderState, scale: number) {
+		const width = Math.max(1, Math.round(state.nativeWidth * scale));
+		const height = Math.max(1, Math.round(state.nativeHeight * scale));
 
-		state.canvas.width = viewport.width;
-		state.canvas.height = viewport.height;
-		state.canvasWrap.setCssStyles({ width: `${viewport.width}px`, height: `${viewport.height}px` });
+		state.canvas.width = width;
+		state.canvas.height = height;
+		state.canvasWrap.setCssStyles({ width: `${width}px`, height: `${height}px` });
+		state.textLayerDiv.setCssStyles({ width: `${width}px`, height: `${height}px` });
 
-		const canvasContext = state.canvas.getContext("2d");
-		if (canvasContext) {
-			await state.pdfPage.render({ canvasContext, viewport }).promise;
+		if (state.imageBitmap) {
+			state.canvas.getContext("2d")?.drawImage(state.imageBitmap, 0, 0, width, height);
 		}
+	}
 
+	// (Re)builds the selectable/searchable text layer at the given viewport.
+	// Shared by ensureTextLayer() (first load) and commitZoom() (rebuild at
+	// the new scale for pages that were already loaded).
+	private async buildTextLayerForState(state: PageRenderState, viewport: any): Promise<void> {
 		const textContent = await state.pdfPage.getTextContent();
 		state.text = textContent.items.map((item: any) => ('str' in item ? item.str : '')).join('');
 
 		const hasTextLayer = await renderTextLayer(this.pdfjsLib, textContent, state.textLayerDiv, viewport);
 		state.spans = hasTextLayer ? Array.from(state.textLayerDiv.querySelectorAll('span')) : [];
+	}
+
+	// Loads this page's text layer if it hasn't been already — triggered by
+	// pageObserver as a page nears the viewport, or forced immediately by
+	// page-jump/thumbnail-click/find-in-note so those don't have to wait on
+	// scroll+observer timing. Idempotent and safe to call speculatively.
+	private async ensureTextLayer(state: PageRenderState): Promise<void> {
+		if (state.textLayerLoaded) return;
+		state.textLayerLoaded = true; // set eagerly: no double-trigger race
+
+		try {
+			const pdfDoc = await this.pdfDocPromise;
+			if (!pdfDoc) return;
+
+			if (!state.pdfPage) {
+				state.pdfPage = await pdfDoc.getPage(state.pageNumber);
+			}
+
+			const viewport = state.pdfPage.getViewport({ scale: state.baseScale * this.zoomScale });
+			await this.buildTextLayerForState(state, viewport);
+		} catch (error) {
+			console.error(`Failed to build text layer for page ${state.pageNumber}:`, error);
+		}
 	}
 
 	private buildToolbar(container: HTMLElement, pageCount: number) {
@@ -693,7 +729,11 @@ export class SupernoteView extends FileView {
 				if (!Number.isFinite(requested)) return;
 				const target = Math.min(pageCount, Math.max(1, Math.round(requested)));
 				pageInput.value = String(target);
-				this.pageStates[target - 1]?.pageContainer.scrollIntoView({ block: 'start', behavior: 'smooth' });
+				const state = this.pageStates[target - 1];
+				state?.pageContainer.scrollIntoView({ block: 'start', behavior: 'smooth' });
+				// Don't wait on scroll+observer timing for a page the user
+				// explicitly asked to jump to.
+				if (state) void this.ensureTextLayer(state);
 			};
 
 			pageInput.addEventListener('keydown', (evt: KeyboardEvent) => {
@@ -733,7 +773,9 @@ export class SupernoteView extends FileView {
 			item.createEl('span', { cls: 'supernote-thumb-label', text: String(i + 1) });
 
 			item.addEventListener('click', () => {
-				this.pageStates[i]?.pageContainer.scrollIntoView({ block: 'start', behavior: 'smooth' });
+				const state = this.pageStates[i];
+				state?.pageContainer.scrollIntoView({ block: 'start', behavior: 'smooth' });
+				if (state) void this.ensureTextLayer(state);
 			});
 
 			this.thumbItems.push(item);
@@ -830,8 +872,16 @@ export class SupernoteView extends FileView {
 	private async commitZoom(): Promise<void> {
 		const targetZoom = this.zoomScale;
 		for (const state of this.pageStates) {
-			await this.renderPage(state, state.baseScale * targetZoom);
+			this.drawPageImage(state, state.baseScale * targetZoom);
 			state.canvasWrap.setCssStyles({ transform: '', transformOrigin: '' });
+
+			// Only rebuild the text layer for pages that already had one —
+			// pages not yet loaded (ensureTextLayer() never ran) will build
+			// theirs at whatever zoom is current when they eventually do.
+			if (state.textLayerLoaded && state.pdfPage) {
+				const viewport = state.pdfPage.getViewport({ scale: state.baseScale * targetZoom });
+				await this.buildTextLayerForState(state, viewport);
+			}
 		}
 		this.renderedZoomScale = targetZoom;
 		this.updateCurrentPageIndicator();
@@ -933,9 +983,21 @@ export class SupernoteView extends FileView {
 		return -1;
 	}
 
-	private runFind(query: string) {
+	private async runFind(query: string) {
+		const requestId = ++this.findRequestId;
+
 		this.clearFindHighlights();
 		if (!query) return;
+
+		// Search needs every page's text, not just whatever's been lazily
+		// loaded so far — force any not-yet-loaded pages to load now rather
+		// than silently missing matches on pages the user hasn't scrolled to.
+		// Already-loaded pages resolve near-instantly, so this only really
+		// costs anything on the first search of a long, mostly-unscrolled note.
+		await Promise.all(this.pageStates.map((state) => this.ensureTextLayer(state)));
+		// A newer search may have started (and even finished) while this one
+		// was waiting on that — don't clobber its results with stale ones.
+		if (requestId !== this.findRequestId) return;
 
 		const lowerQuery = query.toLowerCase();
 		for (let pageIndex = 0; pageIndex < this.pageStates.length; pageIndex++) {
@@ -994,6 +1056,7 @@ export class SupernoteView extends FileView {
 		window.clearTimeout(this.zoomDebounceTimer);
 		window.clearTimeout(this.fitWidthDebounceTimer);
 		this.resizeObserver?.disconnect();
+		this.pageObserver?.disconnect();
 	}
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -309,11 +309,16 @@ export class SupernoteView extends FileView {
 
 	private pdfjsLib: any;
 	private pageStates: PageRenderState[] = [];
+	private pagesEl: HTMLElement | null = null;
 
 	private zoomScale = 1;
 	private renderedZoomScale = 1;
 	private zoomDebounceTimer: number | undefined;
 	private zoomLabelEl: HTMLElement | null = null;
+
+	private layerMode: 'image' | 'text' = 'image';
+	private imageModeBtn: HTMLElement | null = null;
+	private textModeBtn: HTMLElement | null = null;
 
 	private findBarEl: HTMLElement | null = null;
 	private findInput: SearchComponent | null = null;
@@ -419,55 +424,18 @@ export class SupernoteView extends FileView {
 			});
 		}
 
-		this.buildZoomBar(container);
+		this.buildToolbar(container, images.length);
 		this.buildFindBar(container);
 
-		if (images.length > 1 && this.settings.showTOC) {
-			const atoc = container.createEl("a");
-			atoc.id = "toc";
-			atoc.createEl("h2", { text: "Table of contents" });
-			const ul = container.createEl("ul");
-			for (let i = 0; i < images.length; i++) {
-				const a = ul.createEl("li").createEl("a");
-				a.href = `#page${i + 1}`
-				a.text = `Page ${i + 1}`
-			}
-		}
-
-		const pagesEl = container.createEl("div", { cls: 'supernote-pages' });
+		this.pagesEl = container.createEl("div", { cls: 'supernote-pages' });
+		this.pagesEl.toggleClass('supernote-mode-text', this.layerMode === 'text');
 
 		for (let i = 0; i < images.length; i++) {
 			const imageDataUrl = images[i];
 
-			const pageContainer = pagesEl.createEl("div", {
+			const pageContainer = this.pagesEl.createEl("div", {
 				cls: 'page-container',
 			})
-
-			if (images.length > 1 && this.settings.showTOC) {
-				const a = pageContainer.createEl("a");
-				a.id = `page${i + 1}`;
-				a.href = "#toc";
-				a.createEl("h3", { text: `Page ${i + 1}` });
-			}
-
-			// Show the text of the page, if any
-			if (sn.pages[i].text !== undefined && sn.pages[i].text.length > 0) {
-				let text;
-
-				// If Collapse Text setting is enabled, place the text into an HTML `details` element
-				if (this.settings.collapseRecognizedText) {
-					text = pageContainer.createEl('details', {
-						text: '\n' + processSupernoteText(sn.pages[i].text,this.settings),
-						cls: 'page-recognized-text',
-					});
-					text.createEl('summary', { text: `Page ${i + 1} Recognized Text` });
-				} else {
-					text = pageContainer.createEl('div', {
-						text: processSupernoteText(sn.pages[i].text, this.settings),
-						cls: 'page-recognized-text',
-					});
-				}
-			}
 
 			// Render the page through pdf.js against the in-memory PDF built above,
 			// instead of dropping in the raw page image.
@@ -545,16 +513,62 @@ export class SupernoteView extends FileView {
 		state.spans = hasTextLayer ? Array.from(state.textLayerDiv.querySelectorAll('span')) : [];
 	}
 
-	private buildZoomBar(container: HTMLElement) {
-		const zoomBar = container.createEl('div', { cls: 'supernote-zoom-bar' });
-		const zoomOutBtn = zoomBar.createEl('button', { text: '−', cls: 'clickable-icon', attr: { 'aria-label': 'Zoom out' } });
-		this.zoomLabelEl = zoomBar.createEl('span', { cls: 'supernote-zoom-label', text: '100%' });
-		const zoomInBtn = zoomBar.createEl('button', { text: '+', cls: 'clickable-icon', attr: { 'aria-label': 'Zoom in' } });
-		const zoomResetBtn = zoomBar.createEl('button', { text: 'Reset zoom', cls: 'clickable-icon' });
+	private buildToolbar(container: HTMLElement, pageCount: number) {
+		const toolbar = container.createEl('div', { cls: 'supernote-toolbar' });
+
+		const zoomGroup = toolbar.createEl('div', { cls: 'supernote-toolbar-group' });
+		const zoomOutBtn = zoomGroup.createEl('button', { text: '−', cls: 'clickable-icon', attr: { 'aria-label': 'Zoom out' } });
+		this.zoomLabelEl = zoomGroup.createEl('span', { cls: 'supernote-zoom-label', text: '100%' });
+		const zoomInBtn = zoomGroup.createEl('button', { text: '+', cls: 'clickable-icon', attr: { 'aria-label': 'Zoom in' } });
+		const zoomResetBtn = zoomGroup.createEl('button', { text: 'Reset zoom', cls: 'clickable-icon' });
 
 		zoomOutBtn.addEventListener('click', () => this.setZoom(this.zoomScale / 1.25));
 		zoomInBtn.addEventListener('click', () => this.setZoom(this.zoomScale * 1.25));
 		zoomResetBtn.addEventListener('click', () => this.setZoom(1));
+
+		const layerGroup = toolbar.createEl('div', { cls: 'supernote-toolbar-group' });
+		this.imageModeBtn = layerGroup.createEl('button', { text: 'Image', cls: 'clickable-icon', attr: { 'aria-label': 'Show page image' } });
+		this.textModeBtn = layerGroup.createEl('button', { text: 'Text', cls: 'clickable-icon', attr: { 'aria-label': 'Show recognized text' } });
+		this.imageModeBtn.addEventListener('click', () => this.setLayerMode('image'));
+		this.textModeBtn.addEventListener('click', () => this.setLayerMode('text'));
+		this.updateLayerModeButtons();
+
+		if (pageCount > 1) {
+			const jumpGroup = toolbar.createEl('div', { cls: 'supernote-toolbar-group' });
+			jumpGroup.createEl('span', { text: 'Page', cls: 'supernote-page-jump-label' });
+			const pageInput = jumpGroup.createEl('input', {
+				cls: 'supernote-page-jump-input',
+				attr: { type: 'number', min: '1', max: String(pageCount) },
+			});
+			jumpGroup.createEl('span', { text: `/ ${pageCount}`, cls: 'supernote-page-jump-total' });
+
+			const jumpToPage = () => {
+				const requested = Number(pageInput.value);
+				if (!Number.isFinite(requested)) return;
+				const target = Math.min(pageCount, Math.max(1, Math.round(requested)));
+				pageInput.value = String(target);
+				this.pageStates[target - 1]?.pageContainer.scrollIntoView({ block: 'start', behavior: 'smooth' });
+			};
+
+			pageInput.addEventListener('keydown', (evt: KeyboardEvent) => {
+				if (evt.key === 'Enter') {
+					evt.preventDefault();
+					jumpToPage();
+				}
+			});
+			pageInput.addEventListener('blur', jumpToPage);
+		}
+	}
+
+	private setLayerMode(mode: 'image' | 'text') {
+		this.layerMode = mode;
+		this.pagesEl?.toggleClass('supernote-mode-text', mode === 'text');
+		this.updateLayerModeButtons();
+	}
+
+	private updateLayerModeButtons() {
+		this.imageModeBtn?.toggleClass('is-active', this.layerMode === 'image');
+		this.textModeBtn?.toggleClass('is-active', this.layerMode === 'text');
 	}
 
 	private setZoom(newScale: number) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -392,6 +392,11 @@ export class SupernoteView extends FileView {
 	private imageModeBtn: HTMLElement | null = null;
 	private textModeBtn: HTMLElement | null = null;
 
+	private thumbnailsVisible = false;
+	private thumbToggleBtn: HTMLElement | null = null;
+	private thumbSidebarEl: HTMLElement | null = null;
+	private thumbItems: HTMLElement[] = [];
+
 	private headerEl: HTMLElement | null = null;
 	private pageJumpInput: HTMLInputElement | null = null;
 	private scrollUpdateScheduled = false;
@@ -535,8 +540,12 @@ export class SupernoteView extends FileView {
 		this.headerEl = container.createEl("div", { cls: 'supernote-header' });
 		this.buildToolbar(this.headerEl, images.length);
 		this.buildFindBar(this.headerEl);
+		this.updateThumbSidebarOffset();
 
-		this.pagesEl = container.createEl("div", { cls: 'supernote-pages' });
+		const body = container.createEl("div", { cls: 'supernote-body' });
+		this.buildThumbSidebar(body, images);
+
+		this.pagesEl = body.createEl("div", { cls: 'supernote-pages' });
 		this.pagesEl.toggleClass('supernote-mode-text', this.layerMode === 'text');
 
 		for (let i = 0; i < images.length; i++) {
@@ -646,6 +655,12 @@ export class SupernoteView extends FileView {
 		this.updateLayerModeButtons();
 
 		if (pageCount > 1) {
+			const thumbGroup = toolbar.createEl('div', { cls: 'supernote-toolbar-group' });
+			this.thumbToggleBtn = thumbGroup.createEl('button', { text: 'Thumbnails', cls: 'clickable-icon', attr: { 'aria-label': 'Toggle page thumbnails' } });
+			this.thumbToggleBtn.addEventListener('click', () => this.toggleThumbnails());
+		}
+
+		if (pageCount > 1) {
 			const jumpGroup = toolbar.createEl('div', { cls: 'supernote-toolbar-group' });
 			jumpGroup.createEl('span', { text: 'Page', cls: 'supernote-page-jump-label' });
 			const pageInput = jumpGroup.createEl('input', {
@@ -684,6 +699,56 @@ export class SupernoteView extends FileView {
 		this.textModeBtn?.toggleClass('is-active', this.layerMode === 'text');
 	}
 
+	// Reuses the same page PNGs already generated for the save-to-vault/
+	// drag-out buttons — no separate low-res render pass, just let CSS scale
+	// them down. Built up front (images are ready before pdf.js even starts),
+	// independent of the pdf.js page-render loop below.
+	private buildThumbSidebar(body: HTMLElement, images: string[]) {
+		this.thumbSidebarEl = body.createEl('div', { cls: 'supernote-thumb-sidebar' });
+		this.thumbItems = [];
+
+		images.forEach((dataUrl, i) => {
+			const item = this.thumbSidebarEl!.createEl('div', { cls: 'supernote-thumb-item' });
+			const img = item.createEl('img', { cls: 'supernote-thumb-img' });
+			img.src = dataUrl;
+			item.createEl('span', { cls: 'supernote-thumb-label', text: String(i + 1) });
+
+			item.addEventListener('click', () => {
+				this.pageStates[i]?.pageContainer.scrollIntoView({ block: 'start', behavior: 'smooth' });
+			});
+
+			this.thumbItems.push(item);
+		});
+
+		this.applyThumbSidebarVisibility();
+	}
+
+	private toggleThumbnails() {
+		this.thumbnailsVisible = !this.thumbnailsVisible;
+		this.applyThumbSidebarVisibility();
+	}
+
+	private applyThumbSidebarVisibility() {
+		this.thumbSidebarEl?.toggle(this.thumbnailsVisible);
+		this.thumbToggleBtn?.toggleClass('is-active', this.thumbnailsVisible);
+		if (this.thumbnailsVisible) this.updateThumbSidebarOffset();
+	}
+
+	// The thumbnail sidebar is sticky below the header, not at top:0 like the
+	// header itself — otherwise it would stick right under the top edge of
+	// the view, overlapping the header instead of sitting below it. The find
+	// bar toggling open/closed changes the header's height, so this needs
+	// re-running whenever that happens, not just once at load.
+	private updateThumbSidebarOffset() {
+		if (!this.thumbSidebarEl) return;
+		const headerHeight = this.headerEl?.offsetHeight ?? 0;
+		this.thumbSidebarEl.setCssStyles({ top: `${headerHeight}px` });
+	}
+
+	private highlightThumbnail(index: number) {
+		this.thumbItems.forEach((item, i) => item.toggleClass('is-active', i === index));
+	}
+
 	// Scrollspy: find the last page whose top has scrolled up past the sticky
 	// header, and reflect it in the toolbar's page number — unless the user is
 	// actively typing in that field themselves.
@@ -704,6 +769,7 @@ export class SupernoteView extends FileView {
 		}
 
 		this.pageJumpInput.value = String(current + 1);
+		this.highlightThumbnail(current);
 	}
 
 	private setZoom(newScale: number) {
@@ -771,11 +837,13 @@ export class SupernoteView extends FileView {
 		this.findBarEl.show();
 		this.findInput?.inputEl.focus();
 		this.findInput?.inputEl.select();
+		this.updateThumbSidebarOffset();
 	}
 
 	private closeFindBar() {
 		this.clearFindHighlights();
 		this.findBarEl?.hide();
+		this.updateThumbSidebarOffset();
 	}
 
 	private clearFindHighlights() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,7 +66,7 @@ function decodeRecognizedLabel(label: string): string {
 // what lets a PDF viewer (or this plugin's own find-in-note) land on the
 // right word in the right place rather than just confirming the word exists
 // somewhere on the page.
-function drawPositionedRecognizedText(pdf: jsPDF, page: NotePage, pageWidth: number, pageHeight: number): boolean {
+function drawPositionedRecognizedText(pdf: jsPDF, page: NotePage): boolean {
     const elements = page.recognitionElements ?? [];
     let drewAny = false;
 
@@ -84,7 +84,14 @@ function drawPositionedRecognizedText(pdf: jsPDF, page: NotePage, pageWidth: num
             const y = box.y * RECOGNITION_BOX_SCALE;
             const width = box.width * RECOGNITION_BOX_SCALE;
             const height = box.height * RECOGNITION_BOX_SCALE;
-            if (x >= pageWidth || y >= pageHeight || width <= 0 || height <= 0) continue;
+            // No page-bounds cutoff here: with an approximate scale factor,
+            // legitimate words (especially on the last couple of lines,
+            // where y is largest) can land right at or just past the
+            // computed page edge. Drawing invisible text slightly outside
+            // the page is harmless — PDF viewers simply don't render past
+            // the MediaBox — but dropping the word entirely was silently
+            // losing whole bottom lines.
+            if (width <= 0 || height <= 0) continue;
 
             // jsPDF's unit:'px' only applies to coordinates; setFontSize is
             // always in points (72/in vs. px's 96/in), hence the 0.75 factor.
@@ -112,7 +119,7 @@ function buildNotePdf(sn: SupernoteX, images: string[], settings: SupernotePlugi
         }
 
         const page = sn.pages[i];
-        const positioned = drawPositionedRecognizedText(pdf, page, sn.pageWidth, sn.pageHeight);
+        const positioned = drawPositionedRecognizedText(pdf, page);
 
         // Fall back to one flowed invisible block when there's no per-word
         // position data, so text still exists somewhere for search/copy.

--- a/src/main.ts
+++ b/src/main.ts
@@ -424,8 +424,11 @@ export class SupernoteView extends FileView {
 			});
 		}
 
-		this.buildToolbar(container, images.length);
-		this.buildFindBar(container);
+		// Sticky header so the toolbar (and find bar, when open) stay visible
+		// while scrolling through a long note instead of scrolling away with it.
+		const header = container.createEl("div", { cls: 'supernote-header' });
+		this.buildToolbar(header, images.length);
+		this.buildFindBar(header);
 
 		this.pagesEl = container.createEl("div", { cls: 'supernote-pages' });
 		this.pagesEl.toggleClass('supernote-mode-text', this.layerMode === 'text');

--- a/src/main.ts
+++ b/src/main.ts
@@ -359,6 +359,8 @@ async function renderTextLayer(pdfjsLib: any, textContent: any, container: HTMLE
 type PageRenderState = {
 	pdfPage: any;
 	baseScale: number;
+	nativeWidth: number;
+	nativeHeight: number;
 	pageContainer: HTMLElement;
 	canvasWrap: HTMLElement;
 	canvas: HTMLCanvasElement;
@@ -387,6 +389,11 @@ export class SupernoteView extends FileView {
 	private renderedZoomScale = 1;
 	private zoomDebounceTimer: number | undefined;
 	private zoomLabelEl: HTMLElement | null = null;
+
+	private fitWidthEnabled = false;
+	private fitWidthBtn: HTMLElement | null = null;
+	private fitWidthDebounceTimer: number | undefined;
+	private resizeObserver: ResizeObserver | null = null;
 
 	private layerMode: 'image' | 'text' = 'image';
 	private imageModeBtn: HTMLElement | null = null;
@@ -472,6 +479,17 @@ export class SupernoteView extends FileView {
 				this.updateCurrentPageIndicator();
 			});
 		}, { passive: true });
+
+		// While "Fit width" is on, keep the page matched to however much room
+		// is actually available as the pane resizes (split panes, sidebars
+		// opening/closing, window resize) — not just at the moment it was
+		// turned on. Debounced since resize fires continuously while dragging.
+		this.resizeObserver = new ResizeObserver(() => {
+			if (!this.fitWidthEnabled) return;
+			window.clearTimeout(this.fitWidthDebounceTimer);
+			this.fitWidthDebounceTimer = window.setTimeout(() => this.applyFitWidth(), 150);
+		});
+		this.resizeObserver.observe(this.contentEl);
 	}
 
 	async onLoadFile(file: TFile): Promise<void> {
@@ -585,6 +603,8 @@ export class SupernoteView extends FileView {
 			const state: PageRenderState = {
 				pdfPage,
 				baseScale,
+				nativeWidth: unscaledViewport.width,
+				nativeHeight: unscaledViewport.height,
 				pageContainer,
 				canvasWrap,
 				canvas,
@@ -611,6 +631,9 @@ export class SupernoteView extends FileView {
 			}
 		}
 
+		if (this.fitWidthEnabled) {
+			this.applyFitWidth();
+		}
 		this.updateCurrentPageIndicator();
 	}
 
@@ -637,15 +660,29 @@ export class SupernoteView extends FileView {
 		this.pageJumpInput = null;
 		const toolbar = container.createEl('div', { cls: 'supernote-toolbar' });
 
+		if (pageCount > 1) {
+			const thumbGroup = toolbar.createEl('div', { cls: 'supernote-toolbar-group' });
+			this.thumbToggleBtn = thumbGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Toggle page thumbnails' } });
+			setIcon(this.thumbToggleBtn, 'layout-list');
+			this.thumbToggleBtn.addEventListener('click', () => this.toggleThumbnails());
+		}
+
 		const zoomGroup = toolbar.createEl('div', { cls: 'supernote-toolbar-group' });
 		const zoomOutBtn = zoomGroup.createEl('button', { text: '−', cls: 'clickable-icon', attr: { 'aria-label': 'Zoom out' } });
 		this.zoomLabelEl = zoomGroup.createEl('span', { cls: 'supernote-zoom-label', text: '100%' });
 		const zoomInBtn = zoomGroup.createEl('button', { text: '+', cls: 'clickable-icon', attr: { 'aria-label': 'Zoom in' } });
 		const zoomResetBtn = zoomGroup.createEl('button', { text: 'Reset zoom', cls: 'clickable-icon' });
+		this.fitWidthBtn = zoomGroup.createEl('button', { text: 'Fit width', cls: 'clickable-icon', attr: { 'aria-label': 'Fit page to viewport width' } });
 
 		zoomOutBtn.addEventListener('click', () => this.setZoom(this.zoomScale / 1.25));
 		zoomInBtn.addEventListener('click', () => this.setZoom(this.zoomScale * 1.25));
 		zoomResetBtn.addEventListener('click', () => this.setZoom(1));
+		this.fitWidthBtn.addEventListener('click', () => {
+			this.fitWidthEnabled = true;
+			this.applyFitWidth();
+			this.updateFitWidthButton();
+		});
+		this.updateFitWidthButton();
 
 		const layerGroup = toolbar.createEl('div', { cls: 'supernote-toolbar-group' });
 		this.imageModeBtn = layerGroup.createEl('button', { text: 'Image', cls: 'clickable-icon', attr: { 'aria-label': 'Show page image' } });
@@ -653,13 +690,6 @@ export class SupernoteView extends FileView {
 		this.imageModeBtn.addEventListener('click', () => this.setLayerMode('image'));
 		this.textModeBtn.addEventListener('click', () => this.setLayerMode('text'));
 		this.updateLayerModeButtons();
-
-		if (pageCount > 1) {
-			const thumbGroup = toolbar.createEl('div', { cls: 'supernote-toolbar-group' });
-			this.thumbToggleBtn = thumbGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Toggle page thumbnails' } });
-			setIcon(this.thumbToggleBtn, 'layout-list');
-			this.thumbToggleBtn.addEventListener('click', () => this.toggleThumbnails());
-		}
 
 		if (pageCount > 1) {
 			const jumpGroup = toolbar.createEl('div', { cls: 'supernote-toolbar-group' });
@@ -773,7 +803,16 @@ export class SupernoteView extends FileView {
 		this.highlightThumbnail(current);
 	}
 
-	private setZoom(newScale: number) {
+	private setZoom(newScale: number, opts: { manual?: boolean } = {}) {
+		if (opts.manual !== false) {
+			// Any direct zoom action (buttons, wheel, reset) is the user taking
+			// manual control — stop auto-adjusting on resize until they ask for
+			// fit-width again. applyFitWidth() itself calls in with manual:false
+			// so it doesn't immediately cancel the mode it's trying to apply.
+			this.fitWidthEnabled = false;
+			this.updateFitWidthButton();
+		}
+
 		this.zoomScale = Math.min(5, Math.max(0.25, newScale));
 		this.zoomLabelEl?.setText(`${Math.round(this.zoomScale * 100)}%`);
 
@@ -797,6 +836,28 @@ export class SupernoteView extends FileView {
 		}
 		this.renderedZoomScale = targetZoom;
 		this.updateCurrentPageIndicator();
+	}
+
+	// Scales the page so its rendered width matches however much horizontal
+	// space is actually available (pagesEl's content box, which already
+	// accounts for the thumbnail sidebar if it's open) minus the page
+	// container's own margin, rather than the fixed noteImageMaxDim cap.
+	private applyFitWidth() {
+		const state = this.pageStates[0];
+		if (!state || !this.pagesEl || state.nativeWidth <= 0) return;
+
+		const availableWidth = this.pagesEl.clientWidth;
+		if (availableWidth <= 0) return;
+
+		const containerStyle = getComputedStyle(state.pageContainer);
+		const horizontalMargin = parseFloat(containerStyle.marginLeft || '0') + parseFloat(containerStyle.marginRight || '0');
+		const targetWidth = Math.max(availableWidth - horizontalMargin, 1);
+
+		this.setZoom(targetWidth / (state.nativeWidth * state.baseScale), { manual: false });
+	}
+
+	private updateFitWidthButton() {
+		this.fitWidthBtn?.toggleClass('is-active', this.fitWidthEnabled);
 	}
 
 	private buildFindBar(container: HTMLElement) {
@@ -933,6 +994,8 @@ export class SupernoteView extends FileView {
 
 	async onClose() {
 		window.clearTimeout(this.zoomDebounceTimer);
+		window.clearTimeout(this.fitWidthDebounceTimer);
+		this.resizeObserver?.disconnect();
 	}
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -428,11 +428,21 @@ export class SupernoteView extends FileView {
 			return false;
 		});
 
-		// Ctrl/Cmd+scroll to zoom; plain scroll keeps paging through the note as
-		// before. contentEl persists across file loads (onLoadFile only rebuilds
-		// its children), so this only needs registering once.
+		// Ctrl+scroll to zoom (trackpad pinch-to-zoom is reported as a wheel
+		// event with ctrlKey set, on every platform); plain scroll keeps paging
+		// through the note as before. contentEl persists across file loads
+		// (onLoadFile only rebuilds its children), so this only needs
+		// registering once.
+		//
+		// Deliberately NOT metaKey (Cmd on macOS): Cmd is also the modifier
+		// held down through a whole Cmd+Tab app switch, and a wheel event from
+		// scroll momentum/inertia that happens to fire mid-switch — nothing to
+		// do with zooming — would still carry metaKey:true and get treated as
+		// a zoom gesture. Trackpad pinch never sets metaKey, only ctrlKey, so
+		// dropping metaKey here loses nothing for the gesture this is actually
+		// meant to support.
 		this.registerDomEvent(this.contentEl, 'wheel', (evt: WheelEvent) => {
-			if (!(evt.ctrlKey || evt.metaKey)) return;
+			if (!evt.ctrlKey) return;
 			evt.preventDefault();
 
 			// Trackpads report a pinch-to-zoom gesture as a wheel event with

--- a/src/main.ts
+++ b/src/main.ts
@@ -434,7 +434,16 @@ export class SupernoteView extends FileView {
 		this.registerDomEvent(this.contentEl, 'wheel', (evt: WheelEvent) => {
 			if (!(evt.ctrlKey || evt.metaKey)) return;
 			evt.preventDefault();
-			const factor = evt.deltaY < 0 ? 1.1 : 1 / 1.1;
+
+			// Trackpads report a pinch-to-zoom gesture as a wheel event with
+			// ctrlKey set — the same flag an ordinary two-finger scroll can
+			// spuriously carry for a stray event or two right as the scroll
+			// hits a boundary (e.g. scrolling up to the very top). A fixed
+			// per-event zoom step let a short burst of those misfires snowball
+			// straight to the zoom cap. Scaling the step by the event's own
+			// deltaY keeps a real, sustained pinch feeling responsive while
+			// capping how much a single misfired event can do.
+			const factor = Math.min(1.05, Math.max(0.95, 1 - evt.deltaY * 0.01));
 			this.setZoom(this.zoomScale * factor);
 		}, { passive: false });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -458,6 +458,7 @@ export class SupernoteView extends FileView {
 		// Sticky header so the toolbar (and find bar, when open) stay visible
 		// while scrolling through a long note instead of scrolling away with it.
 		this.headerEl = container.createEl("div", { cls: 'supernote-header' });
+		this.pullHeaderFlushWithContent(this.headerEl);
 		this.buildToolbar(this.headerEl, images.length);
 		this.buildFindBar(this.headerEl);
 		this.updateThumbSidebarOffset();
@@ -556,6 +557,32 @@ export class SupernoteView extends FileView {
 
 		const hasTextLayer = await renderTextLayer(this.pdfjsLib, textContent, state.textLayerDiv, viewport);
 		state.spans = hasTextLayer ? Array.from(state.textLayerDiv.querySelectorAll('span')) : [];
+	}
+
+	// Obsidian's .view-content has its own top/left/right padding, which left
+	// a gap between the pane's own header and this sticky toolbar — and,
+	// since `position: sticky` sticks relative to the padding edge of its
+	// scrolling ancestor, having the header sit inside that padding (instead
+	// of flush against the true top of the scrollport) is also the likely
+	// cause of page content occasionally rendering through/under it while
+	// scrolling. Cancel the padding out with a matching negative margin
+	// (computed at runtime so this doesn't hardcode a theme's padding value)
+	// and re-add it as the header's own padding, so it reads flush against
+	// the pane header while the toolbar's contents keep the same inset.
+	private pullHeaderFlushWithContent(header: HTMLElement) {
+		const contentStyle = getComputedStyle(this.contentEl);
+		const topPad = contentStyle.paddingTop || '0px';
+		const leftPad = contentStyle.paddingLeft || '0px';
+		const rightPad = contentStyle.paddingRight || '0px';
+
+		header.setCssStyles({
+			marginTop: `-${topPad}`,
+			marginLeft: `-${leftPad}`,
+			marginRight: `-${rightPad}`,
+			paddingTop: topPad,
+			paddingLeft: leftPad,
+			paddingRight: rightPad,
+		});
 	}
 
 	private buildToolbar(container: HTMLElement, pageCount: number) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -678,8 +678,10 @@ export class SupernoteView extends FileView {
 		zoomInBtn.addEventListener('click', () => this.setZoom(this.zoomScale * 1.25));
 		zoomResetBtn.addEventListener('click', () => this.setZoom(1));
 		this.fitWidthBtn.addEventListener('click', () => {
-			this.fitWidthEnabled = true;
-			this.applyFitWidth();
+			this.fitWidthEnabled = !this.fitWidthEnabled;
+			if (this.fitWidthEnabled) {
+				this.applyFitWidth();
+			}
 			this.updateFitWidthButton();
 		});
 		this.updateFitWidthButton();

--- a/src/main.ts
+++ b/src/main.ts
@@ -394,7 +394,6 @@ export class SupernoteView extends FileView {
 	async onLoadFile(file: TFile): Promise<void> {
 		const container = this.contentEl;
 		container.empty();
-		container.createEl("h1", { text: file.name });
 
 		window.clearTimeout(this.zoomDebounceTimer);
 		this.pageStates = [];

--- a/src/main.ts
+++ b/src/main.ts
@@ -640,11 +640,12 @@ export class SupernoteView extends FileView {
 	// them down. Built up front (images are ready before pdf.js even starts),
 	// independent of the pdf.js page-render loop below.
 	private buildThumbSidebar(body: HTMLElement, images: string[]) {
-		this.thumbSidebarEl = body.createEl('div', { cls: 'supernote-thumb-sidebar' });
+		const thumbSidebarEl = body.createEl('div', { cls: 'supernote-thumb-sidebar' });
+		this.thumbSidebarEl = thumbSidebarEl;
 		this.thumbItems = [];
 
 		images.forEach((dataUrl, i) => {
-			const item = this.thumbSidebarEl!.createEl('div', { cls: 'supernote-thumb-item' });
+			const item = thumbSidebarEl.createEl('div', { cls: 'supernote-thumb-item' });
 			const img = item.createEl('img', { cls: 'supernote-thumb-img' });
 			img.src = dataUrl;
 			item.createEl('span', { cls: 'supernote-thumb-label', text: String(i + 1) });
@@ -848,8 +849,7 @@ export class SupernoteView extends FileView {
 			const state = this.pageStates[pageIndex];
 			const lowerText = state.text.toLowerCase();
 
-			let searchStart = 0;
-			while (true) {
+			for (let searchStart = 0; ;) {
 				const matchOffset = lowerText.indexOf(lowerQuery, searchStart);
 				if (matchOffset === -1) break;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -320,6 +320,10 @@ export class SupernoteView extends FileView {
 	private imageModeBtn: HTMLElement | null = null;
 	private textModeBtn: HTMLElement | null = null;
 
+	private headerEl: HTMLElement | null = null;
+	private pageJumpInput: HTMLInputElement | null = null;
+	private scrollUpdateScheduled = false;
+
 	private findBarEl: HTMLElement | null = null;
 	private findInput: SearchComponent | null = null;
 	private findMatchCountEl: HTMLElement | null = null;
@@ -361,6 +365,17 @@ export class SupernoteView extends FileView {
 			const factor = evt.deltaY < 0 ? 1.1 : 1 / 1.1;
 			this.setZoom(this.zoomScale * factor);
 		}, { passive: false });
+
+		// Keep the toolbar's page number in sync with whatever page is actually
+		// scrolled into view, rAF-throttled since scroll fires very frequently.
+		this.registerDomEvent(this.contentEl, 'scroll', () => {
+			if (this.scrollUpdateScheduled) return;
+			this.scrollUpdateScheduled = true;
+			requestAnimationFrame(() => {
+				this.scrollUpdateScheduled = false;
+				this.updateCurrentPageIndicator();
+			});
+		}, { passive: true });
 	}
 
 	async onLoadFile(file: TFile): Promise<void> {
@@ -426,9 +441,9 @@ export class SupernoteView extends FileView {
 
 		// Sticky header so the toolbar (and find bar, when open) stay visible
 		// while scrolling through a long note instead of scrolling away with it.
-		const header = container.createEl("div", { cls: 'supernote-header' });
-		this.buildToolbar(header, images.length);
-		this.buildFindBar(header);
+		this.headerEl = container.createEl("div", { cls: 'supernote-header' });
+		this.buildToolbar(this.headerEl, images.length);
+		this.buildFindBar(this.headerEl);
 
 		this.pagesEl = container.createEl("div", { cls: 'supernote-pages' });
 		this.pagesEl.toggleClass('supernote-mode-text', this.layerMode === 'text');
@@ -495,6 +510,8 @@ export class SupernoteView extends FileView {
 				});
 			}
 		}
+
+		this.updateCurrentPageIndicator();
 	}
 
 	private async renderPage(state: PageRenderState, scale: number): Promise<void> {
@@ -517,6 +534,7 @@ export class SupernoteView extends FileView {
 	}
 
 	private buildToolbar(container: HTMLElement, pageCount: number) {
+		this.pageJumpInput = null;
 		const toolbar = container.createEl('div', { cls: 'supernote-toolbar' });
 
 		const zoomGroup = toolbar.createEl('div', { cls: 'supernote-toolbar-group' });
@@ -541,8 +559,9 @@ export class SupernoteView extends FileView {
 			jumpGroup.createEl('span', { text: 'Page', cls: 'supernote-page-jump-label' });
 			const pageInput = jumpGroup.createEl('input', {
 				cls: 'supernote-page-jump-input',
-				attr: { type: 'number', min: '1', max: String(pageCount) },
+				attr: { type: 'number', min: '1', max: String(pageCount), value: '1' },
 			});
+			this.pageJumpInput = pageInput;
 			jumpGroup.createEl('span', { text: `/ ${pageCount}`, cls: 'supernote-page-jump-total' });
 
 			const jumpToPage = () => {
@@ -574,6 +593,28 @@ export class SupernoteView extends FileView {
 		this.textModeBtn?.toggleClass('is-active', this.layerMode === 'text');
 	}
 
+	// Scrollspy: find the last page whose top has scrolled up past the sticky
+	// header, and reflect it in the toolbar's page number — unless the user is
+	// actively typing in that field themselves.
+	private updateCurrentPageIndicator() {
+		if (!this.pageJumpInput || this.pageStates.length === 0) return;
+		if (document.activeElement === this.pageJumpInput) return;
+
+		const headerHeight = this.headerEl?.offsetHeight ?? 0;
+		const threshold = this.contentEl.getBoundingClientRect().top + headerHeight + 1;
+
+		let current = 0;
+		for (let i = 0; i < this.pageStates.length; i++) {
+			if (this.pageStates[i].pageContainer.getBoundingClientRect().top <= threshold) {
+				current = i;
+			} else {
+				break;
+			}
+		}
+
+		this.pageJumpInput.value = String(current + 1);
+	}
+
 	private setZoom(newScale: number) {
 		this.zoomScale = Math.min(5, Math.max(0.25, newScale));
 		this.zoomLabelEl?.setText(`${Math.round(this.zoomScale * 100)}%`);
@@ -597,6 +638,7 @@ export class SupernoteView extends FileView {
 			state.canvasWrap.setCssStyles({ transform: '', transformOrigin: '' });
 		}
 		this.renderedZoomScale = targetZoom;
+		this.updateCurrentPageIndicator();
 	}
 
 	private buildFindBar(container: HTMLElement) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -289,7 +289,7 @@ export class SupernoteView extends FileView {
 	private zoomDebounceTimer: number | undefined;
 	private zoomLabelEl: HTMLElement | null = null;
 
-	private fitWidthEnabled = false;
+	private fitWidthEnabled = true;
 	private fitWidthBtn: HTMLElement | null = null;
 	private fitWidthDebounceTimer: number | undefined;
 	private resizeObserver: ResizeObserver | null = null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -333,6 +333,16 @@ export class SupernoteView extends FileView {
 	}
 
 	async onOpen(): Promise<void> {
+		// Obsidian's .view-content has its own top padding, leaving a gap
+		// above the sticky toolbar. A previous attempt cancelled it with a
+		// negative margin on the (sticky) header itself, which fought with
+		// `position: sticky`'s own positioning math and let page content
+		// render through/above the stuck toolbar instead. Zeroing the
+		// ancestor's padding directly avoids combining sticky with a negative
+		// margin at all; .supernote-header's own (positive, sticky-safe)
+		// padding-top puts a little breathing room back.
+		this.contentEl.setCssStyles({ paddingTop: '0' });
+
 		this.scope?.register(['Mod'], 'f', (evt) => {
 			evt.preventDefault();
 			this.toggleFindBar();
@@ -458,7 +468,6 @@ export class SupernoteView extends FileView {
 		// Sticky header so the toolbar (and find bar, when open) stay visible
 		// while scrolling through a long note instead of scrolling away with it.
 		this.headerEl = container.createEl("div", { cls: 'supernote-header' });
-		this.pullHeaderFlushWithContent(this.headerEl);
 		this.buildToolbar(this.headerEl, images.length);
 		this.buildFindBar(this.headerEl);
 		this.updateThumbSidebarOffset();
@@ -557,32 +566,6 @@ export class SupernoteView extends FileView {
 
 		const hasTextLayer = await renderTextLayer(this.pdfjsLib, textContent, state.textLayerDiv, viewport);
 		state.spans = hasTextLayer ? Array.from(state.textLayerDiv.querySelectorAll('span')) : [];
-	}
-
-	// Obsidian's .view-content has its own top/left/right padding, which left
-	// a gap between the pane's own header and this sticky toolbar — and,
-	// since `position: sticky` sticks relative to the padding edge of its
-	// scrolling ancestor, having the header sit inside that padding (instead
-	// of flush against the true top of the scrollport) is also the likely
-	// cause of page content occasionally rendering through/under it while
-	// scrolling. Cancel the padding out with a matching negative margin
-	// (computed at runtime so this doesn't hardcode a theme's padding value)
-	// and re-add it as the header's own padding, so it reads flush against
-	// the pane header while the toolbar's contents keep the same inset.
-	private pullHeaderFlushWithContent(header: HTMLElement) {
-		const contentStyle = getComputedStyle(this.contentEl);
-		const topPad = contentStyle.paddingTop || '0px';
-		const leftPad = contentStyle.paddingLeft || '0px';
-		const rightPad = contentStyle.paddingRight || '0px';
-
-		header.setCssStyles({
-			marginTop: `-${topPad}`,
-			marginLeft: `-${leftPad}`,
-			marginRight: `-${rightPad}`,
-			paddingTop: topPad,
-			paddingLeft: leftPad,
-			paddingRight: rightPad,
-		});
 	}
 
 	private buildToolbar(container: HTMLElement, pageCount: number) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,66 @@ function dataUrlToBuffer(dataUrl: string): ArrayBuffer {
 // Assembles a searchable PDF (page image plus an invisible OCR text layer) from
 // already-rendered page images. Shared by the vault "Attach as PDF" export and the
 // in-memory pdf.js preview in SupernoteView, so both stay byte-for-byte consistent.
+type NotePage = SupernoteX['pages'][number];
+
+// supernote-typescript's recognitionElements carry a per-word bounding box
+// (page.recognitionElements[].words[].['bounding-box']), but those units are
+// noticeably smaller than page pixels — word heights come out ~8-20 units
+// regardless of whether the note's native page is 1404x1872 or 1920x2560 px,
+// which only makes sense if recognition runs against a downscaled canvas.
+// This constant is an approximation, not a documented Supernote constant:
+// fitting it against supernote-typescript's own test fixtures (checked out
+// as a submodule here), scale 13.5 puts recognized-word extents at ~93-96%
+// of tests/input/rtr.note's page dimensions with no words landing outside
+// the page — the closest fit found among a few fixtures tried. If the note
+// view's "Text" mode shows words drifting away from the handwriting they
+// came from, tune this first.
+const RECOGNITION_BOX_SCALE = 13.5;
+
+// Matches supernote-typescript's own _extractText/_extractParagraphs decode
+// step (src/parsing.ts) for recognized labels.
+function decodeRecognizedLabel(label: string): string {
+    return decodeURIComponent(escape(label));
+}
+
+// Draws each recognized word as invisible text positioned directly over the
+// handwriting it was recognized from, instead of one flowed block — this is
+// what lets a PDF viewer (or this plugin's own find-in-note) land on the
+// right word in the right place rather than just confirming the word exists
+// somewhere on the page.
+function drawPositionedRecognizedText(pdf: jsPDF, page: NotePage, pageWidth: number, pageHeight: number): boolean {
+    const elements = page.recognitionElements ?? [];
+    let drewAny = false;
+
+    pdf.setTextColor(0, 0, 0, 0); // Transparent text
+
+    for (const element of elements) {
+        if (element.type !== 'Text') continue;
+
+        for (const word of element.words ?? []) {
+            const box = word['bounding-box'];
+            const label = word.label?.trim();
+            if (!box || !label) continue;
+
+            const x = box.x * RECOGNITION_BOX_SCALE;
+            const y = box.y * RECOGNITION_BOX_SCALE;
+            const width = box.width * RECOGNITION_BOX_SCALE;
+            const height = box.height * RECOGNITION_BOX_SCALE;
+            if (x >= pageWidth || y >= pageHeight || width <= 0 || height <= 0) continue;
+
+            // jsPDF's unit:'px' only applies to coordinates; setFontSize is
+            // always in points (72/in vs. px's 96/in), hence the 0.75 factor.
+            pdf.setFontSize(height * 0.75);
+            // y is the text baseline in jsPDF, not the box's top.
+            pdf.text(decodeRecognizedLabel(label), x, y + height, { maxWidth: Math.max(width, 1) });
+            drewAny = true;
+        }
+    }
+
+    pdf.setTextColor(0, 0, 0, 1);
+    return drewAny;
+}
+
 function buildNotePdf(sn: SupernoteX, images: string[], settings: SupernotePluginSettings): jsPDF {
     const pdf = new jsPDF({
         orientation: 'portrait',
@@ -51,10 +111,15 @@ function buildNotePdf(sn: SupernoteX, images: string[], settings: SupernotePlugi
             pdf.addPage();
         }
 
-        if (sn.pages[i].text !== undefined && sn.pages[i].text.length > 0) {
+        const page = sn.pages[i];
+        const positioned = drawPositionedRecognizedText(pdf, page, sn.pageWidth, sn.pageHeight);
+
+        // Fall back to one flowed invisible block when there's no per-word
+        // position data, so text still exists somewhere for search/copy.
+        if (!positioned && page.text !== undefined && page.text.length > 0) {
             pdf.setFontSize(100);
             pdf.setTextColor(0, 0, 0, 0); // Transparent text
-            pdf.text(processSupernoteText(sn.pages[i].text, settings), 20, 20, { maxWidth: sn.pageWidth });
+            pdf.text(processSupernoteText(page.text, settings), 20, 20, { maxWidth: sn.pageWidth });
             pdf.setTextColor(0, 0, 0, 1);
         }
 

--- a/src/myworker.worker.ts
+++ b/src/myworker.worker.ts
@@ -1,18 +1,16 @@
 import { installAtPolyfill } from 'polyfills';
 installAtPolyfill();
 
-import { SupernoteX, toImage, IRenderableNote } from 'supernote-typescript';
-import { encodeDataURL, encodePng } from 'image-js';
+import { SupernoteX, toImage } from 'supernote-typescript';
+import { encodeDataURL } from 'image-js';
 
 export { };
 
 export type SupernoteWorkerMessage =
-    | { type: 'convert'; note: SupernoteX; pageNumbers?: number[] }
-    | { type: 'renderPdfPage'; pageRenderData: IRenderableNote };
+    | { type: 'convert'; note: SupernoteX; pageNumbers?: number[] };
 
 export type SupernoteWorkerResponse =
     | { type: 'result'; images: string[] }
-    | { type: 'pdfPageResult'; pngBytes: Uint8Array }
     | { type: 'error'; error: string };
 
 self.onmessage = async (e: MessageEvent<SupernoteWorkerMessage>) => {
@@ -24,11 +22,6 @@ self.onmessage = async (e: MessageEvent<SupernoteWorkerMessage>) => {
             // Convert canvas/images to data URLs before sending
             const images = results.map(result => encodeDataURL(result));
             const response: SupernoteWorkerResponse = { type: 'result', images };
-            self.postMessage(response);
-        } else if (data.type === 'renderPdfPage') {
-            const [image] = await toImage(data.pageRenderData, [1]);
-            const pngBytes = encodePng(image);
-            const response: SupernoteWorkerResponse = { type: 'pdfPageResult', pngBytes };
             self.postMessage(response);
         }
     } catch (error) {

--- a/src/myworker.worker.ts
+++ b/src/myworker.worker.ts
@@ -1,42 +1,41 @@
 import { installAtPolyfill } from 'polyfills';
 installAtPolyfill();
 
-import { SupernoteX, toImage } from 'supernote-typescript';
-import { encodeDataURL } from 'image-js';
+import { SupernoteX, toImage, IRenderableNote } from 'supernote-typescript';
+import { encodeDataURL, encodePng } from 'image-js';
 
 export { };
 
-export type SupernoteWorkerMessage = {
-    type: 'convert';
-    note: SupernoteX;
-    pageNumbers?: number[];
-}
+export type SupernoteWorkerMessage =
+    | { type: 'convert'; note: SupernoteX; pageNumbers?: number[] }
+    | { type: 'renderPdfPage'; pageRenderData: IRenderableNote };
 
-export type SupernoteWorkerResponse = {
-    type: 'result';
-    images: string[];
-    error?: string;
-}
+export type SupernoteWorkerResponse =
+    | { type: 'result'; images: string[] }
+    | { type: 'pdfPageResult'; pngBytes: Uint8Array }
+    | { type: 'error'; error: string };
 
 self.onmessage = async (e: MessageEvent<SupernoteWorkerMessage>) => {
     try {
-        const { type, note, pageNumbers } = e.data;
+        const data = e.data;
 
-        if (type === 'convert') {
-            const results = await toImage(note, pageNumbers);
+        if (data.type === 'convert') {
+            const results = await toImage(data.note, data.pageNumbers);
             // Convert canvas/images to data URLs before sending
-            const dataUrls = results.map(result => encodeDataURL(result));
-
-            self.postMessage({
-                type: 'result',
-                images: dataUrls
-            });
+            const images = results.map(result => encodeDataURL(result));
+            const response: SupernoteWorkerResponse = { type: 'result', images };
+            self.postMessage(response);
+        } else if (data.type === 'renderPdfPage') {
+            const [image] = await toImage(data.pageRenderData, [1]);
+            const pngBytes = encodePng(image);
+            const response: SupernoteWorkerResponse = { type: 'pdfPageResult', pngBytes };
+            self.postMessage(response);
         }
     } catch (error) {
-        self.postMessage({
-            type: 'result',
-            images: [],
+        const response: SupernoteWorkerResponse = {
+            type: 'error',
             error: error instanceof Error ? error.message : 'Unknown error occurred'
-        });
+        };
+        self.postMessage(response);
     }
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,18 +8,14 @@ export const IP_VALIDATION_PATTERN = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.
 export interface SupernotePluginSettings extends CustomDictionarySettings {
     directConnectIP: string;
     invertColorsWhenDark: boolean;
-    showTOC: boolean;
     showExportButtons: boolean;
-    collapseRecognizedText: boolean,
     noteImageMaxDim: number;
 }
 
 export const DEFAULT_SETTINGS: SupernotePluginSettings = {
     directConnectIP: '',
     invertColorsWhenDark: true,
-    showTOC: true,
     showExportButtons: true,
-    collapseRecognizedText: false,
     noteImageMaxDim: 800, // Sensible default for Nomad pages to be legible but not too big. Unit: px
 	...CUSTOM_DICTIONARY_DEFAULT_SETTINGS,
 }
@@ -75,20 +71,6 @@ export class SupernoteSettingTab extends PluginSettingTab {
             );
 
         new Setting(containerEl)
-            .setName('Show table of contents and page headings')
-            .setDesc(
-                'When viewing .note files, show a table of contents and page number headings',
-            )
-            .addToggle((text) =>
-                text
-                    .setValue(this.plugin.settings.showTOC)
-                    .onChange(async (value) => {
-                        this.plugin.settings.showTOC = value;
-                        await this.plugin.saveSettings();
-                    }),
-            );
-
-        new Setting(containerEl)
             .setName('Show export buttons')
             .setDesc(
                 'When viewing .note files, show buttons for exporting images and/or markdown files to vault. These features can still be accessed via the command pallete.',
@@ -100,17 +82,6 @@ export class SupernoteSettingTab extends PluginSettingTab {
                         this.plugin.settings.showExportButtons = value;
                         await this.plugin.saveSettings();
                     }),
-            );
-
-        new Setting(containerEl)
-            .setName('Collapse recognized text')
-            .setDesc('When viewing .note files, hide recognized text in a collapsible element. This does not affect exported markdown.')
-            .addToggle(text => text
-                .setValue(this.plugin.settings.collapseRecognizedText)
-                .onChange(async (value) => {
-                    this.plugin.settings.collapseRecognizedText = value;
-                    await this.plugin.saveSettings();
-                })
             );
 
         new Setting(containerEl)

--- a/styles.css
+++ b/styles.css
@@ -33,9 +33,86 @@ button.mod-cta {
 }
 
 div.page-container {
-    display: inline-block; 
+    display: inline-block;
     vertical-align: top;
     margin: 1.2em;
+}
+
+div.supernote-canvas-wrap {
+    position: relative;
+    display: inline-block;
+    transform-origin: top left;
+}
+
+div.supernote-canvas-wrap canvas {
+    display: block;
+    max-width: 100%;
+}
+
+/* Mirrors pdf.js's own text_layer_builder.css: canvas carries the pixels,
+   this transparent layer carries selectable/searchable text on top of it. */
+.textLayer {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    line-height: 1;
+    text-align: initial;
+    transform-origin: 0 0;
+}
+
+.textLayer span,
+.textLayer br {
+    color: transparent;
+    position: absolute;
+    white-space: pre;
+    cursor: text;
+    transform-origin: 0% 0%;
+}
+
+.textLayer ::selection {
+    background: var(--text-selection);
+}
+
+.textLayer .supernote-find-match {
+    background: rgba(255, 224, 0, 0.4);
+    border-radius: 2px;
+}
+
+.textLayer .supernote-find-match-current {
+    background: rgba(255, 145, 0, 0.7);
+}
+
+.supernote-zoom-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    margin: 0.5em 0;
+}
+
+.supernote-zoom-label {
+    min-width: 3.5em;
+    text-align: center;
+}
+
+.supernote-find-bar {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    padding: 0.4em;
+    background: var(--background-primary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-s);
+    margin-bottom: 0.5em;
+    width: fit-content;
+}
+
+.supernote-find-count {
+    min-width: 5em;
+    color: var(--text-muted);
+    font-size: var(--font-smaller);
 }
 
 /* Custom dictionary settings styles */

--- a/styles.css
+++ b/styles.css
@@ -76,6 +76,14 @@ div.supernote-canvas-wrap canvas {
     background: rgba(255, 145, 0, 0.7);
 }
 
+.supernote-header {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: var(--background-primary);
+    padding-bottom: 0.5em;
+}
+
 .supernote-toolbar {
     display: flex;
     flex-wrap: wrap;
@@ -126,9 +134,6 @@ div.supernote-canvas-wrap canvas {
 }
 
 .supernote-find-bar {
-    position: sticky;
-    top: 0;
-    z-index: 10;
     display: flex;
     align-items: center;
     gap: 0.5em;
@@ -136,7 +141,6 @@ div.supernote-canvas-wrap canvas {
     background: var(--background-primary);
     border: 1px solid var(--background-modifier-border);
     border-radius: var(--radius-s);
-    margin-bottom: 0.5em;
     width: fit-content;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -82,6 +82,11 @@ div.supernote-canvas-wrap canvas {
     z-index: 10;
     background: var(--background-primary);
     padding-bottom: 0.5em;
+    /* Guards against a subpixel seam at the sticky boundary letting page
+       content peek through by a fraction of a pixel — page dimensions come
+       from fractional zoom/scale math, so exact-pixel alignment isn't
+       guaranteed. */
+    box-shadow: 0 1px 0 0 var(--background-primary);
 }
 
 .supernote-toolbar {

--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,14 @@
     filter: invert(1);
 }
 
+.theme-dark canvas.supernote-invert-dark {
+    filter: invert(1);
+}
+
+.theme-light canvas.supernote-invert-light {
+    filter: invert(1);
+}
+
 button.mod-cta {
     display: block;
 }

--- a/styles.css
+++ b/styles.css
@@ -81,12 +81,8 @@ div.supernote-canvas-wrap canvas {
     top: 0;
     z-index: 10;
     background: var(--background-primary);
+    padding-top: 0.5em;
     padding-bottom: 0.5em;
-    /* Guards against a subpixel seam at the sticky boundary letting page
-       content peek through by a fraction of a pixel — page dimensions come
-       from fractional zoom/scale math, so exact-pixel alignment isn't
-       guaranteed. */
-    box-shadow: 0 1px 0 0 var(--background-primary);
 }
 
 .supernote-toolbar {

--- a/styles.css
+++ b/styles.css
@@ -26,12 +26,6 @@ button.mod-cta {
     display: block;
 }
 
-.page-recognized-text {
-    user-select: text; 
-    white-space: pre-line; 
-    margin: 1.2em 0;
-}
-
 div.page-container {
     display: inline-block;
     vertical-align: top;
@@ -82,16 +76,53 @@ div.supernote-canvas-wrap canvas {
     background: rgba(255, 145, 0, 0.7);
 }
 
-.supernote-zoom-bar {
+.supernote-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1em;
+    margin: 0.5em 0;
+}
+
+.supernote-toolbar-group {
     display: flex;
     align-items: center;
-    gap: 0.5em;
-    margin: 0.5em 0;
+    gap: 0.4em;
 }
 
 .supernote-zoom-label {
     min-width: 3.5em;
     text-align: center;
+}
+
+.supernote-toolbar-group button.is-active {
+    color: var(--text-on-accent);
+    background-color: var(--interactive-accent);
+}
+
+.supernote-page-jump-input {
+    width: 4em;
+    text-align: center;
+}
+
+.supernote-page-jump-total {
+    color: var(--text-muted);
+}
+
+/* Text mode: hide the raster page, make the text layer's spans (otherwise
+   transparent, for overlaying selectable text on the image) actually
+   visible in roughly their original on-page layout. */
+.supernote-mode-text .supernote-canvas-wrap canvas {
+    display: none;
+}
+
+.supernote-mode-text .textLayer {
+    background: var(--background-primary);
+    border: 1px solid var(--background-modifier-border);
+}
+
+.supernote-mode-text .textLayer span {
+    color: var(--text-normal);
 }
 
 .supernote-find-bar {

--- a/styles.css
+++ b/styles.css
@@ -150,6 +150,62 @@ div.supernote-canvas-wrap canvas {
     font-size: var(--font-smaller);
 }
 
+.supernote-body {
+    display: flex;
+    align-items: flex-start;
+    gap: 1em;
+}
+
+.supernote-pages {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.supernote-thumb-sidebar {
+    display: flex;
+    position: sticky;
+    align-self: flex-start;
+    flex-flow: column;
+    flex-shrink: 0;
+    width: 140px;
+    max-height: calc(100vh - 4em);
+    overflow-y: auto;
+    gap: 0.75em;
+    padding: 0.5em;
+    background: var(--background-secondary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-s);
+}
+
+.supernote-thumb-item {
+    cursor: pointer;
+    text-align: center;
+    padding: 0.25em;
+    border: 2px solid transparent;
+    border-radius: var(--radius-s);
+}
+
+.supernote-thumb-item:hover {
+    background: var(--background-modifier-hover);
+}
+
+.supernote-thumb-item.is-active {
+    border-color: var(--interactive-accent);
+}
+
+.supernote-thumb-img {
+    display: block;
+    width: 100%;
+    border-radius: 2px;
+}
+
+.supernote-thumb-label {
+    display: block;
+    margin-top: 0.25em;
+    color: var(--text-muted);
+    font-size: var(--font-smaller);
+}
+
 /* Custom dictionary settings styles */
 .supernote-settings-custom-dictionary-subtitle {
 	padding: 0 0 0.75em;


### PR DESCRIPTION
## Summary

Sketch/proof-of-concept exploring a pdf.js-based note view, in response to "can the plugin view a `.note` file directly the way Obsidian views a PDF, e.g. by transparently converting to PDF?"

- Obsidian's native PDF view is internal and file-backed (not in `obsidian.d.ts`), so it can't be handed an in-memory blob directly. It does expose `loadPdfJs()`, which returns the same `pdfjsLib` its own viewer uses.
- Factored the jsPDF assembly (page image + invisible OCR text layer) out of `VaultWriter.exportToPDF` into a shared `buildNotePdf()` helper.
- `SupernoteView.onLoadFile` builds that same in-memory PDF, loads it via `loadPdfJs()` + `pdfjsLib.getDocument()`, and renders each page to a `<canvas>` instead of stacking `<img>` elements — no vault file is written for the preview.
- Added the actual payoff of using pdf.js instead of raw images:
  - **Selectable text layer** over each page, via `pdfjsLib.TextLayer` (falling back to the older `renderTextLayer()`, or degrading gracefully to "no text layer" if neither exists on Obsidian's bundled pdf.js version).
  - **Cmd/Ctrl+F find-in-note bar**, searching the per-page text, with match highlighting and next/prev navigation, scoped to this view via its own `Scope`.
  - **Zoom** toolbar + Ctrl/Cmd+scroll-wheel, with instant CSS-scale feedback and a debounced full re-render (canvas + text layer) at the target resolution.
  - **Pan** via native container scrolling (no custom drag-to-pan in this pass).
  - **Best-effort drag-out** on the canvas, reusing the same page PNG it was rendered from, since `<canvas>` doesn't get native image drag for free like `<img>` did.
- Export buttons are unchanged.

### Follow-up after real-Obsidian testing

The controls worked, but the table of contents and the always-visible recognized-text block made the view feel cluttered — especially since the text is already selectable directly on the page via the text layer. So:

- Removed the table of contents (and its per-page jump anchors) and the separate recognized-text block per page. `showTOC` and `collapseRecognizedText` are now unused and were dropped from settings entirely (not left as dead toggles).
- Added an **Image/Text toggle** in the toolbar: "Text" mode hides the canvas and makes the text layer (previously transparent, selection-only) visible in its on-page positions instead.
- Added a **page-number jump box** in the toolbar to replace the TOC's list-of-links — type a page number, Enter or blur scrolls it into view. It now also updates live as you scroll (scrollspy), rAF-throttled, skipped while you're typing in it.
- The toolbar (and find bar, when open) is now sticky (`position: sticky`) so it stays visible instead of scrolling away with the page stack.

### Word-positioned invisible text (this round)

The invisible OCR text baked into the PDF (used for both "Attach as PDF" and this view's own text layer/find-in-note) was previously one flowed block per page at a fixed position, unrelated to where each word was actually written — so search could confirm a word existed on the page but never highlighted it near the real handwriting.

`supernote-typescript` already exposes what's needed for this, no library change required: `page.recognitionElements[].words[].['bounding-box']` gives per-word x/y/width/height. Each word is now drawn as its own invisible glyph sized and placed over its bounding box (`RECOGNITION_BOX_SCALE = 13.5`, an empirical fit against the submodule's own `rtr.note` test fixture — the box units aren't page pixels, word heights are ~8-20 units regardless of whether the note is 1404x1872 or 1920x2560px natively). Falls back to the old single-block placement for pages with text but no `recognitionElements`.

Tradeoff: per-word text no longer goes through `processSupernoteText`'s custom-dictionary substitution (multi-word dictionary phrases don't map onto individual OCR word boxes) — dictionary corrections still apply to exported markdown, just not to this invisible search layer.

## Known gaps / open questions (this is a sketch, not a finished feature)

- `pdfjsLib.TextLayer` availability was never confirmed against a real Obsidian install ahead of time — the code has a fallback chain and degrades to "no text/search" rather than crashing if it's missing. (Live testing did confirm the general pdf.js/canvas/controls approach works.)
- `RECOGNITION_BOX_SCALE` is an empirical fit from one library test fixture, not a documented Supernote constant — needs visual confirmation via the "Text" mode toggle against real notes, and likely tuning.
- Find-in-note maps a text match back to a span by assuming one span per text-content item; a match straddling a span boundary highlights the span it starts in rather than a precise sub-range.
- No custom drag-to-pan (relies on native scrollbars).
- Drag-out is best-effort and untested against a real vault.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds (only pre-existing `bresenham-zingl` warnings)
- [ ] Manually load a multi-page `.note` file in Obsidian and confirm:
  - [ ] Pages render correctly via canvas; text is selectable and aligns with the rendered glyphs
  - [ ] "Text" mode shows recognized words roughly where they were handwritten, not clustered/offset
  - [ ] Cmd/Ctrl+F opens the find bar, highlights matches across pages, next/prev/Esc work, and the hotkey doesn't leak into other views
  - [ ] Zoom in/out (toolbar and Ctrl/Cmd+scroll) re-renders crisply without jank; plain scroll still pages normally
  - [ ] Toolbar stays pinned while scrolling; page-jump box tracks the current page and accepts manual jumps
  - [ ] "Attach as PDF" / "Save image to vault" still produce correct output
  - [ ] Settings tab no longer shows "table of contents" or "collapse recognized text" toggles