### PR TITLE
Add setting to defer rendering restored .note views on startup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -519,6 +519,37 @@ export class SupernoteView extends FileView {
 		// (unrelated) pageStates.
 		this.findRequestId++;
 
+		// Obsidian reconstructs every leaf left open from the previous
+		// session while restoring the saved workspace layout, calling
+		// onLoadFile() for each even if the user never asked to see it again
+		// this session — for a large note that means real rasterization work
+		// nobody wanted, which can stall startup or (on mobile) overwhelm the
+		// whole device. workspace.layoutReady is false only during that
+		// restore, so it's a reliable way to tell "being reopened by
+		// Obsidian" apart from "opened by the user" (by the time the user can
+		// click anything, layout restore has already finished).
+		if (this.settings.deferRenderOnStartup && !this.app.workspace.layoutReady) {
+			this.renderLoadPlaceholder(container, file);
+			return;
+		}
+
+		await this.renderNote(container, file);
+	}
+
+	private renderLoadPlaceholder(container: HTMLElement, file: TFile): void {
+		const placeholder = container.createEl('div', { cls: 'supernote-load-placeholder' });
+		placeholder.createEl('p', { text: `"${file.basename}" was left open from your last session.` });
+		const loadBtn = placeholder.createEl('button', {
+			text: 'Load note',
+			cls: 'mod-cta',
+		});
+		loadBtn.addEventListener('click', () => {
+			container.empty();
+			void this.renderNote(container, file);
+		});
+	}
+
+	private async renderNote(container: HTMLElement, file: TFile): Promise<void> {
 		const note = await this.app.vault.readBinary(file);
 		const sn = new SupernoteX(new Uint8Array(note));
 		let images: string[] = [];

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,6 +10,7 @@ export interface SupernotePluginSettings extends CustomDictionarySettings {
     invertColorsWhenDark: boolean;
     showExportButtons: boolean;
     noteImageMaxDim: number;
+    deferRenderOnStartup: boolean;
 }
 
 export const DEFAULT_SETTINGS: SupernotePluginSettings = {
@@ -17,6 +18,7 @@ export const DEFAULT_SETTINGS: SupernotePluginSettings = {
     invertColorsWhenDark: true,
     showExportButtons: true,
     noteImageMaxDim: 800, // Sensible default for Nomad pages to be legible but not too big. Unit: px
+    deferRenderOnStartup: false,
 	...CUSTOM_DICTIONARY_DEFAULT_SETTINGS,
 }
 
@@ -95,6 +97,20 @@ export class SupernoteSettingTab extends PluginSettingTab {
                     this.plugin.settings.noteImageMaxDim = value;
                     await this.plugin.saveSettings();
                 })
+            );
+
+        new Setting(containerEl)
+            .setName('Defer rendering restored notes on startup')
+            .setDesc(
+                'When Obsidian reopens .note files left open from a previous session, show a "Load note" button instead of rendering immediately. Large notes can otherwise make startup noticeably slow, especially on mobile. Notes you open yourself during the session still render right away.',
+            )
+            .addToggle((text) =>
+                text
+                    .setValue(this.plugin.settings.deferRenderOnStartup)
+                    .onChange(async (value) => {
+                        this.plugin.settings.deferRenderOnStartup = value;
+                        await this.plugin.saveSettings();
+                    }),
             );
 
 		// Add custom dictionary settings to the settings tab

--- a/styles.css
+++ b/styles.css
@@ -151,6 +151,14 @@ div.supernote-canvas-wrap canvas {
     font-size: var(--font-smaller);
 }
 
+.supernote-load-placeholder {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5em;
+    padding: 1em 0;
+}
+
 .supernote-body {
     display: flex;
     align-items: flex-start;


### PR DESCRIPTION
## Summary
- Fixes #64: large `.note` files re-render at full cost every time Obsidian restores them as previously-open leaves at startup, which can noticeably stall the app (and on mobile, reportedly overwhelm the whole device).
- Adds a "Defer rendering restored notes on startup" setting (off by default). When enabled, `.note` leaves that Obsidian reconstructs while restoring the saved workspace layout show a "Load note" button instead of rendering immediately; notes opened by the user during the session still render right away.
- Detection uses `workspace.layoutReady`, which is `false` only while Obsidian is still restoring the saved layout — a reliable signal for "being reopened by Obsidian" vs. "opened by the user."

## Test plan
- [x] `./scripts/build` (submodule + plugin build) succeeds
- [x] `npx tsc -noEmit -skipLibCheck` passes with no errors
- [ ] Manual check in Obsidian: enable the setting, leave a large `.note` file open, restart Obsidian, confirm a "Load note" placeholder appears instead of an immediate render, and clicking it renders the note normally
- [ ] Manual check: with the setting off (default), behavior is unchanged from before