### PR TITLE
Fix picomatch vulnerabilities via npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -143,12 +143,13 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.3.tgz",
-			"integrity": "sha512-1Mlz934GvbgdDmt26rTLmf03cAgLg5HyOgJN+ZGCeP3Q9ynYTNMn2/LQxIl7Uy+o4K6Rfi2OuLsr12JQQR8gNg==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+			"integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
 			"cpu": [
 				"arm"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
@@ -158,12 +159,13 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.3.tgz",
-			"integrity": "sha512-XvJsYo3dO3Pi4kpalkyMvfQsjxPWHYjoX4MDiB/FUM4YMfWcXa5l4VCwFWVYI1+92yxqjuqrhNg0CZg3gSouyQ==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+			"integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
@@ -173,12 +175,13 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.3.tgz",
-			"integrity": "sha512-nuV2CmLS07Gqh5/GrZLuqkU9Bm6H6vcCspM+zjp9TdQlxJtIe+qqEXQChmfc7nWdyr/yz3h45Utk1tUn8Cz5+A==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+			"integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
@@ -188,12 +191,13 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.3.tgz",
-			"integrity": "sha512-01Hxaaat6m0Xp9AXGM8mjFtqqwDjzlMP0eQq9zll9U85ttVALGCGDuEvra5Feu/NbP5AEP1MaopPwzsTcUq1cw==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+			"integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -203,12 +207,13 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.3.tgz",
-			"integrity": "sha512-Eo2gq0Q/er2muf8Z83X21UFoB7EU6/m3GNKvrhACJkjVThd0uA+8RfKpfNhuMCl1bKRfBzKOk6xaYKQZ4lZqvA==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+			"integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -218,12 +223,13 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.3.tgz",
-			"integrity": "sha512-CN62ESxaquP61n1ZjQP/jZte8CE09M6kNn3baos2SeUfdVBkWN5n6vGp2iKyb/bm/x4JQzEvJgRHLGd5F5b81w==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+			"integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -233,12 +239,13 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.3.tgz",
-			"integrity": "sha512-feq+K8TxIznZE+zhdVurF3WNJ/Sa35dQNYbaqM/wsCbWdzXr5lyq+AaTUSER2cUR+SXPnd/EY75EPRjf4s1SLg==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+			"integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -248,12 +255,13 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.3.tgz",
-			"integrity": "sha512-CLP3EgyNuPcg2cshbwkqYy5bbAgK+VhyfMU7oIYyn+x4Y67xb5C5ylxsNUjRmr8BX+MW3YhVNm6Lq6FKtRTWHQ==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+			"integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
 			"cpu": [
 				"arm"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -263,12 +271,13 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.3.tgz",
-			"integrity": "sha512-JHeZXD4auLYBnrKn6JYJ0o5nWJI9PhChA/Nt0G4MvLaMrvXuWnY93R3a7PiXeJQphpL1nYsaMcoV2QtuvRnF/g==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+			"integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -278,12 +287,13 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.3.tgz",
-			"integrity": "sha512-FyXlD2ZjZqTFh0sOQxFDiWG1uQUEOLbEh9gKN/7pFxck5Vw0qjWSDqbn6C10GAa1rXJpwsntHcmLqydY9ST9ZA==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+			"integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
 			"cpu": [
 				"ia32"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -293,12 +303,13 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.3.tgz",
-			"integrity": "sha512-OrDGMvDBI2g7s04J8dh8/I7eSO+/E7nMDT2Z5IruBfUO/RiigF1OF6xoH33Dn4W/OwAWSUf1s2nXamb28ZklTA==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+			"integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
 			"cpu": [
 				"loong64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -308,12 +319,13 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.3.tgz",
-			"integrity": "sha512-DcnUpXnVCJvmv0TzuLwKBC2nsQHle8EIiAJiJ+PipEVC16wHXaPEKP0EqN8WnBe0TPvMITOUlP2aiL5YMld+CQ==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+			"integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
 			"cpu": [
 				"mips64el"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -323,12 +335,13 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.3.tgz",
-			"integrity": "sha512-BDYf/l1WVhWE+FHAW3FzZPtVlk9QsrwsxGzABmN4g8bTjmhazsId3h127pliDRRu5674k1Y2RWejbpN46N9ZhQ==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+			"integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
 			"cpu": [
 				"ppc64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -338,12 +351,13 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.3.tgz",
-			"integrity": "sha512-WViAxWYMRIi+prTJTyV1wnqd2mS2cPqJlN85oscVhXdb/ZTFJdrpaqm/uDsZPGKHtbg5TuRX/ymKdOSk41YZow==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+			"integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
 			"cpu": [
 				"riscv64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -353,12 +367,13 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.3.tgz",
-			"integrity": "sha512-Iw8lkNHUC4oGP1O/KhumcVy77u2s6+KUjieUqzEU3XuWJqZ+AY7uVMrrCbAiwWTkpQHkr00BuXH5RpC6Sb/7Ug==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+			"integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
 			"cpu": [
 				"s390x"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -368,12 +383,13 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.3.tgz",
-			"integrity": "sha512-0AGkWQMzeoeAtXQRNB3s4J1/T2XbigM2/Mn2yU1tQSmQRmHIZdkGbVq2A3aDdNslPyhb9/lH0S5GMTZ4xsjBqg==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+			"integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -401,12 +417,13 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.3.tgz",
-			"integrity": "sha512-4+rR/WHOxIVh53UIQIICryjdoKdHsFZFD4zLSonJ9RRw7bhKzVyXbnRPsWSfwybYqw9sB7ots/SYyufL1mBpEg==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+			"integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"netbsd"
@@ -434,12 +451,13 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.3.tgz",
-			"integrity": "sha512-cVpWnkx9IYg99EjGxa5Gc0XmqumtAwK3aoz7O4Dii2vko+qXbkHoujWA68cqXjhh6TsLaQelfDO4MVnyr+ODeA==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+			"integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"openbsd"
@@ -467,12 +485,13 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.3.tgz",
-			"integrity": "sha512-RxmhKLbTCDAY2xOfrww6ieIZkZF+KBqG7S2Ako2SljKXRFi+0863PspK74QQ7JpmWwncChY25JTJSbVBYGQk2Q==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+			"integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"sunos"
@@ -482,12 +501,13 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.3.tgz",
-			"integrity": "sha512-0r36VeEJ4efwmofxVJRXDjVRP2jTmv877zc+i+Pc7MNsIr38NfsjkQj23AfF7l0WbB+RQ7VUb+LDiqC/KY/M/A==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+			"integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -497,12 +517,13 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.3.tgz",
-			"integrity": "sha512-wgO6rc7uGStH22nur4aLFcq7Wh86bE9cOFmfTr/yxN3BXvDEdCSXyKkO+U5JIt53eTOgC47v9k/C1bITWL/Teg==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+			"integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
 			"cpu": [
 				"ia32"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -512,12 +533,13 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.3.tgz",
-			"integrity": "sha512-FdVl64OIuiKjgXBjwZaJLKp0eaEckifbhn10dXWhysMJkWblg3OEEGKSIyhiD5RSgAya8WzP3DNkngtIg3Nt7g==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+			"integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -2566,10 +2588,11 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.3.tgz",
-			"integrity": "sha512-9n3AsBRe6sIyOc6kmoXg2ypCLgf3eZSraWFRpnkto+svt8cZNuKTkb1bhQcitBcvIqjNiK7K0J3KPmwGSfkA8g==",
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+			"integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
 			"hasInstallScript": true,
+			"license": "MIT",
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -2577,28 +2600,28 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/android-arm": "0.17.3",
-				"@esbuild/android-arm64": "0.17.3",
-				"@esbuild/android-x64": "0.17.3",
-				"@esbuild/darwin-arm64": "0.17.3",
-				"@esbuild/darwin-x64": "0.17.3",
-				"@esbuild/freebsd-arm64": "0.17.3",
-				"@esbuild/freebsd-x64": "0.17.3",
-				"@esbuild/linux-arm": "0.17.3",
-				"@esbuild/linux-arm64": "0.17.3",
-				"@esbuild/linux-ia32": "0.17.3",
-				"@esbuild/linux-loong64": "0.17.3",
-				"@esbuild/linux-mips64el": "0.17.3",
-				"@esbuild/linux-ppc64": "0.17.3",
-				"@esbuild/linux-riscv64": "0.17.3",
-				"@esbuild/linux-s390x": "0.17.3",
-				"@esbuild/linux-x64": "0.17.3",
-				"@esbuild/netbsd-x64": "0.17.3",
-				"@esbuild/openbsd-x64": "0.17.3",
-				"@esbuild/sunos-x64": "0.17.3",
-				"@esbuild/win32-arm64": "0.17.3",
-				"@esbuild/win32-ia32": "0.17.3",
-				"@esbuild/win32-x64": "0.17.3"
+				"@esbuild/android-arm": "0.17.19",
+				"@esbuild/android-arm64": "0.17.19",
+				"@esbuild/android-x64": "0.17.19",
+				"@esbuild/darwin-arm64": "0.17.19",
+				"@esbuild/darwin-x64": "0.17.19",
+				"@esbuild/freebsd-arm64": "0.17.19",
+				"@esbuild/freebsd-x64": "0.17.19",
+				"@esbuild/linux-arm": "0.17.19",
+				"@esbuild/linux-arm64": "0.17.19",
+				"@esbuild/linux-ia32": "0.17.19",
+				"@esbuild/linux-loong64": "0.17.19",
+				"@esbuild/linux-mips64el": "0.17.19",
+				"@esbuild/linux-ppc64": "0.17.19",
+				"@esbuild/linux-riscv64": "0.17.19",
+				"@esbuild/linux-s390x": "0.17.19",
+				"@esbuild/linux-x64": "0.17.19",
+				"@esbuild/netbsd-x64": "0.17.19",
+				"@esbuild/openbsd-x64": "0.17.19",
+				"@esbuild/sunos-x64": "0.17.19",
+				"@esbuild/win32-arm64": "0.17.19",
+				"@esbuild/win32-ia32": "0.17.19",
+				"@esbuild/win32-x64": "0.17.19"
 			}
 		},
 		"node_modules/esbuild-plugin-inline-worker": {
@@ -5542,10 +5565,11 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
 			},


### PR DESCRIPTION
## Summary
- Runs `npm audit fix` to resolve 2 high-severity picomatch advisories (ReDoS via extglob quantifiers, method injection in POSIX character classes)
- Only `package-lock.json` changes — no `package.json` dependency bump needed, purely a transitive resolution update
- 13 vulnerabilities remain (`brace-expansion`, `esbuild`), both with no upstream fix available yet; these come from the eslint plugin toolchain (devDependencies) and esbuild's dev-server, not runtime code shipped in the plugin

## Test plan
- [x] `npm audit` confirms picomatch no longer listed, count drops from 14 to 13
- [x] `npm run lint` runs successfully (pre-existing errors unrelated to this change, caused by uninitialized `supernote-typescript` submodule in this fresh worktree)
- [ ] Full `npm run build` requires submodule setup per CLAUDE.md; not re-verified here since this change doesn't touch build tooling