### PR TITLE
Fix Browse and Access failing on iOS by using requestUrl instead of fetch

### DIFF
--- a/src/FileListModal.ts
+++ b/src/FileListModal.ts
@@ -2,7 +2,7 @@ import { App, SuggestModal, Notice, MarkdownView, TFile } from 'obsidian';
 import SupernotePlugin from './main';
 import { SupernotePluginSettings, IP_VALIDATION_PATTERN } from 'settings';
 import { parseDeviceDate } from './deviceDate';
-import { fetchFromDevice } from './deviceFetch';
+import { fetchFromDevice, buildMultipartBody } from './deviceFetch';
 import { ErrorModal } from './ErrorModal';
 
 export interface SupernoteFile {
@@ -29,7 +29,7 @@ interface SupernoteResponse {
 export async function fetchSupernoteDirectory(ip: string, path: string): Promise<SupernoteFile[]> {
     const response = await fetchFromDevice(ip, path, 'Failed to load file list');
     if (!response.ok) {
-        throw new Error(`Failed to load file list: Supernote responded with an error (${response.statusText}).`);
+        throw new Error(`Failed to load file list: Supernote responded with an error (status ${response.status}).`);
     }
     const html = await response.text();
 
@@ -144,7 +144,7 @@ export class DownloadListModal extends FileListModal {
                 try {
                     const fileResponse = await fetchFromDevice(this.settings.directConnectIP, file.uri, 'Failed to download file');
                     if (!fileResponse.ok) {
-                        throw new Error(`Failed to download file: Supernote responded with an error (${fileResponse.statusText}).`);
+                        throw new Error(`Failed to download file: Supernote responded with an error (status ${fileResponse.status}).`);
                     }
 
                     const buffer = await fileResponse.arrayBuffer();
@@ -223,28 +223,25 @@ export class UploadListModal extends FileListModal {
                         return;
                     }
 
-                    // Create FormData with file payload
                     // Generate filename with .txt extension for markdown files
                     const uploadFilename = this.currentFile.extension === "md"
                         ? `${this.currentFile.basename}.txt`  // Change extension to .txt
                         : this.currentFile.name;
 
-                    const formData = new FormData();
                     const fileContent = this.currentFile.extension === "md"
-                        ? await this.app.vault.read(this.currentFile)
+                        ? new TextEncoder().encode(await this.app.vault.read(this.currentFile)).buffer
                         : await this.app.vault.readBinary(this.currentFile);
 
                     const mimeType = this.currentFile.extension === "md"
                         ? 'text/plain'  // Use text/plain for compatibility
                         : 'application/octet-stream';
 
-                    // Use modified filename in the FormData
-                    formData.append('file', new Blob([fileContent], { type: mimeType }), uploadFilename);
+                    const { body, contentType } = buildMultipartBody('file', uploadFilename, mimeType, fileContent);
 
                     const response = await fetchFromDevice(this.settings.directConnectIP, this.currentPath, 'Upload failed', {
                         method: "POST",
-                        mode: 'cors',
-                        body: formData
+                        contentType,
+                        body
                     });
 
                     if (!response.ok) {

--- a/src/FileListModal.ts
+++ b/src/FileListModal.ts
@@ -2,7 +2,7 @@ import { App, SuggestModal, Notice, MarkdownView, TFile } from 'obsidian';
 import SupernotePlugin from './main';
 import { SupernotePluginSettings, IP_VALIDATION_PATTERN } from 'settings';
 import { parseDeviceDate } from './deviceDate';
-import { fetchFromDevice, buildMultipartBody } from './deviceFetch';
+import { fetchFromDevice, buildMultipartBody, DEVICE_TRANSFER_TIMEOUT_MS } from './deviceFetch';
 import { ErrorModal } from './ErrorModal';
 
 export interface SupernoteFile {
@@ -142,7 +142,9 @@ export class DownloadListModal extends FileListModal {
                 this.open();
             } else {
                 try {
-                    const fileResponse = await fetchFromDevice(this.settings.directConnectIP, file.uri, 'Failed to download file');
+                    const fileResponse = await fetchFromDevice(this.settings.directConnectIP, file.uri, 'Failed to download file', {
+                        timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS,
+                    });
                     if (!fileResponse.ok) {
                         throw new Error(`Failed to download file: Supernote responded with an error (status ${fileResponse.status}).`);
                     }
@@ -241,7 +243,8 @@ export class UploadListModal extends FileListModal {
                     const response = await fetchFromDevice(this.settings.directConnectIP, this.currentPath, 'Upload failed', {
                         method: "POST",
                         contentType,
-                        body
+                        body,
+                        timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS,
                     });
 
                     if (!response.ok) {

--- a/src/ImportTodayModal.ts
+++ b/src/ImportTodayModal.ts
@@ -1,7 +1,7 @@
 import { App, Modal, Notice, Editor } from 'obsidian';
 import SupernotePlugin from './main';
 import { SupernoteFile, fetchSupernoteDirectory } from './FileListModal';
-import { fetchFromDevice } from './deviceFetch';
+import { fetchFromDevice, DEVICE_TRANSFER_TIMEOUT_MS } from './deviceFetch';
 import { parseDeviceDate, isSameLocalDay, todayLocalMidnight, formatDateInputValue, parseDateInputValue } from './deviceDate';
 
 interface ScannedNote {
@@ -150,7 +150,9 @@ export class ImportTodayModal extends Modal {
         let combined = '';
         try {
             for (const file of chosen) {
-                const response = await fetchFromDevice(ip, file.uri, `Failed to download ${file.name}`);
+                const response = await fetchFromDevice(ip, file.uri, `Failed to download ${file.name}`, {
+                    timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS,
+                });
                 if (!response.ok) {
                     throw new Error(`Failed to download ${file.name}: Supernote responded with an error (status ${response.status}).`);
                 }

--- a/src/ImportTodayModal.ts
+++ b/src/ImportTodayModal.ts
@@ -152,7 +152,7 @@ export class ImportTodayModal extends Modal {
             for (const file of chosen) {
                 const response = await fetchFromDevice(ip, file.uri, `Failed to download ${file.name}`);
                 if (!response.ok) {
-                    throw new Error(`Failed to download ${file.name}: Supernote responded with an error (${response.statusText}).`);
+                    throw new Error(`Failed to download ${file.name}: Supernote responded with an error (status ${response.status}).`);
                 }
                 const buffer = await response.arrayBuffer();
                 combined += await this.plugin.vaultWriter.buildInsertableMarkdown(file.name, buffer, this.targetPath);

--- a/src/deviceFetch.test.ts
+++ b/src/deviceFetch.test.ts
@@ -1,65 +1,116 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { fetchFromDevice, DEVICE_REQUEST_TIMEOUT_MS } from './deviceFetch';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { requestUrl } from 'obsidian';
+import { fetchFromDevice, buildMultipartBody, DEVICE_REQUEST_TIMEOUT_MS } from './deviceFetch';
+
+vi.mock('obsidian', () => ({
+    requestUrl: vi.fn(),
+}));
+
+// deviceFetch.ts calls window.setTimeout/clearTimeout (needed for Obsidian's
+// popout windows at runtime); vitest's default node environment has no
+// `window`, so alias it to the global timer functions for these tests.
+vi.stubGlobal('window', globalThis);
+
+function mockResponse(overrides: Partial<Awaited<ReturnType<typeof requestUrl>>> = {}) {
+    return {
+        status: 200,
+        headers: {},
+        arrayBuffer: new ArrayBuffer(0),
+        json: undefined,
+        text: '',
+        ...overrides,
+    };
+}
 
 describe('fetchFromDevice', () => {
     afterEach(() => {
-        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+        vi.useRealTimers();
     });
 
-    it('returns the response on success', async () => {
-        const response = new Response('ok', { status: 200 });
-        const fetchMock = vi.fn().mockResolvedValue(response);
-        vi.stubGlobal('fetch', fetchMock);
+    it('returns an ok response on success', async () => {
+        vi.mocked(requestUrl).mockResolvedValue(mockResponse({ status: 200, text: 'ok' }));
 
         const result = await fetchFromDevice('192.168.1.50', '/path', 'Failed to load file list');
 
-        expect(result).toBe(response);
-        expect(fetchMock).toHaveBeenCalledWith(
-            'http://192.168.1.50:8089/path',
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- vitest types expect.any()'s return as `any` by design
-            expect.objectContaining({ signal: expect.any(AbortSignal) }),
+        expect(result.ok).toBe(true);
+        expect(result.status).toBe(200);
+        expect(await result.text()).toBe('ok');
+        expect(requestUrl).toHaveBeenCalledWith(
+            expect.objectContaining({ url: 'http://192.168.1.50:8089/path', throw: false }),
         );
     });
 
-    it('forwards request init options like method and body alongside the timeout signal', async () => {
-        const fetchMock = vi.fn().mockResolvedValue(new Response('ok'));
-        vi.stubGlobal('fetch', fetchMock);
-        const body = new FormData();
+    it('reports non-2xx statuses as not ok instead of throwing', async () => {
+        vi.mocked(requestUrl).mockResolvedValue(mockResponse({ status: 404, text: 'not found' }));
 
-        await fetchFromDevice('192.168.1.50', '/path', 'Upload failed', { method: 'POST', body });
+        const result = await fetchFromDevice('192.168.1.50', '/path', 'Failed to load file list');
 
-        expect(fetchMock).toHaveBeenCalledWith(
-            'http://192.168.1.50:8089/path',
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- vitest types expect.any()'s return as `any` by design
-            expect.objectContaining({ method: 'POST', body, signal: expect.any(AbortSignal) }),
+        expect(result.ok).toBe(false);
+        expect(result.status).toBe(404);
+    });
+
+    it('forwards request init options like method, body, and contentType', async () => {
+        vi.mocked(requestUrl).mockResolvedValue(mockResponse());
+
+        await fetchFromDevice('192.168.1.50', '/path', 'Upload failed', {
+            method: 'POST',
+            body: 'payload',
+            contentType: 'text/plain',
+        });
+
+        expect(requestUrl).toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'POST', body: 'payload', contentType: 'text/plain' }),
         );
     });
 
-    it('reports the device as unresponsive when the request times out', async () => {
-        const fetchMock = vi.fn().mockRejectedValue(new DOMException('The operation timed out.', 'TimeoutError'));
-        vi.stubGlobal('fetch', fetchMock);
+    describe('with fake timers', () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
 
-        await expect(fetchFromDevice('192.168.1.50', '/path', 'Failed to load file list')).rejects.toThrow(
-            `Failed to load file list: Supernote at 192.168.1.50 did not respond within ${DEVICE_REQUEST_TIMEOUT_MS / 1000}s. `
-            + `Check that it's on the same network and "Browse and Access" is turned on.`
-        );
-    });
+        it('reports the device as unresponsive when the request times out', async () => {
+            const pending = new Promise(() => { /* never resolves */ });
+            vi.mocked(requestUrl).mockReturnValue(Object.assign(pending, {
+                arrayBuffer: pending.then(() => new ArrayBuffer(0)),
+                json: pending.then(() => undefined),
+                text: pending.then(() => ''),
+            }) as ReturnType<typeof requestUrl>);
 
-    it('treats an AbortError the same as a timeout', async () => {
-        const fetchMock = vi.fn().mockRejectedValue(new DOMException('The operation was aborted.', 'AbortError'));
-        vi.stubGlobal('fetch', fetchMock);
-
-        await expect(fetchFromDevice('192.168.1.50', '/path', 'Failed to load file list')).rejects.toThrow(
-            /did not respond within/
-        );
+            const assertion = expect(fetchFromDevice('192.168.1.50', '/path', 'Failed to load file list')).rejects.toThrow(
+                `Failed to load file list: Supernote at 192.168.1.50 did not respond within ${DEVICE_REQUEST_TIMEOUT_MS / 1000}s. `
+                + `Check that it's on the same network and "Browse and Access" is turned on.`
+            );
+            await vi.advanceTimersByTimeAsync(DEVICE_REQUEST_TIMEOUT_MS);
+            await assertion;
+        });
     });
 
     it('reports an unreachable device distinctly from a timeout', async () => {
-        const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
-        vi.stubGlobal('fetch', fetchMock);
+        vi.mocked(requestUrl).mockRejectedValue(new Error('net::ERR_CONNECTION_REFUSED'));
 
         await expect(fetchFromDevice('192.168.1.50', '/path', 'Failed to load file list')).rejects.toThrow(
-            'Failed to load file list: could not reach Supernote at 192.168.1.50 (Failed to fetch).'
+            'Failed to load file list: could not reach Supernote at 192.168.1.50 (net::ERR_CONNECTION_REFUSED).'
+        );
+    });
+});
+
+describe('buildMultipartBody', () => {
+    it('encodes a single-part multipart/form-data body with the given field, filename, and content', () => {
+        const content = new TextEncoder().encode('hello world').buffer;
+
+        const { body, contentType } = buildMultipartBody('file', 'note.txt', 'text/plain', content);
+
+        expect(contentType).toMatch(/^multipart\/form-data; boundary=/);
+        const boundary = contentType.split('boundary=')[1];
+        const decoded = new TextDecoder().decode(body);
+
+        expect(decoded).toBe(
+            `--${boundary}\r\n`
+            + `Content-Disposition: form-data; name="file"; filename="note.txt"\r\n`
+            + `Content-Type: text/plain\r\n\r\n`
+            + `hello world`
+            + `\r\n--${boundary}--\r\n`
         );
     });
 });

--- a/src/deviceFetch.test.ts
+++ b/src/deviceFetch.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { requestUrl } from 'obsidian';
-import { fetchFromDevice, buildMultipartBody, DEVICE_REQUEST_TIMEOUT_MS } from './deviceFetch';
+import { fetchFromDevice, buildMultipartBody, DEVICE_REQUEST_TIMEOUT_MS, DEVICE_TRANSFER_TIMEOUT_MS } from './deviceFetch';
 
 vi.mock('obsidian', () => ({
     requestUrl: vi.fn(),
@@ -64,24 +64,52 @@ describe('fetchFromDevice', () => {
         );
     });
 
+    it('does not forward timeoutMs to requestUrl, which has no such option', async () => {
+        vi.mocked(requestUrl).mockResolvedValue(mockResponse());
+
+        await fetchFromDevice('192.168.1.50', '/path', 'Upload failed', { timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS });
+
+        const [[calledWith]] = vi.mocked(requestUrl).mock.calls;
+        expect(calledWith).not.toHaveProperty('timeoutMs');
+    });
+
     describe('with fake timers', () => {
         beforeEach(() => {
             vi.useFakeTimers();
         });
 
-        it('reports the device as unresponsive when the request times out', async () => {
+        function mockNeverResolving() {
             const pending = new Promise(() => { /* never resolves */ });
             vi.mocked(requestUrl).mockReturnValue(Object.assign(pending, {
                 arrayBuffer: pending.then(() => new ArrayBuffer(0)),
                 json: pending.then(() => undefined),
                 text: pending.then(() => ''),
             }) as ReturnType<typeof requestUrl>);
+        }
+
+        it('reports the device as unresponsive when the request times out', async () => {
+            mockNeverResolving();
 
             const assertion = expect(fetchFromDevice('192.168.1.50', '/path', 'Failed to load file list')).rejects.toThrow(
                 `Failed to load file list: Supernote at 192.168.1.50 did not respond within ${DEVICE_REQUEST_TIMEOUT_MS / 1000}s. `
                 + `Check that it's on the same network and "Browse and Access" is turned on.`
             );
             await vi.advanceTimersByTimeAsync(DEVICE_REQUEST_TIMEOUT_MS);
+            await assertion;
+        });
+
+        it('honors a longer timeoutMs override for file transfers', async () => {
+            mockNeverResolving();
+
+            const assertion = expect(
+                fetchFromDevice('192.168.1.50', '/path', 'Failed to download file', { timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS })
+            ).rejects.toThrow(
+                `Failed to download file: Supernote at 192.168.1.50 did not respond within ${DEVICE_TRANSFER_TIMEOUT_MS / 1000}s. `
+                + `Check that it's on the same network and "Browse and Access" is turned on.`
+            );
+            // Confirm it hasn't already rejected at the short default timeout.
+            await vi.advanceTimersByTimeAsync(DEVICE_REQUEST_TIMEOUT_MS);
+            await vi.advanceTimersByTimeAsync(DEVICE_TRANSFER_TIMEOUT_MS - DEVICE_REQUEST_TIMEOUT_MS);
             await assertion;
         });
     });

--- a/src/deviceFetch.ts
+++ b/src/deviceFetch.ts
@@ -13,7 +13,13 @@ import { requestUrl, RequestUrlParam } from 'obsidian';
 // restrictions). `requestUrl` goes through Obsidian's native networking
 // layer instead of the WebView's, so it isn't subject to those restrictions
 // on either desktop or mobile.
+//
+// This short timeout is for metadata calls (directory listing) where a
+// non-responding device should fail fast. File transfers (download/upload)
+// pass a much longer `timeoutMs` below since moving the actual file bytes
+// over a slow LAN/Tailscale link can legitimately take longer.
 export const DEVICE_REQUEST_TIMEOUT_MS = 3000;
+export const DEVICE_TRANSFER_TIMEOUT_MS = 120_000;
 
 export interface DeviceResponse {
     ok: boolean;
@@ -22,7 +28,9 @@ export interface DeviceResponse {
     arrayBuffer(): Promise<ArrayBuffer>;
 }
 
-export type DeviceRequestInit = Pick<RequestUrlParam, 'method' | 'body' | 'contentType' | 'headers'>;
+export type DeviceRequestInit = Pick<RequestUrlParam, 'method' | 'body' | 'contentType' | 'headers'> & {
+    timeoutMs?: number;
+};
 
 // `requestUrl`'s body can only be a string or ArrayBuffer (no FormData/Blob
 // support like `fetch`), so a file upload has to be multipart/form-data-
@@ -56,11 +64,13 @@ export async function fetchFromDevice(
     context: string,
     init: DeviceRequestInit = {},
 ): Promise<DeviceResponse> {
+    const { timeoutMs = DEVICE_REQUEST_TIMEOUT_MS, ...requestInit } = init;
+
     let timeoutHandle: ReturnType<typeof window.setTimeout>;
     const timeout = new Promise<never>((_, reject) => {
         timeoutHandle = window.setTimeout(
             () => reject(new DOMException('The operation timed out.', 'TimeoutError')),
-            DEVICE_REQUEST_TIMEOUT_MS,
+            timeoutMs,
         );
     });
 
@@ -69,7 +79,7 @@ export async function fetchFromDevice(
             requestUrl({
                 url: `http://${ip}:8089${path}`,
                 throw: false,
-                ...init,
+                ...requestInit,
             }),
             timeout,
         ]);
@@ -85,7 +95,7 @@ export async function fetchFromDevice(
         const name = (err as { name?: string } | null)?.name;
         if (name === 'TimeoutError' || name === 'AbortError') {
             throw new Error(
-                `${context}: Supernote at ${ip} did not respond within ${DEVICE_REQUEST_TIMEOUT_MS / 1000}s. `
+                `${context}: Supernote at ${ip} did not respond within ${timeoutMs / 1000}s. `
                 + `Check that it's on the same network and "Browse and Access" is turned on.`
             );
         }

--- a/src/deviceFetch.ts
+++ b/src/deviceFetch.ts
@@ -1,22 +1,87 @@
-// Wraps `fetch` requests to the Supernote's local "Browse and Access" HTTP
-// server so every call site (listing, download, upload) times out and fails
-// with the same clear message instead of hanging until the OS's TCP timeout
-// (which can take a minute or more on an unreachable device and, to the
-// user, looks indistinguishable from the plugin just doing nothing).
+import { requestUrl, RequestUrlParam } from 'obsidian';
+
+// Wraps Obsidian's `requestUrl` for requests to the Supernote's local "Browse
+// and Access" HTTP server so every call site (listing, download, upload)
+// times out and fails with the same clear message instead of hanging until
+// the OS's TCP timeout (which can take a minute or more on an unreachable
+// device and, to the user, looks indistinguishable from the plugin just
+// doing nothing).
+//
+// This uses `requestUrl` rather than the global `fetch` because Obsidian's
+// mobile app runs inside a WKWebView, which blocks cross-origin `fetch()`
+// calls to a plain-HTTP LAN device (no CORS headers, mixed-content
+// restrictions). `requestUrl` goes through Obsidian's native networking
+// layer instead of the WebView's, so it isn't subject to those restrictions
+// on either desktop or mobile.
 export const DEVICE_REQUEST_TIMEOUT_MS = 3000;
+
+export interface DeviceResponse {
+    ok: boolean;
+    status: number;
+    text(): Promise<string>;
+    arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+export type DeviceRequestInit = Pick<RequestUrlParam, 'method' | 'body' | 'contentType' | 'headers'>;
+
+// `requestUrl`'s body can only be a string or ArrayBuffer (no FormData/Blob
+// support like `fetch`), so a file upload has to be multipart/form-data-
+// encoded by hand.
+export function buildMultipartBody(
+    fieldName: string,
+    filename: string,
+    mimeType: string,
+    content: ArrayBuffer,
+): { body: ArrayBuffer; contentType: string } {
+    const boundary = `----ObsidianFormBoundary${Date.now().toString(16)}${Math.random().toString(16).slice(2)}`;
+    const encoder = new TextEncoder();
+    const head = encoder.encode(
+        `--${boundary}\r\n`
+        + `Content-Disposition: form-data; name="${fieldName}"; filename="${filename}"\r\n`
+        + `Content-Type: ${mimeType}\r\n\r\n`
+    );
+    const tail = encoder.encode(`\r\n--${boundary}--\r\n`);
+
+    const body = new Uint8Array(head.length + content.byteLength + tail.length);
+    body.set(head, 0);
+    body.set(new Uint8Array(content), head.length);
+    body.set(tail, head.length + content.byteLength);
+
+    return { body: body.buffer, contentType: `multipart/form-data; boundary=${boundary}` };
+}
 
 export async function fetchFromDevice(
     ip: string,
     path: string,
     context: string,
-    init: RequestInit = {},
-): Promise<Response> {
+    init: DeviceRequestInit = {},
+): Promise<DeviceResponse> {
+    let timeoutHandle: ReturnType<typeof window.setTimeout>;
+    const timeout = new Promise<never>((_, reject) => {
+        timeoutHandle = window.setTimeout(
+            () => reject(new DOMException('The operation timed out.', 'TimeoutError')),
+            DEVICE_REQUEST_TIMEOUT_MS,
+        );
+    });
+
     try {
-        return await fetch(`http://${ip}:8089${path}`, {
-            ...init,
-            signal: AbortSignal.timeout(DEVICE_REQUEST_TIMEOUT_MS),
-        });
+        const response = await Promise.race([
+            requestUrl({
+                url: `http://${ip}:8089${path}`,
+                throw: false,
+                ...init,
+            }),
+            timeout,
+        ]);
+        window.clearTimeout(timeoutHandle!);
+        return {
+            ok: response.status >= 200 && response.status < 300,
+            status: response.status,
+            text: async () => response.text,
+            arrayBuffer: async () => response.arrayBuffer,
+        };
     } catch (err) {
+        window.clearTimeout(timeoutHandle!);
         const name = (err as { name?: string } | null)?.name;
         if (name === 'TimeoutError' || name === 'AbortError') {
             throw new Error(

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { installAtPolyfill } from './polyfills';
-import { App, Modal, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, loadPdfJs, Scope, SearchComponent, setIcon } from 'obsidian';
+import { App, Modal, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, loadPdfJs, Scope, SearchComponent, setIcon, Platform } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS } from './settings';
 import { SupernoteX, fetchMirrorFrame, createPdfContext, addPdfPage } from 'supernote-typescript';
 import { encode } from 'image-js';
@@ -1223,6 +1223,23 @@ export default class SupernotePlugin extends Plugin {
 			id: 'insert-supernote-screen-mirror-image',
 			name: 'Insert a supernote screen mirroring image as attachment',
 			editorCallback: async (editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
+				// Screen mirroring is an indefinitely-open multipart MJPEG stream read
+				// with a raw `fetch()` + ReadableStream reader (see fetchMirrorFrame in
+				// supernote-typescript). Mobile Obsidian runs in a WKWebView, which
+				// blocks cross-origin fetch() to a plain-HTTP LAN device, and
+				// Obsidian's mobile-safe `requestUrl` alternative can't substitute here
+				// because it only resolves once the whole response body finishes -
+				// which for this stream never happens. Fail fast with an actionable
+				// message instead of attempting (and mysteriously failing) the request.
+				if (Platform.isMobile) {
+					new ErrorModal(this.app, new Error(
+						"Screen mirroring insert isn't supported on Obsidian mobile: it needs a continuous network "
+						+ "stream that mobile's WebView can't read. Use \"Browse and Access\" to insert a file "
+						+ "instead, or run this command on desktop."
+					)).open();
+					return;
+				}
+
 				// generate a unique filename for the mirror based on the current note path
 				const ts = generateTimestamp();
 				const f = this.app.workspace.activeEditor?.file?.basename || '';


### PR DESCRIPTION
## Summary
- Fixes #79: on Obsidian mobile (iOS/Android), the plugin's Browse and Access commands (file listing, download, upload) and screen mirroring insert all failed with a generic "Load failed" error, while working fine on desktop.
- Root cause: Obsidian mobile runs in a WKWebView, which blocks cross-origin `fetch()` to a plain-HTTP LAN device (no CORS headers from the Supernote, plus mixed-content restrictions). Desktop Electron doesn't enforce this the same way, so it worked there.
- `src/deviceFetch.ts` now uses Obsidian's `requestUrl` API instead of `fetch`, which goes through native networking rather than the WebView and isn't subject to those restrictions on either platform. This fixes file listing, download, and upload (`FileListModal.ts`, `ImportTodayModal.ts`).
- The upload path previously built its request body with `FormData`, which `requestUrl` doesn't accept (only `string | ArrayBuffer`). Added `buildMultipartBody` to hand-encode a `multipart/form-data` body instead.
- Screen mirroring insert (`fetchMirrorFrame`, in the `supernote-typescript` submodule) reads a continuous MJPEG multipart stream via `fetch()`'s `ReadableStream`, aborting once one JPEG frame is captured. `requestUrl` has no streaming equivalent — it only resolves once the whole response completes, which this endpoint never does on its own. That's a real platform limitation, not something fixable client-side, so the command now fails fast on mobile with an explanation ("use Browse and Access instead, or run on desktop") rather than attempting a doomed network call.

## Test plan
- [x] `npm run build` (tsc + esbuild) passes
- [x] `npm test` (vitest) passes, including rewritten `deviceFetch.test.ts` mocking `obsidian`'s `requestUrl`
- [x] `npm run lint` passes with 0 errors (pre-existing warnings unrelated to this change remain)
- [ ] Manual verification on an actual iOS device (I don't have one handy — would appreciate confirmation from the issue reporter)