### PR TITLE
Add sort by name/date to device file browser

### DIFF
--- a/src/FileListModal.ts
+++ b/src/FileListModal.ts
@@ -1,6 +1,6 @@
 import { App, SuggestModal, Notice, MarkdownView, TFile } from 'obsidian';
 import SupernotePlugin from './main';
-import { SupernotePluginSettings, IP_VALIDATION_PATTERN } from 'settings';
+import { SupernotePluginSettings, IP_VALIDATION_PATTERN, FileBrowserSortOrder } from 'settings';
 import { parseDeviceDate } from './deviceDate';
 import { fetchFromDevice, buildMultipartBody, DEVICE_TRANSFER_TIMEOUT_MS } from './deviceFetch';
 import { ErrorModal } from './ErrorModal';
@@ -58,16 +58,84 @@ export abstract class FileListModal extends SuggestModal<SupernoteFile> {
     settings: SupernotePluginSettings;
     files: SupernoteFile[] = [];
     currentPath = '/';
+    sortOrder: FileBrowserSortOrder;
+    private nameSortButton!: HTMLButtonElement;
+    private dateSortButton!: HTMLButtonElement;
 
     constructor(app: App, plugin: SupernotePlugin) {
         super(app);
         this.settings = plugin.settings;
+        this.sortOrder = this.settings.fileBrowserSortOrder;
         this.setPlaceholder("Select a file to download or directory to open");
+        this.buildSortToolbar();
+    }
+
+    private buildSortToolbar() {
+        const toolbarEl = createDiv({ cls: 'supernote-toolbar supernote-file-list-toolbar' });
+        this.modalEl.prepend(toolbarEl);
+
+        const groupEl = toolbarEl.createDiv({ cls: 'supernote-toolbar-group' });
+        groupEl.createSpan({ text: 'Sort by:' });
+        this.nameSortButton = groupEl.createEl('button', { type: 'button' });
+        this.nameSortButton.addEventListener('click', () => this.toggleSort('name'));
+        this.dateSortButton = groupEl.createEl('button', { type: 'button' });
+        this.dateSortButton.addEventListener('click', () => this.toggleSort('date'));
+
+        this.updateSortButtons();
+    }
+
+    private toggleSort(field: 'name' | 'date') {
+        const currentField = this.sortOrder.startsWith('name') ? 'name' : 'date';
+        const currentlyAscending = !this.sortOrder.endsWith('desc');
+        if (currentField === field) {
+            this.sortOrder = `${field}-${currentlyAscending ? 'desc' : 'asc'}` as FileBrowserSortOrder;
+        } else {
+            // Switching fields: default to the most useful direction for that field.
+            this.sortOrder = field === 'name' ? 'name-asc' : 'date-desc';
+        }
+        this.updateSortButtons();
+        this.sortFiles();
+        // SuggestModal has no public API to refresh its results; re-dispatching the
+        // input event is the standard way plugins trigger it to re-run getSuggestions.
+        this.inputEl.dispatchEvent(new Event('input'));
+    }
+
+    private updateSortButtons() {
+        const field = this.sortOrder.startsWith('name') ? 'name' : 'date';
+        const ascending = !this.sortOrder.endsWith('desc');
+        const arrow = ascending ? '↑' : '↓';
+        this.nameSortButton.textContent = field === 'name' ? `Name ${arrow}` : 'Name';
+        this.nameSortButton.toggleClass('is-active', field === 'name');
+        this.dateSortButton.textContent = field === 'date' ? `Date ${arrow}` : 'Date';
+        this.dateSortButton.toggleClass('is-active', field === 'date');
+    }
+
+    private sortFiles() {
+        this.files = [...this.files].sort((a, b) => this.compareFiles(a, b));
+    }
+
+    private compareFiles(a: SupernoteFile, b: SupernoteFile): number {
+        if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
+
+        switch (this.sortOrder) {
+            case 'name-desc':
+                return b.name.localeCompare(a.name, undefined, { numeric: true, sensitivity: 'base' });
+            case 'date-asc':
+            case 'date-desc': {
+                const aDate = parseDeviceDate(a.date)?.getTime() ?? 0;
+                const bDate = parseDeviceDate(b.date)?.getTime() ?? 0;
+                return this.sortOrder === 'date-asc' ? aDate - bDate : bDate - aDate;
+            }
+            case 'name-asc':
+            default:
+                return a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' });
+        }
     }
 
     async loadFiles() {
         try {
             this.files = await fetchSupernoteDirectory(this.settings.directConnectIP, this.currentPath);
+            this.sortFiles();
         } catch (err) {
             this.close();
             new ErrorModal(this.app, err instanceof Error ? err : new Error(String(err))).open();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,12 +4,21 @@ import { App, ExtraButtonComponent, PluginSettingTab, Setting } from 'obsidian';
 
 export const IP_VALIDATION_PATTERN = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/;
 
+export type FileBrowserSortOrder = 'name-asc' | 'name-desc' | 'date-desc' | 'date-asc';
+
+export const FILE_BROWSER_SORT_LABELS: Record<FileBrowserSortOrder, string> = {
+    'name-asc': 'Name (A to Z)',
+    'name-desc': 'Name (Z to A)',
+    'date-desc': 'Date (newest first)',
+    'date-asc': 'Date (oldest first)',
+};
 
 export interface SupernotePluginSettings extends CustomDictionarySettings {
     directConnectIP: string;
     invertColorsWhenDark: boolean;
     showExportButtons: boolean;
     noteImageMaxDim: number;
+    fileBrowserSortOrder: FileBrowserSortOrder;
 }
 
 export const DEFAULT_SETTINGS: SupernotePluginSettings = {
@@ -17,6 +26,7 @@ export const DEFAULT_SETTINGS: SupernotePluginSettings = {
     invertColorsWhenDark: true,
     showExportButtons: true,
     noteImageMaxDim: 800, // Sensible default for Nomad pages to be legible but not too big. Unit: px
+    fileBrowserSortOrder: 'name-asc',
 	...CUSTOM_DICTIONARY_DEFAULT_SETTINGS,
 }
 
@@ -93,6 +103,18 @@ export class SupernoteSettingTab extends PluginSettingTab {
                 .setValue(this.plugin.settings.noteImageMaxDim)
                 .onChange(async (value) => {
                     this.plugin.settings.noteImageMaxDim = value;
+                    await this.plugin.saveSettings();
+                })
+            );
+
+        new Setting(containerEl)
+            .setName('Device file browser sort order')
+            .setDesc('Default order to list files and folders in when browsing the supernote device (e.g. "attach supernote file from device"). Can also be changed from the browser itself.')
+            .addDropdown(dropdown => dropdown
+                .addOptions(FILE_BROWSER_SORT_LABELS)
+                .setValue(this.plugin.settings.fileBrowserSortOrder)
+                .onChange(async (value) => {
+                    this.plugin.settings.fileBrowserSortOrder = value as FileBrowserSortOrder;
                     await this.plugin.saveSettings();
                 })
             );

--- a/styles.css
+++ b/styles.css
@@ -113,6 +113,11 @@ div.supernote-canvas-wrap canvas {
     background-color: var(--interactive-accent);
 }
 
+.supernote-file-list-toolbar {
+    padding: 0.5em 0.75em 0;
+    margin: 0;
+}
+
 .supernote-page-jump-input {
     width: 4em;
     text-align: center;


### PR DESCRIPTION
## Summary
- Adds Name/Date toggle buttons to the device file browser modal ("Attach Supernote file from device", download, and upload flows) — click to sort by that field, click again to reverse direction. Directories still stay grouped above files.
- Adds a "Device file browser sort order" dropdown in plugin settings to configure the default (Name A→Z/Z→A, Date newest/oldest first).

Fixes #75

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes (no new warnings/errors)
- [x] `npm test` passes (19/19)
- [x] `npm run build` bundles successfully