### PR TITLE
Fix exported PNG filenames to use 1-based page numbers

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -230,7 +230,7 @@ class VaultWriter {
 
 		const imgs: TFile[] = [];
 		for (let i = 0; i < images.length; i++) {
-			const filename = await this.app.fileManager.getAvailablePathForAttachment(`${basename}-${i}.png`);
+			const filename = await this.app.fileManager.getAvailablePathForAttachment(`${basename}-${i + 1}.png`);
 			const buffer = dataUrlToBuffer(images[i]);
 			imgs.push(await this.app.vault.createBinary(filename, buffer));
 		}
@@ -691,7 +691,7 @@ export class SupernoteView extends FileView {
 				});
 
 				saveButton.addEventListener("click", () => void (async () => {
-					const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}-${i}.png`);
+					const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}-${i + 1}.png`);
 					const buffer = dataUrlToBuffer(imageDataUrl);
 					await this.app.vault.createBinary(filename, buffer);
 				})());


### PR DESCRIPTION
## Summary
- Exported page images were named after the 0-based loop index instead of the notebook's page number: page 1 became `NoteTitle-0.png`, page 73 became `NoteTitle-72.png`.
- Both `VaultWriter.writeImageFiles` (used by "Attach note as image files") and the per-page "Save image to vault" button in the note viewer now use `i + 1` when building the filename, so exported filenames match the notebook's own page numbers.

Fixes #70

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (22/22)
- [ ] Manually export a multi-page note in Obsidian and confirm page 1 saves as `NoteTitle-1.png`