### PR TITLE
Scope button.mod-cta display:block rule to plugin's own UI

### DIFF
--- a/src/ImportTodayModal.ts
+++ b/src/ImportTodayModal.ts
@@ -31,6 +31,10 @@ export class ImportTodayModal extends Modal {
     async onOpen() {
         const { contentEl } = this;
         contentEl.empty();
+        // Scopes styles.css's button.mod-cta display:block rule to just this
+        // modal, instead of it applying to every CTA button in Obsidian (see
+        // issue #74 — an unscoped rule shifted button text down app-wide).
+        contentEl.addClass('supernote-import-modal');
         contentEl.createEl('h2', { text: 'Import supernote pages' });
         const status = contentEl.createEl('p', { text: 'Scanning device for notes…' });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -461,6 +461,11 @@ export class SupernoteView extends FileView {
 	}
 
 	async onOpen(): Promise<void> {
+		// Scopes styles.css's button.mod-cta display:block rule to just this
+		// view, instead of it applying to every CTA button in Obsidian (see
+		// issue #74 — an unscoped rule shifted button text down app-wide).
+		this.contentEl.addClass('supernote-view-content');
+
 		// Obsidian's .view-content has its own top padding, leaving a gap
 		// above the sticky toolbar. A previous attempt cancelled it with a
 		// negative margin on the (sticky) header itself, which fought with

--- a/styles.css
+++ b/styles.css
@@ -26,7 +26,8 @@
     filter: invert(1);
 }
 
-button.mod-cta {
+.supernote-view-content button.mod-cta,
+.supernote-import-modal button.mod-cta {
     display: block;
 }
 


### PR DESCRIPTION
## Summary
- `styles.css` had an unscoped `button.mod-cta { display: block; }` rule that applied to every CTA button in Obsidian (settings dialogs, other plugins, core UI), not just this plugin's own buttons — causing button text to shift down throughout the app.
- Scopes the rule to `.supernote-view-content button.mod-cta` and `.supernote-import-modal button.mod-cta`, and adds those classes to `SupernoteView`'s content element and `ImportTodayModal`'s content element respectively.

Fixes #74

## Test plan
- [x] `tsc -noEmit` passes
- [ ] Manually verify export/save/import buttons in the plugin still render correctly, and that other Obsidian CTA buttons (e.g. Settings save button) no longer shift text down