### PR TITLE
Fix ESLint warnings from eslint-plugin-obsidianmd

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -33,4 +33,14 @@ export default defineConfig(
 		},
 	},
 	...obsidianmd.configs.recommended,
+	{
+		// obsidianmd/no-global-this exists for popout-window compatibility in
+		// plugin runtime code; it doesn't apply to test setup, where `globalThis`
+		// is the only thing available to stand in for the `window` Vitest's node
+		// environment doesn't provide.
+		files: ['**/*.test.ts'],
+		rules: {
+			'obsidianmd/no-global-this': 'off',
+		},
+	},
 );

--- a/src/main.ts
+++ b/src/main.ts
@@ -1192,7 +1192,7 @@ export default class SupernotePlugin extends Plugin {
 		this.addSettingTab(new SupernoteSettingTab(this.app, this));
 
 		this.addCommand({
-			id: 'attach-supernote-file-from-device',
+			id: 'attach-file-from-device',
 			name: 'Attach supernote file from device',
 			callback: () => {
 				if (this.settings.directConnectIP.length === 0) {
@@ -1204,7 +1204,7 @@ export default class SupernotePlugin extends Plugin {
 		});
 
 		this.addCommand({
-			id: 'upload-file-to-supernote',
+			id: 'upload-file-to-device',
 			name: 'Upload the current file to a supernote device',
 			callback: () => {
 				if (this.settings.directConnectIP.length === 0) {
@@ -1225,7 +1225,7 @@ export default class SupernotePlugin extends Plugin {
 		this.registerExtensions(['note'], VIEW_TYPE_SUPERNOTE);
 
 		this.addCommand({
-			id: 'insert-supernote-screen-mirror-image',
+			id: 'insert-screen-mirror-image',
 			name: 'Insert a supernote screen mirroring image as attachment',
 			editorCallback: async (editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
 				// Screen mirroring is an indefinitely-open multipart MJPEG stream read
@@ -1270,7 +1270,7 @@ export default class SupernotePlugin extends Plugin {
 		});
 
 		this.addCommand({
-			id: 'export-supernote-note-as-files',
+			id: 'export-note-as-files',
 			name: 'Export this supernote note as a Markdown and PNG files as attachments',
 			checkCallback: (checking: boolean) => {
 				const file = this.app.workspace.getActiveFile();
@@ -1295,7 +1295,7 @@ export default class SupernotePlugin extends Plugin {
 		});
 
 		this.addCommand({
-			id: 'export-supernote-note-as-pdf',
+			id: 'export-note-as-pdf',
 			name: 'Export this supernote note as PDF',
 			checkCallback: (checking: boolean) => {
 				const file = this.app.workspace.getActiveFile();
@@ -1320,7 +1320,7 @@ export default class SupernotePlugin extends Plugin {
 		});
 
 		this.addCommand({
-			id: 'export-supernote-note-as-markdown',
+			id: 'export-note-as-markdown',
 			name: 'Export this supernote note as a Markdown file attachment',
 			checkCallback: (checking: boolean) => {
 				const file = this.app.workspace.getActiveFile();
@@ -1345,7 +1345,7 @@ export default class SupernotePlugin extends Plugin {
 		});
 
 		this.addCommand({
-			id: 'import-todays-supernote-pages',
+			id: 'import-todays-pages',
 			name: "Import new or edited supernote pages by date as images",
 			editorCallback: (editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
 				if (this.settings.directConnectIP.length === 0) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,6 +13,43 @@ export const FILE_BROWSER_SORT_LABELS: Record<FileBrowserSortOrder, string> = {
     'date-asc': 'Date (oldest first)',
 };
 
+// Obsidian's declarative settings API (1.13+): PluginSettingTab.getSettingDefinitions().
+// Not present in the `obsidian` devDependency's types (pinned pre-1.13, see CLAUDE.md on
+// why this repo can't casually bump it), so the shapes below are hand-typed to match the
+// real runtime API rather than pulled in from the package.
+interface SettingControlBase<V> {
+    key: string;
+    validate?: (value: V) => string | void;
+}
+interface SettingTextControl extends SettingControlBase<string> {
+    type: 'text';
+    placeholder?: string;
+}
+interface SettingToggleControl extends SettingControlBase<boolean> {
+    type: 'toggle';
+}
+interface SettingSliderControl extends SettingControlBase<number> {
+    type: 'slider';
+    min: number;
+    max: number;
+    step: number;
+}
+interface SettingDropdownControl extends SettingControlBase<string> {
+    type: 'dropdown';
+    options: Record<string, string>;
+}
+type SettingControl = SettingTextControl | SettingToggleControl | SettingSliderControl | SettingDropdownControl;
+interface SettingDefinitionControl {
+    name: string;
+    desc?: string;
+    control: SettingControl;
+}
+interface SettingDefinitionRender {
+    name: string;
+    render: (setting: Setting) => void;
+}
+type SettingDefinitionItem = SettingDefinitionControl | SettingDefinitionRender;
+
 export interface SupernotePluginSettings extends CustomDictionarySettings {
     directConnectIP: string;
     invertColorsWhenDark: boolean;
@@ -36,6 +73,70 @@ export class SupernoteSettingTab extends PluginSettingTab {
     constructor(app: App, plugin: SupernotePlugin) {
         super(app, plugin);
         this.plugin = plugin;
+    }
+
+    // Declarative settings, so entries appear in Obsidian's settings search on 1.13.0+.
+    // `display()` below stays as the fallback for this plugin's minAppVersion (< 1.13.0),
+    // which is still called on those older versions.
+    getSettingDefinitions(): SettingDefinitionItem[] {
+        return [
+            {
+                name: 'Supernote IP address',
+                desc: '(Optional) when using the supernote "browse and access" for document upload/download or "screen mirroring" screenshot attachment this is the IP of the supernote device',
+                control: {
+                    type: 'text',
+                    key: 'directConnectIP',
+                    placeholder: 'IP only e.g. 192.168.1.2',
+                    validate: (value) => {
+                        if (value !== '' && !IP_VALIDATION_PATTERN.test(value)) {
+                            return 'Invalid IP format: must be xxx.xxx.xxx.xxx';
+                        }
+                    },
+                },
+            },
+            {
+                name: 'Invert colors in "dark mode"',
+                desc: 'When Obsidian is in "dark mode" increase image visibility by inverting colors of images',
+                control: {
+                    type: 'toggle',
+                    key: 'invertColorsWhenDark',
+                },
+            },
+            {
+                name: 'Show export buttons',
+                desc: 'When viewing .note files, show buttons for exporting images and/or markdown files to vault. These features can still be accessed via the command pallete.',
+                control: {
+                    type: 'toggle',
+                    key: 'showExportButtons',
+                },
+            },
+            {
+                name: 'Max image side length in .note files',
+                desc: 'Maximum width and height (in pixels) of the note image when viewing .note files. Does not affect exported images and markdown.',
+                control: {
+                    type: 'slider',
+                    key: 'noteImageMaxDim',
+                    min: 200,
+                    max: 1900,
+                    step: 100, // Resolution of an A5X/A6X2/Nomad page is 1404 x 1872 px (with no upscaling)
+                },
+            },
+            {
+                name: 'Device file browser sort order',
+                desc: 'Default order to list files and folders in when browsing the supernote device (e.g. "attach supernote file from device"). Can also be changed from the browser itself.',
+                control: {
+                    type: 'dropdown',
+                    key: 'fileBrowserSortOrder',
+                    options: FILE_BROWSER_SORT_LABELS,
+                },
+            },
+            {
+                name: 'Custom dictionary',
+                render: (setting) => {
+                    createCustomDictionarySettingsUI(setting.settingEl, this.plugin);
+                },
+            },
+        ];
     }
 
     display(): void {


### PR DESCRIPTION
## Summary
The `lint` CI check passes (0 errors) but currently reports 9 obsidianmd warnings. This cleans those up:

- Drop the redundant plugin-ID prefix from command IDs — Obsidian namespaces command IDs with the plugin ID automatically, so including `supernote` in the ID string trips `obsidianmd/commands/no-plugin-id-in-command-id`. No other code references these string literals.
- Implement `PluginSettingTab.getSettingDefinitions()` on `SupernoteSettingTab` so its settings are indexed by Obsidian's settings search on 1.13+ (`obsidianmd/settings-tab/prefer-setting-definitions`). The existing `display()` method is kept as-is since it's still the fallback Obsidian calls on this plugin's pre-1.13 `minAppVersion` (1.7.2). The declarative-settings types aren't in this repo's `obsidian` devDependency (pinned below 1.13 — bumping it to 1.13.1 pulls in unrelated `.d.ts` breakage), so the shapes are hand-typed locally to match the real runtime API.
- Turn off `obsidianmd/no-global-this` for `*.test.ts` — the rule exists for popout-window compatibility in plugin runtime code, which doesn't apply to Vitest's `window` stub in `deviceFetch.test.ts`.

## Test plan
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 22 passed
- [x] `npm run build` — succeeds