### PR TITLE
Add auto-export of .note files to markdown/images

### DIFF
--- a/src/autoExport.test.ts
+++ b/src/autoExport.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { computeDigest, decideAction, isPathInScope, FM_SOURCE_DIGEST, FM_SOURCE_IMAGES, FM_OVERWRITE } from './autoExport';
+
+describe('computeDigest', () => {
+    it('is deterministic for the same bytes', async () => {
+        const bytes = new TextEncoder().encode('hello supernote').buffer;
+        const a = await computeDigest(bytes);
+        const b = await computeDigest(bytes);
+        expect(a).toBe(b);
+        expect(a).toMatch(/^sha1-[0-9a-f]{40}$/);
+    });
+
+    it('differs for different bytes', async () => {
+        const a = await computeDigest(new TextEncoder().encode('one').buffer);
+        const b = await computeDigest(new TextEncoder().encode('two').buffer);
+        expect(a).not.toBe(b);
+    });
+});
+
+describe('isPathInScope', () => {
+    it('is false when the watch list is empty', () => {
+        expect(isPathInScope('Notes/Meeting.note', [])).toBe(false);
+    });
+
+    it('matches a file directly inside a watched folder', () => {
+        expect(isPathInScope('Notes/Meeting.note', ['Notes'])).toBe(true);
+    });
+
+    it('matches a file nested arbitrarily deep inside a watched folder', () => {
+        expect(isPathInScope('Notes/2026/07/Meeting.note', ['Notes'])).toBe(true);
+    });
+
+    it('does not match a sibling folder with a shared prefix', () => {
+        expect(isPathInScope('Notes Archive/Meeting.note', ['Notes'])).toBe(false);
+    });
+
+    it('tolerates leading/trailing slashes in the configured folder', () => {
+        expect(isPathInScope('Notes/Meeting.note', ['/Notes/'])).toBe(true);
+    });
+
+    it('ignores an empty-string folder entry instead of matching everything', () => {
+        expect(isPathInScope('Anything/Meeting.note', ['', 'Other'])).toBe(false);
+    });
+
+    it('matches when one of several watched folders applies', () => {
+        expect(isPathInScope('Work/Meeting.note', ['Personal', 'Work'])).toBe(true);
+    });
+});
+
+describe('decideAction', () => {
+    it('creates when no file exists at the target path', () => {
+        expect(decideAction(null, false, 'sha1-aaa')).toEqual({ type: 'create' });
+    });
+
+    it('skips a foreign file (target exists but has no supernote frontmatter)', () => {
+        expect(decideAction({}, false, 'sha1-aaa')).toEqual({ type: 'skip-foreign-file' });
+    });
+
+    it('is a no-op when the digest is unchanged', () => {
+        const fm = { [FM_SOURCE_DIGEST]: 'sha1-aaa' };
+        expect(decideAction(fm, true, 'sha1-aaa')).toEqual({ type: 'noop' });
+    });
+
+    it('regenerates when the digest changed and overwrite is not disabled', () => {
+        const fm = { [FM_SOURCE_DIGEST]: 'sha1-aaa', [FM_SOURCE_IMAGES]: ['Note-1.png', 'Note-2.png'] };
+        expect(decideAction(fm, true, 'sha1-bbb')).toEqual({
+            type: 'regenerate',
+            staleImages: ['Note-1.png', 'Note-2.png'],
+        });
+    });
+
+    it('regenerates with an empty stale-image list when none were recorded', () => {
+        const fm = { [FM_SOURCE_DIGEST]: 'sha1-aaa' };
+        expect(decideAction(fm, true, 'sha1-bbb')).toEqual({ type: 'regenerate', staleImages: [] });
+    });
+
+    it('skips a user-edited file when the digest changed but overwrite is false', () => {
+        const fm = { [FM_SOURCE_DIGEST]: 'sha1-aaa', [FM_OVERWRITE]: false };
+        expect(decideAction(fm, true, 'sha1-bbb')).toEqual({ type: 'skip-user-edited' });
+    });
+});

--- a/src/autoExport.ts
+++ b/src/autoExport.ts
@@ -1,0 +1,75 @@
+// Frontmatter keys written into auto-exported markdown files, used to find a
+// `.note` file's companion `.md` again later and to decide whether it needs
+// regenerating. See decideAction() for how these get used.
+export const FM_SOURCE_PATH = 'supernote-source-path';
+export const FM_SOURCE_DIGEST = 'supernote-source-digest';
+export const FM_SOURCE_IMAGES = 'supernote-source-images';
+export const FM_OVERWRITE = 'supernote-overwrite';
+
+export interface AutoExportFrontmatter {
+    [FM_SOURCE_PATH]?: string;
+    [FM_SOURCE_DIGEST]?: string;
+    [FM_SOURCE_IMAGES]?: string[];
+    [FM_OVERWRITE]?: boolean;
+}
+
+// sha1 is plenty here - this is a change-detection fingerprint, not a
+// security boundary - and matches the "sha1-..." format philips proposed in
+// https://github.com/philips/supernote-obsidian-plugin/issues/41.
+export async function computeDigest(data: ArrayBuffer): Promise<string> {
+    const hashBuffer = await crypto.subtle.digest('SHA-1', data);
+    const hex = Array.from(new Uint8Array(hashBuffer))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+    return `sha1-${hex}`;
+}
+
+// Folder scope check: `notePath` is in scope if it sits inside (at any depth)
+// one of `watchFolders`. Folder paths are matched by exact segment, not
+// substring, so a folder "Notes" doesn't accidentally match "Notes Archive".
+// An empty watch list means nothing is in scope - auto-export is opt-in per
+// folder, not vault-wide by default.
+export function isPathInScope(notePath: string, watchFolders: string[]): boolean {
+    for (const folder of watchFolders) {
+        const normalized = folder.replace(/^\/+|\/+$/g, '');
+        if (normalized.length === 0) continue; // vault root as a watch folder would match everything; require an explicit folder
+        if (notePath === normalized || notePath.startsWith(`${normalized}/`)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export type AutoExportAction =
+    | { type: 'create' }
+    | { type: 'regenerate'; staleImages: string[] }
+    | { type: 'noop' }
+    | { type: 'skip-user-edited' }
+    | { type: 'skip-foreign-file' };
+
+// Decides what auto-export should do with a `.note` file given whatever
+// already exists at its deterministic target `.md` path.
+//
+// - `existingFrontmatter` is null when no file exists at the target path yet.
+// - `hasSupernoteFrontmatter` distinguishes "no file there" from "a file is
+//   there but it's not one we generated" (e.g. an unrelated user note that
+//   happens to share the same basename) - never overwrite the latter.
+export function decideAction(
+    existingFrontmatter: AutoExportFrontmatter | null,
+    hasSupernoteFrontmatter: boolean,
+    newDigest: string,
+): AutoExportAction {
+    if (existingFrontmatter === null) {
+        return { type: 'create' };
+    }
+    if (!hasSupernoteFrontmatter) {
+        return { type: 'skip-foreign-file' };
+    }
+    if (existingFrontmatter[FM_SOURCE_DIGEST] === newDigest) {
+        return { type: 'noop' };
+    }
+    if (existingFrontmatter[FM_OVERWRITE] === false) {
+        return { type: 'skip-user-edited' };
+    }
+    return { type: 'regenerate', staleImages: existingFrontmatter[FM_SOURCE_IMAGES] ?? [] };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { installAtPolyfill } from './polyfills';
-import { App, Modal, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, loadPdfJs, Scope, SearchComponent, setIcon, Platform } from 'obsidian';
+import { App, Modal, TFile, TAbstractFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, loadPdfJs, Scope, SearchComponent, setIcon, Platform, Notice, getFrontMatterInfo, parseYaml, stringifyYaml } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS } from './settings';
 import { SupernoteX, fetchMirrorFrame, createPdfContext, addPdfPage } from 'supernote-typescript';
 import { encode } from 'image-js';
@@ -9,6 +9,7 @@ import { ErrorModal } from './ErrorModal';
 import { SupernoteWorkerMessage, SupernoteWorkerResponse } from './myworker.worker';
 import Worker from 'myworker.worker';
 import { replaceTextWithCustomDictionary } from './customDictionary';
+import { computeDigest, decideAction, isPathInScope, AutoExportFrontmatter, FM_SOURCE_PATH, FM_SOURCE_DIGEST, FM_SOURCE_IMAGES, FM_OVERWRITE } from './autoExport';
 
 function generateTimestamp(): string {
 	const date = new Date();
@@ -186,8 +187,6 @@ class VaultWriter {
 	}
 
 	async writeMarkdownFile(file: TFile, sn: SupernoteX, imgs: TFile[] | null) {
-		let content = '';
-
 		// Generate a non-conflicting filename - it has a bit of a race but that is OK
 		let filename = `${file.parent?.path}/${file.basename}.md`;
 		let i = 0;
@@ -195,7 +194,15 @@ class VaultWriter {
 			filename = `${file.parent?.path}/${file.basename} ${++i}.md`;
 		}
 
-		content = this.app.fileManager.generateMarkdownLink(file, filename);
+		const content = this.buildMarkdownBody(file, sn, imgs, filename);
+		await this.app.vault.create(filename, content);
+	}
+
+	// Shared by writeMarkdownFile() (manual export, picks a non-conflicting
+	// filename) and autoExportNote() (writes to a deterministic path so it can
+	// find/update the same file again next time).
+	private buildMarkdownBody(file: TFile, sn: SupernoteX, imgs: TFile[] | null, targetPath: string): string {
+		let content = this.app.fileManager.generateMarkdownLink(file, targetPath);
 		content += '\n';
 
 		for (let i = 0; i < sn.pages.length; i++) {
@@ -209,24 +216,15 @@ class VaultWriter {
 					alt = 'supernote-invert-dark';
 				}
 
-				const link = generateMarkdownImageEmbed(this.app, imgs[i], filename, alt);
+				const link = generateMarkdownImageEmbed(this.app, imgs[i], targetPath, alt);
 				content += `${link}\n`;
 			}
 		}
-
-		await this.app.vault.create(filename, content);
+		return content;
 	}
 
 	async writeImageFiles(basename: string, sn: SupernoteX): Promise<TFile[]> {
-		let images: string[] = [];
-
-		const converter = new ImageConverter();
-		try {
-			images = await converter.convertToImages(sn);
-		} finally {
-			// Clean up the worker when done
-			converter.terminate();
-		}
+		const images = await this.renderPageImages(sn);
 
 		const imgs: TFile[] = [];
 		for (let i = 0; i < images.length; i++) {
@@ -235,6 +233,164 @@ class VaultWriter {
 			imgs.push(await this.app.vault.createBinary(filename, buffer));
 		}
 		return imgs;
+	}
+
+	// Like writeImageFiles(), but writes to deterministic filenames (so a
+	// later regenerate overwrites the same attachments in place instead of
+	// piling up "-1 2.png"-style numbered duplicates every time a .note file
+	// changes) rather than probing for a non-conflicting name.
+	private async writeImageFilesAt(basename: string, folder: string, sn: SupernoteX): Promise<TFile[]> {
+		const images = await this.renderPageImages(sn);
+
+		const imgs: TFile[] = [];
+		for (let i = 0; i < images.length; i++) {
+			const path = this.joinVaultPath(folder, `${basename}-${i + 1}.png`);
+			const buffer = dataUrlToBuffer(images[i]);
+			imgs.push(await this.writeOrOverwriteBinary(path, buffer));
+		}
+		return imgs;
+	}
+
+	private async renderPageImages(sn: SupernoteX): Promise<string[]> {
+		const converter = new ImageConverter();
+		try {
+			return await converter.convertToImages(sn);
+		} finally {
+			// Clean up the worker when done
+			converter.terminate();
+		}
+	}
+
+	private async writeOrOverwriteBinary(path: string, buffer: ArrayBuffer): Promise<TFile> {
+		const existing = this.app.vault.getFileByPath(path);
+		if (existing) {
+			await this.app.vault.modifyBinary(existing, buffer);
+			return existing;
+		}
+		return await this.app.vault.createBinary(path, buffer);
+	}
+
+	private async ensureFolderExists(path: string): Promise<void> {
+		if (path.length === 0) return;
+		if (this.app.vault.getAbstractFileByPath(path)) return;
+		// Race-tolerant: another auto-export for the same folder may have
+		// created it between the check above and this call.
+		await this.app.vault.createFolder(path).catch(() => { /* already exists */ });
+	}
+
+	// Reads whatever markdown file currently sits at `targetPath` (if any)
+	// and reports both its parsed supernote frontmatter and whether it looks
+	// like one this plugin generated at all - a file with the same basename
+	// as a .note file, but no supernote frontmatter, is left alone rather
+	// than clobbered.
+	private async readAutoExportFrontmatter(targetPath: string): Promise<{ file: TFile | null; frontmatter: AutoExportFrontmatter | null; isOurs: boolean }> {
+		const file = this.app.vault.getFileByPath(targetPath);
+		if (!file) {
+			return { file: null, frontmatter: null, isOurs: false };
+		}
+
+		const existingContent = await this.app.vault.read(file);
+		const fmInfo = getFrontMatterInfo(existingContent);
+		if (!fmInfo.exists) {
+			return { file, frontmatter: {}, isOurs: false };
+		}
+
+		const parsed = (parseYaml(fmInfo.frontmatter) ?? {}) as AutoExportFrontmatter;
+		return { file, frontmatter: parsed, isOurs: typeof parsed[FM_SOURCE_PATH] === 'string' };
+	}
+
+	private autoExportTargetFolder(notePath: string): string {
+		if (this.settings.autoExportOutputFolder.length > 0) {
+			return this.settings.autoExportOutputFolder;
+		}
+		const lastSlash = notePath.lastIndexOf('/');
+		return lastSlash === -1 ? '' : notePath.slice(0, lastSlash);
+	}
+
+	// Joins a folder (possibly '' for the vault root) with a filename without
+	// producing a leading "/" for root-level files.
+	private joinVaultPath(folder: string, name: string): string {
+		return folder.length > 0 ? `${folder}/${name}` : name;
+	}
+
+	private autoExportTargetPath(notePath: string): string {
+		const lastSlash = notePath.lastIndexOf('/');
+		const withoutNoteExt = (lastSlash === -1 ? notePath : notePath.slice(lastSlash + 1)).replace(/\.note$/i, '');
+		return this.joinVaultPath(this.autoExportTargetFolder(notePath), `${withoutNoteExt}.md`);
+	}
+
+	// Creates or updates the deterministic markdown companion (and, depending
+	// on settings.autoExportMode, image attachments) for a .note file living
+	// in a watched auto-export folder. Idempotent: a repeat call with an
+	// unchanged .note file is a no-op (see decideAction()), and a changed one
+	// is regenerated in place rather than creating a numbered duplicate.
+	async autoExportNote(file: TFile): Promise<void> {
+		const noteBuffer = await this.app.vault.readBinary(file);
+		const digest = await computeDigest(noteBuffer);
+
+		const targetPath = this.autoExportTargetPath(file.path);
+		const { file: existingFile, frontmatter: existingFrontmatter, isOurs } = await this.readAutoExportFrontmatter(targetPath);
+
+		const action = decideAction(existingFrontmatter, isOurs, digest);
+		if (action.type !== 'create' && action.type !== 'regenerate') {
+			// noop / skip-user-edited / skip-foreign-file: nothing to write.
+			return;
+		}
+
+		const folder = this.autoExportTargetFolder(file.path);
+
+		if (action.type === 'regenerate') {
+			for (const imageName of action.staleImages) {
+				const staleFile = this.app.vault.getFileByPath(this.joinVaultPath(folder, imageName));
+				if (staleFile) await this.app.fileManager.trashFile(staleFile);
+			}
+		}
+
+		await this.ensureFolderExists(folder);
+
+		const sn = new SupernoteX(new Uint8Array(noteBuffer));
+
+		let imgs: TFile[] | null = null;
+		if (this.settings.autoExportMode === 'markdown-and-images') {
+			imgs = await this.writeImageFilesAt(file.basename, folder, sn);
+		}
+
+		const body = this.buildMarkdownBody(file, sn, imgs, targetPath);
+		const frontmatterObj: AutoExportFrontmatter = {
+			[FM_SOURCE_PATH]: file.path,
+			[FM_SOURCE_DIGEST]: digest,
+			[FM_SOURCE_IMAGES]: imgs?.map(f => f.name) ?? [],
+			[FM_OVERWRITE]: existingFrontmatter?.[FM_OVERWRITE] ?? true,
+		};
+		const content = `---\n${stringifyYaml(frontmatterObj)}---\n${body}`;
+
+		if (existingFile) {
+			await this.app.vault.modify(existingFile, content);
+		} else {
+			await this.app.vault.create(targetPath, content);
+		}
+	}
+
+	// Keeps an already-auto-exported companion file findable after its source
+	// .note file is renamed/moved: relocates the .md to the new deterministic
+	// path (if the rename changes it) and updates its supernote-source-path
+	// frontmatter to match. Image attachments are left where they are - the
+	// markdown links to them were generated as vault-relative paths, not tied
+	// to the source .note's location, so they keep resolving.
+	async patchRenamedNoteSource(oldNotePath: string, newFile: TFile): Promise<void> {
+		const oldTargetPath = this.autoExportTargetPath(oldNotePath);
+		const { file: mdFile, frontmatter, isOurs } = await this.readAutoExportFrontmatter(oldTargetPath);
+		if (!mdFile || !isOurs || frontmatter?.[FM_SOURCE_PATH] !== oldNotePath) return;
+
+		const newTargetPath = this.autoExportTargetPath(newFile.path);
+		if (newTargetPath !== mdFile.path) {
+			await this.ensureFolderExists(this.autoExportTargetFolder(newFile.path));
+			await this.app.vault.rename(mdFile, newTargetPath);
+		}
+
+		await this.app.fileManager.processFrontMatter(mdFile, (fm: AutoExportFrontmatter) => {
+			fm[FM_SOURCE_PATH] = newFile.path;
+		});
 	}
 
 	async attachMarkdownFile(file: TFile) {
@@ -1181,6 +1337,17 @@ export default class SupernotePlugin extends Plugin {
 	settings!: SupernotePluginSettings;
 	vaultWriter!: VaultWriter;
 
+	// FIFO queue for auto-export: 'create'/'modify' handlers just push a
+	// reference and return, so a burst of events (e.g. Obsidian's startup
+	// replay of every already-indexed .note file, or a sync tool dropping
+	// many files at once) never blocks on rasterizing/writing synchronously.
+	// Processed one file at a time - each conversion already spins up its own
+	// WorkerPool, so running several concurrently would multiply that cost
+	// for no benefit.
+	private autoExportQueue: TFile[] = [];
+	private autoExportDraining = false;
+	private autoExportFailures: string[] = [];
+
 	async onload() {
         // Install polyfills before any other code runs
         installAtPolyfill();
@@ -1190,6 +1357,24 @@ export default class SupernotePlugin extends Plugin {
 		this.vaultWriter = vw;
 
 		this.addSettingTab(new SupernoteSettingTab(this.app, this));
+
+		// Registered unconditionally (not inside workspace.onLayoutReady) so
+		// that Obsidian's startup replay of 'create' for every already-
+		// indexed file - which is how a .note file that appeared while
+		// Obsidian was closed (e.g. synced in via OneDrive/Dropbox) gets
+		// caught - reaches this handler. The handler itself only enqueues; see
+		// enqueueAutoExport()/drainAutoExportQueue() for why that's safe to do
+		// this early.
+		this.registerEvent(this.app.vault.on('create', (file) => this.enqueueAutoExport(file)));
+		this.registerEvent(this.app.vault.on('modify', (file) => this.enqueueAutoExport(file)));
+		this.registerEvent(this.app.vault.on('rename', (file, oldPath) => {
+			if (!this.settings.autoExportEnabled) return;
+			if (!(file instanceof TFile) || file.extension !== 'note') return;
+			this.vaultWriter.patchRenamedNoteSource(oldPath, file).catch((err: unknown) => {
+				console.error(`Supernote auto-export: failed to update renamed note reference (${oldPath} -> ${file.path}):`, err);
+			});
+		}));
+		this.app.workspace.onLayoutReady(() => void this.drainAutoExportQueue());
 
 		this.addCommand({
 			id: 'attach-supernote-file-from-device',
@@ -1395,6 +1580,53 @@ export default class SupernotePlugin extends Plugin {
 
 	async saveSettings() {
 		await this.saveData(this.settings);
+	}
+
+	// Filters and enqueues a possible auto-export candidate. Deliberately does
+	// no I/O itself - called directly from vault 'create'/'modify' listeners,
+	// which may fire in a burst (startup replay, a sync tool dropping many
+	// files at once), so it just records which files need attention and
+	// returns.
+	private enqueueAutoExport(file: TAbstractFile) {
+		if (!this.settings.autoExportEnabled) return;
+		if (!(file instanceof TFile) || file.extension !== 'note') return;
+		if (!isPathInScope(file.path, this.settings.autoExportWatchFolders)) return;
+		if (this.autoExportQueue.includes(file)) return;
+
+		this.autoExportQueue.push(file);
+		void this.drainAutoExportQueue();
+	}
+
+	// Processes the queue sequentially. A no-op until the workspace layout is
+	// ready (see onload()'s call into this from workspace.onLayoutReady()) so
+	// nothing here competes with Obsidian's own startup work; enqueueAutoExport()
+	// calling this speculatively before layout-ready is harmless; it just
+	// returns immediately and the onLayoutReady callback picks the backlog up
+	// once things settle.
+	private async drainAutoExportQueue(): Promise<void> {
+		if (this.autoExportDraining) return;
+		if (!this.app.workspace.layoutReady) return;
+
+		this.autoExportDraining = true;
+		try {
+			while (this.autoExportQueue.length > 0) {
+				const file = this.autoExportQueue.shift();
+				if (!file) continue;
+				try {
+					await this.vaultWriter.autoExportNote(file);
+				} catch (err) {
+					console.error(`Supernote auto-export failed for ${file.path}:`, err);
+					this.autoExportFailures.push(file.path);
+				}
+			}
+		} finally {
+			this.autoExportDraining = false;
+		}
+
+		if (this.autoExportFailures.length > 0) {
+			new Notice(`Supernote auto-export: ${this.autoExportFailures.length} file(s) failed - see console for details.`);
+			this.autoExportFailures = [];
+		}
 	}
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,12 +13,29 @@ export const FILE_BROWSER_SORT_LABELS: Record<FileBrowserSortOrder, string> = {
     'date-asc': 'Date (oldest first)',
 };
 
+export type AutoExportMode = 'markdown' | 'markdown-and-images';
+
+export const AUTO_EXPORT_MODE_LABELS: Record<AutoExportMode, string> = {
+    'markdown': 'Markdown only',
+    'markdown-and-images': 'Markdown and images',
+};
+
 export interface SupernotePluginSettings extends CustomDictionarySettings {
     directConnectIP: string;
     invertColorsWhenDark: boolean;
     showExportButtons: boolean;
     noteImageMaxDim: number;
     fileBrowserSortOrder: FileBrowserSortOrder;
+    autoExportEnabled: boolean;
+    autoExportMode: AutoExportMode;
+    // Vault-relative folder paths (one per line in the settings UI) that are
+    // watched for .note files to auto-export. Empty by default: auto-export
+    // is opt-in per folder, not vault-wide, so enabling the feature doesn't
+    // immediately churn through every .note file already in the vault.
+    autoExportWatchFolders: string[];
+    // Where generated .md/.png files land. Empty means "alongside the source
+    // .note file", matching the manual export commands' behavior.
+    autoExportOutputFolder: string;
 }
 
 export const DEFAULT_SETTINGS: SupernotePluginSettings = {
@@ -27,6 +44,10 @@ export const DEFAULT_SETTINGS: SupernotePluginSettings = {
     showExportButtons: true,
     noteImageMaxDim: 800, // Sensible default for Nomad pages to be legible but not too big. Unit: px
     fileBrowserSortOrder: 'name-asc',
+    autoExportEnabled: false,
+    autoExportMode: 'markdown-and-images',
+    autoExportWatchFolders: [],
+    autoExportOutputFolder: '',
 	...CUSTOM_DICTIONARY_DEFAULT_SETTINGS,
 }
 
@@ -118,6 +139,69 @@ export class SupernoteSettingTab extends PluginSettingTab {
                     await this.plugin.saveSettings();
                 })
             );
+
+        new Setting(containerEl)
+            .setName('Auto-export')
+            .setHeading()
+            .setDesc(
+                'Automatically create/update markdown (and optionally images) in the vault whenever a .note file '
+                + 'appears or changes in one of the watched folders below - e.g. a folder synced from your Supernote via '
+                + 'OneDrive/Dropbox/a symlink. Leave the watch folder list empty to keep this off.',
+            );
+
+        new Setting(containerEl)
+            .setName('Enable auto-export')
+            .setDesc('Watch the folders below for new or changed .note files and export them automatically.')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.autoExportEnabled)
+                .onChange(async (value) => {
+                    this.plugin.settings.autoExportEnabled = value;
+                    await this.plugin.saveSettings();
+                    this.display();
+                })
+            );
+
+        if (this.plugin.settings.autoExportEnabled) {
+            new Setting(containerEl)
+                .setName('Watched folders')
+                .setDesc('One vault-relative folder path per line. .note files inside these folders (including subfolders) are auto-exported.')
+                .addTextArea(text => {
+                    text.setPlaceholder('Supernote sync')
+                        .setValue(this.plugin.settings.autoExportWatchFolders.join('\n'))
+                        .onChange(async (value) => {
+                            this.plugin.settings.autoExportWatchFolders = value
+                                .split('\n')
+                                .map(line => line.trim())
+                                .filter(line => line.length > 0);
+                            await this.plugin.saveSettings();
+                        });
+                    text.inputEl.rows = 3;
+                });
+
+            new Setting(containerEl)
+                .setName('Auto-export output')
+                .setDesc('What to generate for each .note file.')
+                .addDropdown(dropdown => dropdown
+                    .addOptions(AUTO_EXPORT_MODE_LABELS)
+                    .setValue(this.plugin.settings.autoExportMode)
+                    .onChange(async (value) => {
+                        this.plugin.settings.autoExportMode = value as AutoExportMode;
+                        await this.plugin.saveSettings();
+                    })
+                );
+
+            new Setting(containerEl)
+                .setName('Auto-export output folder')
+                .setDesc('Vault-relative folder to write generated files to. Leave blank to write alongside each source .note file.')
+                .addText(text => text
+                    .setPlaceholder('(same folder as the .note file)')
+                    .setValue(this.plugin.settings.autoExportOutputFolder)
+                    .onChange(async (value) => {
+                        this.plugin.settings.autoExportOutputFolder = value.trim();
+                        await this.plugin.saveSettings();
+                    })
+                );
+        }
 
 		// Add custom dictionary settings to the settings tab
 		createCustomDictionarySettingsUI(containerEl, this.plugin);


### PR DESCRIPTION
## Summary
- Adds an opt-in auto-export feature (settings: Enable auto-export, Watched folders, Auto-export output, Auto-export output folder) that watches configured vault folders and auto-generates/updates a companion markdown file (and optionally images) whenever a `.note` file appears or changes there - the workflow requested in #41 (e.g. a folder synced from a Supernote via OneDrive/Dropbox/a symlink).
- Tracks each `.note`'s content via a sha1 digest stored in the generated file's frontmatter (`supernote-source-digest`) to detect real changes across devices without relying on mtimes, addressing the reliability concern raised in the issue thread.
- `supernote-overwrite: false` frontmatter lets a user opt a specific generated file out of future auto-regeneration (e.g. after hand-editing it).
- `.note` file renames patch the companion file's `supernote-source-path` frontmatter (and relocate it if needed) instead of orphaning the reference. Deleting a `.note` intentionally leaves previously generated files in place.
- `create`/`modify` listeners are registered unconditionally (to catch the startup replay of files that synced in while Obsidian was closed) but only enqueue a reference; the actual conversion work is deferred until after `workspace.onLayoutReady()` and processed one file at a time, so this never blocks Obsidian's own startup - addressing the original concern that a prior version of this feature scanned/blocked on load.

Closes #41.

## Test plan
- [x] `npx tsc -noEmit -skipLibCheck` passes
- [x] `npx eslint .` - no new errors (pre-existing warnings only)
- [x] `npx vitest run` - 37 tests pass, including new `src/autoExport.test.ts` covering digest determinism, folder-scope matching, and the create/noop/regenerate/skip decision matrix
- [x] `npm run build` succeeds
- [ ] Manual test in a real vault (not done in this environment - no Obsidian instance available)