### PR TITLE
Fix Fit width getting stuck at 500% on large/high-res displays

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -954,7 +954,8 @@ export class SupernoteView extends FileView {
 	}
 
 	private setZoom(newScale: number, opts: { manual?: boolean } = {}) {
-		if (opts.manual !== false) {
+		const isManual = opts.manual !== false;
+		if (isManual) {
 			// Any direct zoom action (buttons, wheel, reset) is the user taking
 			// manual control — stop auto-adjusting on resize until they ask for
 			// fit-width again. applyFitWidth() itself calls in with manual:false
@@ -968,7 +969,20 @@ export class SupernoteView extends FileView {
 		// a narrow mobile screen — especially with the thumbnail sidebar open,
 		// or a wide/landscape note — that can legitimately need to go below
 		// 25%. Clamping it there just forced horizontal scrolling instead.
-		this.zoomScale = Math.min(5, Math.max(0.05, newScale));
+		//
+		// The 500% ceiling only makes sense for *manual* zoom (a sanity cap on
+		// how far a user should zoom in by hand). "100%" here is only ever
+		// relative to noteImageMaxDim — an arbitrary default render size, not
+		// the note's true resolution or the available viewport — so a large or
+		// high-resolution display can legitimately need well over 5x to
+		// actually fill it with "Fit width". Applying the same 500% ceiling
+		// there just left the page stuck at a fixed pixel width regardless of
+		// how much wider the pane actually was, while showing a confusing
+		// pinned "500%" (see issue #108). Fit width instead gets a much higher
+		// ceiling, purely as a guard against a pathological render (e.g. a
+		// zero-width native page) rather than a real intended limit.
+		const ceiling = isManual ? 5 : 20;
+		this.zoomScale = Math.min(ceiling, Math.max(0.05, newScale));
 		this.zoomLabelEl?.setText(`${Math.round(this.zoomScale * 100)}%`);
 
 		// Instant CSS-scale feedback while the user is still zooming; the real


### PR DESCRIPTION
## Summary
- `setZoom()` clamped zoom to a hard 5x (500%) ceiling unconditionally — applied to both manual zoom (buttons/ctrl+wheel) *and* "Fit width" auto-zoom.
- "100%" is only ever relative to `noteImageMaxDim` (an arbitrary default render size, default 800px), not the note's true resolution or the viewport, so on a large or high-resolution display "Fit width" can legitimately need well over 5x to actually fill the available width. Hitting the cap left the page stuck at a fixed pixel width and the zoom label pinned at a confusing "500%" — reads like a miscalculation, but was the clamp working as designed with too low a ceiling for that mode.
- Manual zoom keeps its 500% sanity cap; "Fit width" now gets a much higher one (2000%), purely as a guard against a pathological zero-width render rather than a real intended limit.

Fixes #108

## Test plan
- [x] `tsc -noEmit`, `eslint`, `npm run build`, `npm test` (22 tests) all pass
- [x] Manually confirmed fixed on the reporter's setup (MacBook Pro, large/high-res display) where "Fit width" was previously pinned at 500%