### PR TITLE
Shorten plugin name to "Supernote (Unofficial)" and trim command names

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This plugin has five main features:
 
 ## Install via Community Plugin Store
 
-This plugin is available via the [Obsidian Community Plugin Store](https://obsidian.md/plugins?id=supernote). Click the previous link or search for "Unofficial Supernote by Ratta Integration". 
+This plugin is available via the [Obsidian Community Plugin Store](https://obsidian.md/plugins?id=supernote). Click the previous link or search for "Supernote (Unofficial)". 
 
 ## Install via BRAT
 

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,6 +1,6 @@
 {
 	"id": "supernote",
-	"name": "Unofficial Supernote by Ratta Integration",
+	"name": "Supernote (Unofficial)",
 	"version": "3.0.1",
 	"minAppVersion": "1.12.7",
 	"description": "View Supernote notes, generate markdown from note and capture screen mirror.",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"id": "supernote",
-	"name": "Unofficial Supernote by Ratta Integration",
+	"name": "Supernote (Unofficial)",
 	"version": "2.9.1",
 	"minAppVersion": "1.7.2",
 	"description": "View Supernote notes, generate markdown from note and capture screen mirror.",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1410,7 +1410,7 @@ export default class SupernotePlugin extends Plugin {
 
 		this.addCommand({
 			id: 'attach-file-from-device',
-			name: 'Attach supernote file from device',
+			name: 'Attach file from device',
 			callback: () => {
 				if (this.settings.directConnectIP.length === 0) {
 					new DirectConnectErrorModal(this.app, this.settings, new Error("IP is unset")).open();
@@ -1422,7 +1422,7 @@ export default class SupernotePlugin extends Plugin {
 
 		this.addCommand({
 			id: 'upload-file-to-device',
-			name: 'Upload the current file to a supernote device',
+			name: 'Upload the current file to a device',
 			callback: () => {
 				if (this.settings.directConnectIP.length === 0) {
 					new DirectConnectErrorModal(this.app, this.settings, new Error("IP is unset")).open();
@@ -1457,7 +1457,7 @@ export default class SupernotePlugin extends Plugin {
 
 		this.addCommand({
 			id: 'insert-screen-mirror-image',
-			name: 'Insert a supernote screen mirroring image as attachment',
+			name: 'Insert a screen mirroring image as attachment',
 			editorCallback: async (editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
 				// Screen mirroring is an indefinitely-open multipart MJPEG stream read
 				// with a raw `fetch()` + ReadableStream reader (see fetchMirrorFrame in
@@ -1502,7 +1502,7 @@ export default class SupernotePlugin extends Plugin {
 
 		this.addCommand({
 			id: 'export-note-as-files',
-			name: 'Export this supernote note as a Markdown and PNG files as attachments',
+			name: 'Export this note as a Markdown and PNG files as attachments',
 			checkCallback: (checking: boolean) => {
 				const file = this.app.workspace.getActiveFile();
 				const ext = file?.extension;
@@ -1527,7 +1527,7 @@ export default class SupernotePlugin extends Plugin {
 
 		this.addCommand({
 			id: 'export-note-as-pdf',
-			name: 'Export this supernote note as PDF',
+			name: 'Export this note as PDF',
 			checkCallback: (checking: boolean) => {
 				const file = this.app.workspace.getActiveFile();
 				const ext = file?.extension;
@@ -1552,7 +1552,7 @@ export default class SupernotePlugin extends Plugin {
 
 		this.addCommand({
 			id: 'export-note-as-markdown',
-			name: 'Export this supernote note as a Markdown file attachment',
+			name: 'Export this note as a Markdown file attachment',
 			checkCallback: (checking: boolean) => {
 				const file = this.app.workspace.getActiveFile();
 				const ext = file?.extension;
@@ -1577,7 +1577,7 @@ export default class SupernotePlugin extends Plugin {
 
 		this.addCommand({
 			id: 'import-todays-pages',
-			name: "Import new or edited supernote pages by date as images",
+			name: "Import new or edited pages by date as images",
 			editorCallback: (editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
 				if (this.settings.directConnectIP.length === 0) {
 					new DirectConnectErrorModal(this.app, this.settings, new Error("IP is unset")).open();


### PR DESCRIPTION
## Summary
- Rename the plugin (manifest.json / manifest-beta.json `name`) from "Unofficial Supernote by Ratta Integration" to "Supernote (Unofficial)". Obsidian prefixes every command palette entry with this manifest name, so it directly controls how long commands read.
- Drop the now-redundant word "supernote" from each command's own `name`, e.g. "Attach supernote file from device" → "Attach file from device", so the full palette entry reads "Supernote (Unofficial): Attach file from device" instead of the old "Unofficial Supernote by Ratta Integration: Attach supernote file from device".

## Note
`README.md` still tells users to search the Community Plugin Store for "Unofficial Supernote by Ratta Integration" — left as-is since it wasn't in scope for this change, but it'll need updating to "Supernote (Unofficial)" once this ships.

## Test plan
- [x] `tsc -noEmit -skipLibCheck` passes
- [x] Manually confirm command palette entries and Settings → Community plugins listing show the new name in Obsidian