### PR TITLE
Support #page=N anchors on regular links to .note files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -460,6 +460,17 @@ export class SupernoteView extends FileView {
 		return this.file.basename;
 	}
 
+	// Obsidian delivers a link's `#page=N` subpath here — for both
+	// `[[file.note#page=8]]` and `[text](file.note#page=8)` — once setState()
+	// (which awaits onLoadFile(), so pageStates is already populated) has
+	// resolved. Mirrors the anchor SupernoteEmbed accepts for embeds; see
+	// parsePageAnchor().
+	setEphemeralState(state: unknown): void {
+		const subpath = (state as { subpath?: string } | undefined)?.subpath;
+		const page = parsePageAnchor(subpath);
+		if (page !== null) this.goToPage(page);
+	}
+
 	async onOpen(): Promise<void> {
 		// Scopes styles.css's button.mod-cta display:block rule to just this
 		// view, instead of it applying to every CTA button in Obsidian (see
@@ -836,13 +847,7 @@ export class SupernoteView extends FileView {
 			const jumpToPage = () => {
 				const requested = Number(pageInput.value);
 				if (!Number.isFinite(requested)) return;
-				const target = Math.min(pageCount, Math.max(1, Math.round(requested)));
-				pageInput.value = String(target);
-				const state = this.pageStates[target - 1];
-				state?.pageContainer.scrollIntoView({ block: 'start', behavior: 'smooth' });
-				// Don't wait on scroll+observer timing for a page the user
-				// explicitly asked to jump to.
-				if (state) void this.ensureTextLayer(state);
+				this.goToPage(Math.round(requested));
 			};
 
 			pageInput.addEventListener('keydown', (evt: KeyboardEvent) => {
@@ -882,9 +887,7 @@ export class SupernoteView extends FileView {
 			item.createSpan({ cls: 'supernote-thumb-label', text: String(i + 1) });
 
 			item.addEventListener('click', () => {
-				const state = this.pageStates[i];
-				state?.pageContainer.scrollIntoView({ block: 'start', behavior: 'smooth' });
-				if (state) void this.ensureTextLayer(state);
+				this.goToPage(i + 1);
 			});
 
 			this.thumbItems.push(item);
@@ -928,6 +931,21 @@ export class SupernoteView extends FileView {
 
 	private highlightThumbnail(index: number) {
 		this.thumbItems.forEach((item, i) => item.toggleClass('is-active', i === index));
+	}
+
+	// Shared by the toolbar's page-jump input, the thumbnail sidebar, and
+	// setEphemeralState() (a `#page=N` link anchor) — all three just need to
+	// scroll a given 1-indexed page into view and prime its text layer.
+	private goToPage(pageNumber: number): void {
+		if (this.pageStates.length === 0) return;
+		const clamped = Math.min(this.pageStates.length, Math.max(1, pageNumber));
+		const state = this.pageStates[clamped - 1];
+		if (!state) return;
+		state.pageContainer.scrollIntoView({ block: 'start', behavior: 'smooth' });
+		// Don't wait on scroll+observer timing for a page the user (or link)
+		// explicitly asked to jump to.
+		void this.ensureTextLayer(state);
+		if (this.pageJumpInput) this.pageJumpInput.value = String(clamped);
 	}
 
 	// Scrollspy: find the last page whose top has scrolled up past the sticky
@@ -1191,8 +1209,12 @@ export class SupernoteView extends FileView {
 	}
 }
 
-// Obsidian's PDF embed accepts `![[file.pdf#page=3]]` to jump straight to one
-// page; mirror that syntax for `.note` files rather than inventing a new one.
+// Obsidian's PDF support accepts a `#page=3` anchor — as an embed
+// (`![[file.pdf#page=3]]`) or a regular link (`[[file.pdf#page=3]]` /
+// `[text](file.pdf#page=3)`) — to jump straight to one page; mirror that
+// syntax for `.note` files rather than inventing a new one. Used by both
+// SupernoteView.setEphemeralState() (regular links) and SupernoteEmbed
+// (embeds).
 function parsePageAnchor(subpath?: string): number | null {
 	const match = subpath?.match(/^#page=(\d+)$/);
 	return match ? parseInt(match[1], 10) : null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -405,6 +405,11 @@ export class SupernoteView extends FileView {
 	private renderedZoomScale = 1;
 	private zoomDebounceTimer: number | undefined;
 	private zoomLabelEl: HTMLElement | null = null;
+	// True from the moment setZoom() schedules a debounced commitZoom() until
+	// that commit actually redraws pages at their final size. goToPage() waits
+	// this out — see waitForZoomToSettle() for why.
+	private zoomCommitPending = false;
+	private zoomSettleResolvers: Array<() => void> = [];
 
 	private fitWidthEnabled = true;
 	private fitWidthBtn: HTMLElement | null = null;
@@ -468,7 +473,7 @@ export class SupernoteView extends FileView {
 	setEphemeralState(state: unknown): void {
 		const subpath = (state as { subpath?: string } | undefined)?.subpath;
 		const page = parsePageAnchor(subpath);
-		if (page !== null) this.goToPage(page);
+		if (page !== null) void this.goToPage(page);
 	}
 
 	async onOpen(): Promise<void> {
@@ -847,7 +852,7 @@ export class SupernoteView extends FileView {
 			const jumpToPage = () => {
 				const requested = Number(pageInput.value);
 				if (!Number.isFinite(requested)) return;
-				this.goToPage(Math.round(requested));
+				void this.goToPage(Math.round(requested));
 			};
 
 			pageInput.addEventListener('keydown', (evt: KeyboardEvent) => {
@@ -887,7 +892,7 @@ export class SupernoteView extends FileView {
 			item.createSpan({ cls: 'supernote-thumb-label', text: String(i + 1) });
 
 			item.addEventListener('click', () => {
-				this.goToPage(i + 1);
+				void this.goToPage(i + 1);
 			});
 
 			this.thumbItems.push(item);
@@ -936,7 +941,12 @@ export class SupernoteView extends FileView {
 	// Shared by the toolbar's page-jump input, the thumbnail sidebar, and
 	// setEphemeralState() (a `#page=N` link anchor) — all three just need to
 	// scroll a given 1-indexed page into view and prime its text layer.
-	private goToPage(pageNumber: number): void {
+	private async goToPage(pageNumber: number): Promise<void> {
+		if (this.pageStates.length === 0) return;
+		// Wait out any in-flight fit-width/zoom re-render first — see
+		// waitForZoomToSettle() for why scrolling before it settles can land on
+		// the wrong page.
+		await this.waitForZoomToSettle();
 		if (this.pageStates.length === 0) return;
 		const clamped = Math.min(this.pageStates.length, Math.max(1, pageNumber));
 		const state = this.pageStates[clamped - 1];
@@ -1012,7 +1022,8 @@ export class SupernoteView extends FileView {
 		}
 
 		window.clearTimeout(this.zoomDebounceTimer);
-		this.zoomDebounceTimer = window.setTimeout(() => this.commitZoom(), 200);
+		this.zoomCommitPending = true;
+		this.zoomDebounceTimer = window.setTimeout(() => void this.commitZoom(), 200);
 	}
 
 	private async commitZoom(): Promise<void> {
@@ -1032,6 +1043,26 @@ export class SupernoteView extends FileView {
 		}
 		this.renderedZoomScale = targetZoom;
 		this.updateCurrentPageIndicator();
+
+		this.zoomCommitPending = false;
+		const resolvers = this.zoomSettleResolvers;
+		this.zoomSettleResolvers = [];
+		resolvers.forEach((resolve) => resolve());
+	}
+
+	// Until commitZoom() runs, page containers are still sized at whatever
+	// zoom was rendered *before* the pending setZoom() call (the interim CSS
+	// transform scale it applies for instant visual feedback doesn't change
+	// their layout box). onLoadFile() calls applyFitWidth() as soon as pages
+	// are built, so a page-anchor link (setEphemeralState() -> goToPage(),
+	// firing right as that file finishes loading) can easily land its
+	// scrollIntoView() before fit-width's real re-render — using page heights
+	// that are about to change once commitZoom() actually fires, and landing
+	// on the wrong page once they do. Waiting this out first keeps
+	// scrollIntoView() targeting final, stable page positions.
+	private async waitForZoomToSettle(): Promise<void> {
+		if (!this.zoomCommitPending) return;
+		await new Promise<void>((resolve) => this.zoomSettleResolvers.push(resolve));
 	}
 
 	// Scales the page so its rendered width matches however much horizontal


### PR DESCRIPTION
## Summary
- `SupernoteEmbed` already accepted a `#page=N` anchor for embeds (`![[file.note#page=8]]`), but a plain link — `[[file.note#page=8]]` or `[notes](work.note#page=8)` — always opened the note at page 1. Obsidian delivers a link's subpath to a `FileView` via `setEphemeralState()`, which `SupernoteView` never implemented.
- Adds `SupernoteView.setEphemeralState()`, reusing the existing `parsePageAnchor()` subpath parser.
- Extracts a `goToPage()` helper (scroll page into view + prime its text layer) shared by `setEphemeralState()`, the toolbar's page-jump input, and the thumbnail sidebar's click handler — the three had near-identical inline logic.
- **Fixes a follow-up bug found in manual testing:** a `#page=N` link fired right as the note finished loading could land on the wrong page (e.g. anchor `#page=5` landing on page 3). `onLoadFile()` calls `applyFitWidth()` synchronously right after building pages, but that only applies an instant CSS transform for immediate visual feedback — the real per-page resize (which is what actually changes each page's layout height) is debounced 200ms out in `commitZoom()`. `goToPage()`'s `scrollIntoView()` was running before that resize landed, using page heights that were about to change, so the later reflow shifted the already-fixed scroll position onto an earlier page. `goToPage()` now awaits any in-flight zoom commit before scrolling.

Fixes #107

## Test plan
- [x] `./scripts/build` (submodule init/build + `npm install` + `tsc -noEmit -skipLibCheck` + esbuild) succeeds
- [x] `npm run lint` passes
- [x] `npm test` (vitest) — 22/22 passing
- [x] Manual re-check in a real vault: click a `[text](note.note#page=N)` link on a fresh load and confirm it lands on page N (this is what regressed last round — no browser available in this environment, so this still needs a human check)