### PR TITLE
Add import format dropdown to today's-notes import

### DIFF
--- a/src/ImportTodayModal.ts
+++ b/src/ImportTodayModal.ts
@@ -3,6 +3,7 @@ import SupernotePlugin from './main';
 import { SupernoteFile, fetchSupernoteDirectory } from './FileListModal';
 import { fetchFromDevice, DEVICE_TRANSFER_TIMEOUT_MS } from './deviceFetch';
 import { parseDeviceDate, isSameLocalDay, todayLocalMidnight, formatDateInputValue, parseDateInputValue } from './deviceDate';
+import { ImportFormat, IMPORT_FORMAT_LABELS } from './settings';
 
 interface ScannedNote {
     file: SupernoteFile;
@@ -17,6 +18,7 @@ export class ImportTodayModal extends Modal {
     files: SupernoteFile[] = [];
     selected: Set<string> = new Set();
     selectedDate: Date = todayLocalMidnight();
+    importFormat: ImportFormat;
     listEl!: HTMLElement;
     resultsEl!: HTMLElement;
     importBtn!: HTMLButtonElement;
@@ -26,6 +28,7 @@ export class ImportTodayModal extends Modal {
         this.plugin = plugin;
         this.editor = editor;
         this.targetPath = targetPath;
+        this.importFormat = plugin.settings.importFormat;
     }
 
     async onOpen() {
@@ -61,6 +64,23 @@ export class ImportTodayModal extends Modal {
                 this.selectedDate = parsed;
                 this.renderForSelectedDate();
             }
+        });
+
+        const formatRow = contentEl.createDiv({ cls: 'supernote-import-format-row' });
+        formatRow.createEl('label', { text: 'Import as: ', attr: { for: 'supernote-import-format' } });
+        const formatSelect = formatRow.createEl('select', { attr: { id: 'supernote-import-format' } });
+        for (const [value, label] of Object.entries(IMPORT_FORMAT_LABELS)) {
+            const option = formatSelect.createEl('option', { text: label, value });
+            if (value === this.importFormat) {
+                option.selected = true;
+            }
+        }
+        formatSelect.addEventListener('change', () => {
+            this.importFormat = formatSelect.value as ImportFormat;
+            // Remember the choice as the new default for next time, same as
+            // the settings tab's dropdown would (see issue #104).
+            this.plugin.settings.importFormat = this.importFormat;
+            void this.plugin.saveSettings();
         });
 
         this.resultsEl = contentEl.createDiv();
@@ -161,7 +181,7 @@ export class ImportTodayModal extends Modal {
                     throw new Error(`Failed to download ${file.name}: Supernote responded with an error (status ${response.status}).`);
                 }
                 const buffer = await response.arrayBuffer();
-                combined += await this.plugin.vaultWriter.buildInsertableMarkdown(file.name, buffer, this.targetPath);
+                combined += await this.plugin.vaultWriter.buildInsertableContent(file.name, buffer, this.targetPath, this.importFormat);
                 combined += '\n';
             }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { installAtPolyfill } from './polyfills';
 import { App, Modal, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, Component, loadPdfJs, Scope, SearchComponent, setIcon, Platform } from 'obsidian';
-import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS } from './settings';
+import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS, ImportFormat } from './settings';
 import { SupernoteX, fetchMirrorFrame, createPdfContext, addPdfPage } from 'supernote-typescript';
 import { encode } from 'image-js';
 import { DownloadListModal, UploadListModal } from './FileListModal';
@@ -254,18 +254,45 @@ class VaultWriter {
 
 	/**
 	 * Converts a Supernote .note file (fetched from a device, not yet in the
-	 * vault) into images and returns markdown for inserting its pages inline
-	 * into another note, rather than creating a new .md file for it.
+	 * vault) into the requested format and returns markdown for inserting it
+	 * inline into another note, rather than creating a new .md file for it.
 	 */
-	async buildInsertableMarkdown(deviceFileName: string, noteBuffer: ArrayBuffer, targetPath: string): Promise<string> {
-		const sn = new SupernoteX(new Uint8Array(noteBuffer));
+	async buildInsertableContent(deviceFileName: string, noteBuffer: ArrayBuffer, targetPath: string, format: ImportFormat): Promise<string> {
 		const basename = deviceFileName.replace(/\.note$/i, '');
+
+		// These two formats save the raw .note file itself into the vault and
+		// point at it, rather than rasterizing pages, so they don't need to
+		// touch SupernoteX/ImageConverter at all.
+		if (format === 'note-link' || format === 'embed') {
+			const filename = await this.app.fileManager.getAvailablePathForAttachment(deviceFileName);
+			const tfile = await this.app.vault.createBinary(filename, noteBuffer);
+			const link = this.app.fileManager.generateMarkdownLink(tfile, targetPath);
+			return `${format === 'embed' ? '!' : ''}${link}\n`;
+		}
+
+		const sn = new SupernoteX(new Uint8Array(noteBuffer));
+
+		if (format === 'pdf') {
+			const converter = new ImageConverter();
+			let images: string[] = [];
+			try {
+				images = await converter.convertToImages(sn);
+			} finally {
+				converter.terminate();
+			}
+			const pdfBytes = await assemblePdfFromImages(sn, images);
+			const filename = await this.app.fileManager.getAvailablePathForAttachment(`${basename}.pdf`);
+			const tfile = await this.app.vault.createBinary(filename, toArrayBuffer(pdfBytes));
+			const link = this.app.fileManager.generateMarkdownLink(tfile, targetPath);
+			return `${link}\n`;
+		}
+
 		const imgs = await this.writeImageFiles(basename, sn);
 
 		let content = `## ${basename}\n\n`;
 		for (let i = 0; i < sn.pages.length; i++) {
 			content += `### Page ${i + 1}\n\n`;
-			if (sn.pages[i].text !== undefined && sn.pages[i].text.length > 0) {
+			if (format === 'images-text' && sn.pages[i].text !== undefined && sn.pages[i].text.length > 0) {
 				content += `${processSupernoteText(sn.pages[i].text, this.settings)}\n`;
 			}
 
@@ -1630,7 +1657,7 @@ export default class SupernotePlugin extends Plugin {
 
 		this.addCommand({
 			id: 'import-todays-pages',
-			name: "Import new or edited pages by date as images",
+			name: "Import new or edited pages by date",
 			editorCallback: (editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
 				if (this.settings.directConnectIP.length === 0) {
 					new DirectConnectErrorModal(this.app, this.settings, new Error("IP is unset")).open();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,6 +13,16 @@ export const FILE_BROWSER_SORT_LABELS: Record<FileBrowserSortOrder, string> = {
     'date-asc': 'Date (oldest first)',
 };
 
+export type ImportFormat = 'note-link' | 'embed' | 'images' | 'pdf' | 'images-text';
+
+export const IMPORT_FORMAT_LABELS: Record<ImportFormat, string> = {
+    'note-link': 'Note link (save .note file, link to it)',
+    'embed': 'Embedded note (save .note file, embed it)',
+    'images': 'Images only',
+    'pdf': 'PDF',
+    'images-text': 'Images and text',
+};
+
 // Obsidian's declarative settings API (1.13+): PluginSettingTab.getSettingDefinitions().
 // Not present in the `obsidian` devDependency's types (pinned pre-1.13, see CLAUDE.md on
 // why this repo can't casually bump it), so the shapes below are hand-typed to match the
@@ -56,6 +66,7 @@ export interface SupernotePluginSettings extends CustomDictionarySettings {
     showExportButtons: boolean;
     noteImageMaxDim: number;
     fileBrowserSortOrder: FileBrowserSortOrder;
+    importFormat: ImportFormat;
 }
 
 export const DEFAULT_SETTINGS: SupernotePluginSettings = {
@@ -64,6 +75,7 @@ export const DEFAULT_SETTINGS: SupernotePluginSettings = {
     showExportButtons: true,
     noteImageMaxDim: 800, // Sensible default for Nomad pages to be legible but not too big. Unit: px
     fileBrowserSortOrder: 'name-asc',
+    importFormat: 'images-text',
 	...CUSTOM_DICTIONARY_DEFAULT_SETTINGS,
 }
 
@@ -128,6 +140,15 @@ export class SupernoteSettingTab extends PluginSettingTab {
                     type: 'dropdown',
                     key: 'fileBrowserSortOrder',
                     options: FILE_BROWSER_SORT_LABELS,
+                },
+            },
+            {
+                name: 'Default import format',
+                desc: 'Default format used when importing today\'s (or a chosen date\'s) pages via "import new or edited pages by date". Can also be changed per-import from the import dialog.',
+                control: {
+                    type: 'dropdown',
+                    key: 'importFormat',
+                    options: IMPORT_FORMAT_LABELS,
                 },
             },
             {
@@ -216,6 +237,18 @@ export class SupernoteSettingTab extends PluginSettingTab {
                 .setValue(this.plugin.settings.fileBrowserSortOrder)
                 .onChange(async (value) => {
                     this.plugin.settings.fileBrowserSortOrder = value as FileBrowserSortOrder;
+                    await this.plugin.saveSettings();
+                })
+            );
+
+        new Setting(containerEl)
+            .setName('Default import format')
+            .setDesc('Default format used when importing today\'s (or a chosen date\'s) pages via "import new or edited pages by date". Can also be changed per-import from the import dialog.')
+            .addDropdown(dropdown => dropdown
+                .addOptions(IMPORT_FORMAT_LABELS)
+                .setValue(this.plugin.settings.importFormat)
+                .onChange(async (value) => {
+                    this.plugin.settings.importFormat = value as ImportFormat;
                     await this.plugin.saveSettings();
                 })
             );

--- a/styles.css
+++ b/styles.css
@@ -323,6 +323,13 @@ div.supernote-canvas-wrap canvas {
     margin-bottom: var(--size-4-3);
 }
 
+.supernote-import-format-row {
+    display: flex;
+    align-items: center;
+    gap: var(--size-4-1);
+    margin-bottom: var(--size-4-3);
+}
+
 .supernote-import-controls {
     display: flex;
     gap: var(--size-4-2);


### PR DESCRIPTION
## Summary
- Fixes #104
- The "Import new or edited pages by date" import dialog now has a format dropdown: note link, embedded note, images only, PDF, or images+text (previously always rasterized to images + embedded OCR text).
- The chosen format is remembered as the new default (`importFormat` setting), editable per-import from the dialog or persistently from the plugin's settings tab.
- Note-link/embed formats save the raw `.note` file into the vault and link/embed it (reusing the same pattern as the device file browser's download action and the existing `![[file.note]]` embed support). PDF format rasterizes then assembles a PDF into the vault and links to it (reusing the existing `exportToPDF`/`assemblePdfFromImages` logic).

## Test plan
- [x] `npm run build` (tsc + esbuild) succeeds
- [x] `npm test` — all 22 existing tests pass
- [x] `npm run lint` — no warnings/errors
- [x] Manually verify each of the 5 import formats end-to-end against a real/dev Supernote device (not done in this session — no device available)