### PR TITLE
Never let a beta version land in main's manifest.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,35 +28,56 @@ jobs:
       - name: Determine release channel
         id: channel
         run: |
-          tag="${GITHUB_REF#refs/tags/}"
+          tag="${{ github.ref_name }}"
+
+          # Plain "X.Y.Z" tags are stable/latest releases. Anything with a
+          # semver pre-release suffix (e.g. "3.0.2-beta.1") is a beta build,
+          # published as a GitHub pre-release.
+          if [[ "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "channel=stable" >> "$GITHUB_OUTPUT"
+          else
+            echo "channel=beta" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify manifest.json matches a stable tag
+        if: steps.channel.outputs.channel == 'stable'
+        run: |
+          tag="${{ github.ref_name }}"
           manifest_version=$(node -p "require('./manifest.json').version")
 
-          # BRAT and Obsidian's updater both fetch manifest.json from the
-          # release assets themselves, so it must match the tag exactly
-          # regardless of channel.
+          # Obsidian's own update-checker (for regular Community Store
+          # users, not BRAT) reads manifest.json straight from this repo's
+          # default branch to decide "is there a newer version" - it does
+          # NOT go through GitHub's /releases/latest. So manifest.json on
+          # main must only ever hold a stable version, and must match
+          # exactly what's being tagged here.
           if [ "$tag" != "$manifest_version" ]; then
-            echo "::error::Tag $tag does not match manifest.json's version ($manifest_version). Bump manifest.json to $tag before tagging."
+            echo "::error::Tag $tag does not match manifest.json's version ($manifest_version). Bump manifest.json (npm version) to $tag before tagging a stable release."
             exit 1
           fi
 
-          # Plain "X.Y.Z" tags are stable/latest releases. Anything with a
-          # semver pre-release suffix (e.g. "3.0.2-beta.1") is published as
-          # a GitHub pre-release, which is how BRAT (and Obsidian's own
-          # updater, which only ever looks at the "latest" release) tell
-          # beta builds apart from stable ones.
-          if [[ "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Tag $tag is a plain version -> stable release"
-            echo "channel=stable" >> "$GITHUB_OUTPUT"
-          else
-            echo "Tag $tag has a pre-release suffix -> beta (pre-)release"
-            echo "channel=beta" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Stamp beta version into the packaged manifest.json
+        if: steps.channel.outputs.channel == 'beta'
+        run: |
+          # Deliberately does NOT touch the manifest.json committed to
+          # main/any branch - only this CI workspace's copy, which is what
+          # gets uploaded as the release asset. Betas are never merged into
+          # manifest.json on main, precisely so Obsidian's update-checker
+          # (see the stable-channel check above) never sees a beta version.
+          node -e "
+            const fs = require('fs');
+            const m = JSON.parse(fs.readFileSync('manifest.json', 'utf8'));
+            m.version = process.env.TAG;
+            fs.writeFileSync('manifest.json', JSON.stringify(m, null, '\t'));
+          "
+        env:
+          TAG: ${{ github.ref_name }}
 
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          tag="${GITHUB_REF#refs/tags/}"
+          tag="${{ github.ref_name }}"
           prerelease_flag=""
           if [ "${{ steps.channel.outputs.channel }}" = "beta" ]; then
             prerelease_flag="--prerelease"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,10 +82,14 @@ npm test          # vitest run
   calls — `eslint-plugin-obsidianmd`'s `no-unsupported-api` rule checks this
   against `@since` tags in Obsidian's own type declarations and will error on
   a mismatch.
-- There's no separate beta manifest. BRAT and Obsidian's updater both fetch
-  `manifest.json` from the release assets, not the repo, so beta releases
-  just tag a `manifest.json` version with a semver pre-release suffix (e.g.
-  `3.0.2-beta.1`) — see the "Releasing" section in `README.md`.
+- There's no separate beta manifest file. `manifest.json` as committed must
+  only ever hold the last *stable* version — Obsidian's update-checker reads
+  it straight from the repo (not from GitHub's "latest release"), so a beta
+  version committed here would get offered to every installed user. Beta
+  releases are just a git tag with a semver pre-release suffix (e.g.
+  `3.0.2-beta.1`, no commit needed); the release workflow stamps that
+  version into `manifest.json` only inside its own build, for the release
+  asset — see the "Releasing" section in `README.md`.
 - `npm run version` bumps `manifest.json` and appends to `versions.json`
   (`version-bump.mjs`), skipping the write if that version is already
   present — don't hand-edit `versions.json` (a hand-edit is exactly what

--- a/README.md
+++ b/README.md
@@ -103,18 +103,24 @@ npm install
 
 Pushing a tag is the only manual step; [`.github/workflows/release.yml`](.github/workflows/release.yml)
 builds the plugin and publishes the GitHub release with `main.js`, `manifest.json` and
-`styles.css` attached. [BRAT](https://tfthacker.com/BRAT) and Obsidian's own updater both
-fetch `manifest.json` straight from the release assets (not from the repo), so the tag must
-exactly match the version in `manifest.json` at that commit — the workflow fails instead of
-publishing if it doesn't.
+`styles.css` attached. The tag's format decides the release channel:
 
-The tag's format decides the release channel:
+- A plain `X.Y.Z` tag is a **stable** release. The tag must exactly match the version
+  already committed in `manifest.json` — the workflow fails instead of publishing if it
+  doesn't.
+- A tag with a semver pre-release suffix, e.g. `X.Y.Z-beta.1`, is a **beta** release,
+  published as a GitHub pre-release.
 
-- A plain `X.Y.Z` tag is published as a full/latest release.
-- A tag with a semver pre-release suffix, e.g. `X.Y.Z-beta.1`, is published as a GitHub
-  pre-release. Obsidian's updater only ever looks at the "latest" (non-prerelease) release,
-  so this is invisible to regular Community Store users; BRAT is what beta testers use to
-  pick it up.
+`manifest.json` committed to the repo must only ever hold the last **stable** version.
+Obsidian's own update-checker (for regular Community Store users, not BRAT) reads
+`manifest.json` straight from this repo to decide whether a newer version exists — it does
+not go through GitHub's "latest release" API, so if a beta version ever landed in the
+committed `manifest.json`, every installed user's client would offer it as an update. To
+keep betas invisible to them, a beta tag is never preceded by a commit that bumps
+`manifest.json`: the release workflow stamps the tag's version into `manifest.json` only
+inside its own build, purely for the release asset, and that change is never merged back
+into the repo. [BRAT](https://tfthacker.com/BRAT) fetches `manifest.json` from that release
+asset (not from the repo), so it still sees the right beta version.
 
 To cut a stable release:
 
@@ -123,16 +129,16 @@ npm version <major|minor|patch>
 git push --follow-tags
 ```
 
-To cut a beta release:
+To cut a beta release, no commit is needed — just tag and push:
 
 ```
-npm version prerelease --preid=beta
-git push --follow-tags
+git tag <version>-beta.<n>
+git push origin <version>-beta.<n>
 ```
 
-Running `npm version prerelease --preid=beta` again bumps `3.0.2-beta.0` to
-`3.0.2-beta.1`, etc. To promote a beta that's already been tested to a full release, drop
-the suffix with `npm version patch` (or `npm version <exact version>` to match the beta
-exactly) and tag/push as usual — the same tag can't be reused for two different releases,
-so promoting a beta means cutting a new stable tag on top of it rather than editing the old
-pre-release in place.
+(`git tag -l '*-beta*' --sort=-v:refname` shows the last beta tag, to pick the next `<n>`.)
+
+To promote a beta that's already been tested to a full release, bump `manifest.json` to
+that (or a newer) version with `npm version` as above and tag/push as usual — the same tag
+can't be reused for two different releases, so promoting a beta means cutting a new stable
+tag on top of it rather than editing the old pre-release in place.


### PR DESCRIPTION
## Summary

Follow-up to #114 — fixes a real bug it introduced, caught before any beta tag was pushed under the new workflow.

Obsidian's own update-checker (for regular Community Store users, not BRAT) reads `manifest.json` straight from this repo's default branch to decide whether a newer version is available. It does **not** go through GitHub's `/releases/latest` API the way BRAT does. #114 had beta bumps write the beta version straight into `manifest.json` and commit it, which meant the moment that commit landed on `main`, every installed user's Obsidian client would have offered the beta as a normal update.

Fix:
- `manifest.json` as committed on `main` must only ever hold the last **stable** version. Stable tags still must match it exactly (unchanged from #114).
- Beta tags (`X.Y.Z-beta.N`) need **no commit at all** now — just `git tag` + `git push`. The workflow stamps the tag's version into `manifest.json` only inside its own CI build, purely to produce a correct release asset; that change never gets merged back into the repo.
- BRAT still works correctly since it fetches `manifest.json` from the release asset itself, not from the repo.
- Updated README's "Releasing" section and `AGENTS.md` to explain why this split exists, so it doesn't get "simplified" away again.

## Test plan

- [x] Verified the manifest-stamping snippet in isolation (produces the right `version` field without touching the real committed file).
- [x] `.github/workflows/release.yml` validated with a YAML parser.
- [x] `npm run build` succeeds.
- [ ] Not yet exercised end-to-end via a real tag push.