### PR TITLE
Default "show export buttons" setting to off

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -72,7 +72,7 @@ export interface SupernotePluginSettings extends CustomDictionarySettings {
 export const DEFAULT_SETTINGS: SupernotePluginSettings = {
     directConnectIP: '',
     invertColorsWhenDark: true,
-    showExportButtons: true,
+    showExportButtons: false,
     noteImageMaxDim: 800, // Sensible default for Nomad pages to be legible but not too big. Unit: px
     fileBrowserSortOrder: 'name-asc',
     importFormat: 'images-text',


### PR DESCRIPTION
## Summary
- New installs now default `showExportButtons` to `false` instead of `true`
- Export/import buttons on .note file views are opt-in via settings; the underlying commands remain available in the command palette regardless

## Test plan
- [ ] Fresh install: settings show "Show export buttons" toggle off, no export buttons appear on .note views
- [ ] Existing users: previously-saved `true` value is preserved (this only changes the default, not a migration)