### PR TITLE
Rename import-by-date command to "Import notes edited today"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This plugin has five main features:
 
 - ➡️  Export Supernote `*.note` files as PNGs and/or markdown files and attach them to your Vault.
 
-- 🧠 Attach all of today's modified Supernote notes and text to the current Obsidian note (great when paired with [daily notes](https://obsidian.md/help/plugins/daily-notes))
+- 🧠 Attach all of today's modified Supernote notes and text to the current Obsidian note with the "Import notes edited today" command (great when paired with [daily notes](https://obsidian.md/help/plugins/daily-notes))
 
 - 📺 Copy an image from a Supernote via [screen mirroring](https://support.supernote.com/en_US/organizing-managing/1791924-screen-mirroring) into your current note with the "Insert Supernote mirror image" command ([demo video](https://youtu.be/Ih_NW-z_aLw))
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1657,7 +1657,7 @@ export default class SupernotePlugin extends Plugin {
 
 		this.addCommand({
 			id: 'import-todays-pages',
-			name: "Import new or edited pages by date",
+			name: "Import notes edited today",
 			editorCallback: (editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
 				if (this.settings.directConnectIP.length === 0) {
 					new DirectConnectErrorModal(this.app, this.settings, new Error("IP is unset")).open();


### PR DESCRIPTION
## Summary
- Renames the `import-todays-pages` command from "Import new or edited pages by date" to "Import notes edited today" for clarity.
- Documents the command name in the README next to its feature bullet.

## Test plan
- [ ] Reload the plugin in Obsidian and confirm the command palette shows "Import notes edited today"