### PR TITLE
Auto-sync .note files to markdown, with mirror/watch folders

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -185,15 +185,43 @@ class VaultWriter {
 		this.settings = settings;
 	}
 
-	async writeMarkdownFile(file: TFile, sn: SupernoteX, imgs: TFile[] | null) {
+	async writeMarkdownFile(file: TFile, sn: SupernoteX, imgs: TFile[] | null, overwrite = false) {
 		let content = '';
 
-		// Generate a non-conflicting filename - it has a bit of a race but that is OK
-		let filename = `${file.parent?.path}/${file.basename}.md`;
-		let i = 0;
-		while (this.app.vault.getFileByPath(filename) !== null) {
-			filename = `${file.parent?.path}/${file.basename} ${++i}.md`;
+		// Derive the output path from the .note file's own vault path rather than
+		// `${file.parent?.path}/${file.basename}.md`: for vault-root files
+		// file.parent.path is "/", which produced a "//name.md" double-slash bug.
+		const relMdPath = file.path.replace(/\.note$/i, '.md');
+		// The mirror folder applies only when the file is inside the watched
+		// folder (or no watched folder is set) - files outside it always save
+		// alongside the note. When both are set, the watched folder prefix is
+		// stripped from the mirror path to avoid duplicating it.
+		const mirrorFolder = this.settings.markdownMirrorFolder;
+		const watchFolder = this.settings.noteWatchFolder.replace(/\/$/, '');
+		let baseFilename: string;
+		if (mirrorFolder && (!watchFolder || file.path.startsWith(watchFolder + '/'))) {
+			let mirrorRelPath = relMdPath;
+			if (watchFolder) {
+				const prefix = watchFolder + '/';
+				if (mirrorRelPath.startsWith(prefix)) mirrorRelPath = mirrorRelPath.slice(prefix.length);
+			}
+			baseFilename = `${mirrorFolder}/${mirrorRelPath}`;
+		} else {
+			baseFilename = relMdPath;
 		}
+		const dir = baseFilename.slice(0, baseFilename.length - `${file.basename}.md`.length);
+		let filename = baseFilename;
+
+		if (!overwrite) {
+			// Generate a non-conflicting filename - it has a bit of a race but that is OK
+			let i = 0;
+			while (this.app.vault.getFileByPath(filename) !== null) {
+				filename = `${dir}${file.basename} ${++i}.md`;
+			}
+		}
+
+		// Create any missing parent folders (e.g. the mirror folder) before writing.
+		if (dir) await this.ensureFolderExists(dir.replace(/\/$/, ''));
 
 		content = this.app.fileManager.generateMarkdownLink(file, filename);
 		content += '\n';
@@ -214,7 +242,41 @@ class VaultWriter {
 			}
 		}
 
-		await this.app.vault.create(filename, content);
+		if (overwrite) {
+			const existing = this.app.vault.getFileByPath(baseFilename);
+			if (existing) {
+				await this.app.vault.modify(existing, content);
+			} else {
+				try {
+					await this.app.vault.create(baseFilename, content);
+				} catch {
+					// Race condition: Obsidian fires both 'create' and 'modify' vault
+					// events in quick succession when a .note file syncs, and both
+					// handlers call attachMarkdownFile(). The file may have been
+					// created between the getFileByPath check above and this
+					// vault.create() call - fetch it again and update it instead.
+					const raceFile = this.app.vault.getFileByPath(baseFilename);
+					if (raceFile) await this.app.vault.modify(raceFile, content);
+				}
+			}
+		} else {
+			await this.app.vault.create(filename, content);
+		}
+	}
+
+	private async ensureFolderExists(path: string): Promise<void> {
+		const parts = path.split('/').filter(Boolean);
+		let current = '';
+		for (const part of parts) {
+			current = current ? `${current}/${part}` : part;
+			if (!this.app.vault.getAbstractFileByPath(current)) {
+				try {
+					await this.app.vault.createFolder(current);
+				} catch {
+					// Folder may have been created concurrently by another sync event; ignore.
+				}
+			}
+		}
 	}
 
 	async writeImageFiles(basename: string, sn: SupernoteX): Promise<TFile[]> {
@@ -237,11 +299,11 @@ class VaultWriter {
 		return imgs;
 	}
 
-	async attachMarkdownFile(file: TFile) {
+	async attachMarkdownFile(file: TFile, overwrite = false) {
 		const note = await this.app.vault.readBinary(file);
 		const sn = new SupernoteX(new Uint8Array(note));
 
-		await this.writeMarkdownFile(file, sn, null);
+		await this.writeMarkdownFile(file, sn, null, overwrite);
 	}
 
 	async attachNoteFiles(file: TFile) {
@@ -1671,6 +1733,46 @@ export default class SupernotePlugin extends Plugin {
 				new ImportTodayModal(this.app, this, editor, targetPath).open();
 			},
 		});
+
+		// Auto-sync: keep each watched .note file's markdown export up to date as
+		// the .note file changes, e.g. via a mobile sync tool dropping updated
+		// files into the vault. 'modify' fires on every incremental write during
+		// a sync, so debounce it rather than re-exporting on each one.
+		const syncDebounceMap = new Map<string, ReturnType<typeof window.setTimeout>>();
+		this.register(() => {
+			for (const timeout of syncDebounceMap.values()) window.clearTimeout(timeout);
+			syncDebounceMap.clear();
+		});
+
+		const isWatchedNoteFile = (file: unknown): file is TFile => {
+			if (!this.settings.isAutoSyncMarkdownEnabled) return false;
+			if (!(file instanceof TFile) || file.extension !== 'note') return false;
+			const watchFolder = this.settings.noteWatchFolder.replace(/\/$/, '');
+			return !watchFolder || file.path.startsWith(watchFolder + '/');
+		};
+
+		this.registerEvent(
+			this.app.vault.on('create', (file) => {
+				if (!isWatchedNoteFile(file)) return;
+				vw.attachMarkdownFile(file, true).catch((err: unknown) => {
+					console.error('Supernote auto-sync (create) error:', err);
+				});
+			})
+		);
+
+		this.registerEvent(
+			this.app.vault.on('modify', (file) => {
+				if (!isWatchedNoteFile(file)) return;
+				const existing = syncDebounceMap.get(file.path);
+				if (existing) window.clearTimeout(existing);
+				syncDebounceMap.set(file.path, window.setTimeout(() => {
+					syncDebounceMap.delete(file.path);
+					vw.attachMarkdownFile(file, true).catch((err: unknown) => {
+						console.error('Supernote auto-sync (modify) error:', err);
+					});
+				}, 2000));
+			})
+		);
 	}
 
 	onunload() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -67,6 +67,9 @@ export interface SupernotePluginSettings extends CustomDictionarySettings {
     noteImageMaxDim: number;
     fileBrowserSortOrder: FileBrowserSortOrder;
     importFormat: ImportFormat;
+    isAutoSyncMarkdownEnabled: boolean;
+    noteWatchFolder: string;
+    markdownMirrorFolder: string;
 }
 
 export const DEFAULT_SETTINGS: SupernotePluginSettings = {
@@ -76,6 +79,9 @@ export const DEFAULT_SETTINGS: SupernotePluginSettings = {
     noteImageMaxDim: 800, // Sensible default for Nomad pages to be legible but not too big. Unit: px
     fileBrowserSortOrder: 'name-asc',
     importFormat: 'images-text',
+    isAutoSyncMarkdownEnabled: false,
+    noteWatchFolder: '',
+    markdownMirrorFolder: '',
 	...CUSTOM_DICTIONARY_DEFAULT_SETTINGS,
 }
 
@@ -149,6 +155,32 @@ export class SupernoteSettingTab extends PluginSettingTab {
                     type: 'dropdown',
                     key: 'importFormat',
                     options: IMPORT_FORMAT_LABELS,
+                },
+            },
+            {
+                name: 'Auto-sync .note files to markdown',
+                desc: 'Automatically export recognized text to a .md file whenever a .note file is added or modified in the vault.',
+                control: {
+                    type: 'toggle',
+                    key: 'isAutoSyncMarkdownEnabled',
+                },
+            },
+            {
+                name: 'Auto-sync watched folder',
+                desc: 'Only auto-sync .note files inside this vault folder. Leave empty to watch the whole vault. Example: Supernote',
+                control: {
+                    type: 'text',
+                    key: 'noteWatchFolder',
+                    placeholder: 'Supernote',
+                },
+            },
+            {
+                name: 'Markdown mirror folder',
+                desc: 'Save exported .md files in this vault folder, mirroring the .note file structure, instead of alongside each .note file. Leave empty to save alongside the note. Example: SupernoteMarkdowns',
+                control: {
+                    type: 'text',
+                    key: 'markdownMirrorFolder',
+                    placeholder: 'SupernoteMarkdowns',
                 },
             },
             {
@@ -249,6 +281,41 @@ export class SupernoteSettingTab extends PluginSettingTab {
                 .setValue(this.plugin.settings.importFormat)
                 .onChange(async (value) => {
                     this.plugin.settings.importFormat = value as ImportFormat;
+                    await this.plugin.saveSettings();
+                })
+            );
+
+        new Setting(containerEl)
+            .setName('Auto-sync .note files to markdown')
+            .setDesc('Automatically export recognized text to a .md file whenever a .note file is added or modified in the vault.')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.isAutoSyncMarkdownEnabled)
+                .onChange(async (value) => {
+                    this.plugin.settings.isAutoSyncMarkdownEnabled = value;
+                    await this.plugin.saveSettings();
+                })
+            );
+
+        new Setting(containerEl)
+            .setName('Auto-sync watched folder')
+            .setDesc('Only auto-sync .note files inside this vault folder. Leave empty to watch the whole vault. Example: Supernote')
+            .addText(text => text
+                .setPlaceholder('Supernote')
+                .setValue(this.plugin.settings.noteWatchFolder)
+                .onChange(async (value) => {
+                    this.plugin.settings.noteWatchFolder = value.trim().replace(/\/$/, '');
+                    await this.plugin.saveSettings();
+                })
+            );
+
+        new Setting(containerEl)
+            .setName('Markdown mirror folder')
+            .setDesc('Save exported .md files in this vault folder, mirroring the .note file structure, instead of alongside each .note file. Leave empty to save alongside the note. Example: SupernoteMarkdowns')
+            .addText(text => text
+                .setPlaceholder('SupernoteMarkdowns')
+                .setValue(this.plugin.settings.markdownMirrorFolder)
+                .onChange(async (value) => {
+                    this.plugin.settings.markdownMirrorFolder = value.trim().replace(/\/$/, '');
                     await this.plugin.saveSettings();
                 })
             );


### PR DESCRIPTION
## Summary

Split out of #81 (by @Floper), rebased onto current `main`. This is the auto-sync + mirror/watch-folder piece; it has no dependency on the other pieces of #81.

- **New opt-in auto-sync**: when a `.note` file is created or modified in the vault (e.g. by a mobile sync tool), automatically write/update its markdown export.
  - `modify` events are debounced (2s) since a sync can fire several in quick succession for one file.
  - Handles the race where Obsidian fires both `create` and `modify` for the same sync: falls back from `vault.create` to `vault.modify` if the file already exists by the time we write.
- **Watched folder** setting: scope auto-sync to one vault folder instead of the whole vault.
- **Markdown mirror folder** setting: save exported `.md` files into a separate folder that mirrors the `.note` structure, instead of alongside each `.note` file. `ensureFolderExists` creates missing intermediate folders.
- **Bug fix**: `writeMarkdownFile`'s path construction used `` `${file.parent?.path}/${file.basename}.md` ``, which produces `//name.md` for vault-root files (Obsidian returns `"/"` as the root folder path). Now derived from `file.path` directly.

Ported onto the current `settings.ts` declarative-settings API and the current `VaultWriter` shape (`main` has diverged substantially from #81's base).

## Test plan
- [x] `npm run build` (tsc + esbuild) - clean
- [x] `npx eslint src/main.ts src/settings.ts` - 0 errors
- [x] `npx vitest run` - 22 passed
- [ ] Manual test in Obsidian: enable auto-sync, drop/modify a `.note` file, confirm `.md` export appears/updates; test watched-folder and mirror-folder settings together and independently