### PR TITLE
Export Supernote keywords as tags and links as Wikilinks

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { installAtPolyfill } from './polyfills';
 import { App, Modal, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, Component, loadPdfJs, Scope, SearchComponent, setIcon, Platform } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS, ImportFormat } from './settings';
-import { SupernoteX, fetchMirrorFrame, createPdfContext, addPdfPage } from 'supernote-typescript';
+import { SupernoteX, fetchMirrorFrame, createPdfContext, addPdfPage, ILink } from 'supernote-typescript';
 import { encode } from 'image-js';
 import { DownloadListModal, UploadListModal } from './FileListModal';
 import { ImportTodayModal } from './ImportTodayModal';
@@ -198,10 +198,60 @@ class VaultWriter {
 		content = this.app.fileManager.generateMarkdownLink(file, filename);
 		content += '\n';
 
+		// Build a per-page keyword-tag map from the note's starred keywords. The
+		// KEYWORD footer key's first 4 digits (1-indexed) give the source page,
+		// matching the LINKO key format - more reliable than KEYWORDPAGE, which
+		// can be '0' (invalid). Keyword text is sanitized into a tag by turning
+		// non-alphanumeric characters into '_'.
+		const keywordsByPage = new Map<number, string[]>();
+		if (this.settings.isKeywordsAndLinksEnabled) {
+			for (const key of Object.keys(sn.keywords)) {
+				const pageIdx = parseInt(key.slice(0, 4)) - 1;
+				for (const kw of sn.keywords[key]) {
+					const text = kw.KEYWORD.trim();
+					if (!text) continue;
+					const tag = `#${text.replace(/[^\w-]/g, '_').replace(/_+/g, '_').replace(/^_|_$/g, '')}`;
+					if (!keywordsByPage.has(pageIdx)) keywordsByPage.set(pageIdx, []);
+					if (!keywordsByPage.get(pageIdx)!.includes(tag)) keywordsByPage.get(pageIdx)!.push(tag);
+				}
+			}
+		}
+
+		// Build a per-page link map. The LINKO key's first 4 digits (1-indexed)
+		// give the source page, more reliable than OBJPAGE. Sorting keys gives
+		// top-to-bottom link order within each page (the key also encodes the Y
+		// coordinate after the page prefix).
+		const linksByPage = new Map<number, string[]>();
+		if (this.settings.isKeywordsAndLinksEnabled) {
+			const noteCache = new Map<string, SupernoteX>();
+			for (const key of Object.keys(sn.links).sort()) {
+				for (const link of sn.links[key]) {
+					if (!link.text) continue;
+					const text = await this.resolvePageAnchor(link, noteCache);
+					const pageIdx = parseInt(key.slice(0, 4)) - 1;
+					if (!linksByPage.has(pageIdx)) linksByPage.set(pageIdx, []);
+					linksByPage.get(pageIdx)!.push(`[[${text}]]`);
+				}
+			}
+		}
+
 		for (let i = 0; i < sn.pages.length; i++) {
 			content += `## Page ${i + 1}\n\n`
+			let pageOcrText = '';
 			if (sn.pages[i].text !== undefined && sn.pages[i].text.length > 0) {
-				content += `${processSupernoteText(sn.pages[i].text, this.settings)}\n`;
+				pageOcrText = processSupernoteText(sn.pages[i].text, this.settings);
+			}
+			// Only emit keyword tags not already present in the OCR text.
+			const pageTags = keywordsByPage.get(i);
+			if (pageTags) {
+				const missing = pageTags.filter(tag => !pageOcrText.includes(tag));
+				if (missing.length > 0) content += missing.join(' ') + '\n\n';
+			}
+			if (pageOcrText) content += `${pageOcrText}\n`;
+			// Append Supernote internal links that appear on this page.
+			const pageLinks = linksByPage.get(i);
+			if (pageLinks) {
+				content += pageLinks.join('\n') + '\n';
 			}
 			if (imgs) {
 				let alt = '';
@@ -215,6 +265,37 @@ class VaultWriter {
 		}
 
 		await this.app.vault.create(filename, content);
+	}
+
+	// The library already resolves same-document page anchors (ILink.text
+	// contains "#Page N" when PAGEID matches a page in this document). This
+	// only has cross-file anchors left to resolve: load the target .note file
+	// from the vault by its (already-decoded) basename and look up PAGEID
+	// among its pages. A per-call cache avoids re-parsing the same file
+	// multiple times when a note links to it more than once.
+	private async resolvePageAnchor(link: ILink, cache: Map<string, SupernoteX>): Promise<string> {
+		if (link.text.includes('#')) return link.text;
+		const pageid = link.PAGEID;
+		if (!pageid || pageid === '0' || pageid === 'none') return link.text;
+
+		const targetBasename = link.text;
+		let targetNote = cache.get(targetBasename);
+		if (!targetNote) {
+			const noteFile = this.app.vault.getFiles().find(
+				f => f.extension === 'note' && f.basename === targetBasename
+			);
+			if (!noteFile) return link.text;
+			try {
+				const buffer = await this.app.vault.readBinary(noteFile);
+				targetNote = new SupernoteX(new Uint8Array(buffer));
+				cache.set(targetBasename, targetNote);
+			} catch {
+				return link.text;
+			}
+		}
+
+		const pageIndex = targetNote.pages.findIndex(p => p.PAGEID === pageid);
+		return pageIndex >= 0 ? `${link.text}#Page ${pageIndex + 1}` : link.text;
 	}
 
 	async writeImageFiles(basename: string, sn: SupernoteX): Promise<TFile[]> {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -67,6 +67,7 @@ export interface SupernotePluginSettings extends CustomDictionarySettings {
     noteImageMaxDim: number;
     fileBrowserSortOrder: FileBrowserSortOrder;
     importFormat: ImportFormat;
+    isKeywordsAndLinksEnabled: boolean;
 }
 
 export const DEFAULT_SETTINGS: SupernotePluginSettings = {
@@ -76,6 +77,7 @@ export const DEFAULT_SETTINGS: SupernotePluginSettings = {
     noteImageMaxDim: 800, // Sensible default for Nomad pages to be legible but not too big. Unit: px
     fileBrowserSortOrder: 'name-asc',
     importFormat: 'images-text',
+    isKeywordsAndLinksEnabled: true,
 	...CUSTOM_DICTIONARY_DEFAULT_SETTINGS,
 }
 
@@ -149,6 +151,14 @@ export class SupernoteSettingTab extends PluginSettingTab {
                     type: 'dropdown',
                     key: 'importFormat',
                     options: IMPORT_FORMAT_LABELS,
+                },
+            },
+            {
+                name: 'Convert supernote keywords to tags and links to wikilinks',
+                desc: 'In exported markdown, turn starred keywords into Obsidian tags (e.g. #my_tag) and supernote internal links into wikilinks (e.g. [[note#page 1]]).',
+                control: {
+                    type: 'toggle',
+                    key: 'isKeywordsAndLinksEnabled',
                 },
             },
             {
@@ -249,6 +259,17 @@ export class SupernoteSettingTab extends PluginSettingTab {
                 .setValue(this.plugin.settings.importFormat)
                 .onChange(async (value) => {
                     this.plugin.settings.importFormat = value as ImportFormat;
+                    await this.plugin.saveSettings();
+                })
+            );
+
+        new Setting(containerEl)
+            .setName('Convert supernote keywords to tags and links to wikilinks')
+            .setDesc('In exported markdown, turn starred keywords into Obsidian tags (e.g. #my_tag) and supernote internal links into wikilinks (e.g. [[note#page 1]]).')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.isKeywordsAndLinksEnabled)
+                .onChange(async (value) => {
+                    this.plugin.settings.isKeywordsAndLinksEnabled = value;
                     await this.plugin.saveSettings();
                 })
             );


### PR DESCRIPTION
## Summary

Split out of #81 (by @Floper), stacked on #121 (submodule bump) since it needs `ILink`/`sn.links` and richer `sn.keywords` from `supernote-typescript`.

- **Keywords → tags**: starred keywords are emitted as Obsidian tags (e.g. `#My_Keyword`) on the correct page, rather than as a flat list at the top of the document. Page is derived from the `KEYWORD` footer key's prefix (more reliable than `KEYWORDPAGE`, which can be `'0'`/invalid - see the parsing library's own test for this). Deduplicated against tags already present in that page's OCR text.
- **Links → Wikilinks**: Supernote internal links are emitted as Wikilinks on the correct page, ordered top-to-bottom by sorting `LINKO` keys. The library already resolves same-document page anchors (`ILink.text` gets `#Page N` appended); this adds cross-file anchor resolution - loads the target `.note` file from the vault and looks up its `PAGEID`, with a per-call cache to avoid re-parsing the same target note more than once per export.
- Both gated behind a new **"Convert supernote keywords to tags and links to wikilinks"** setting, on by default.

Ported onto the current `main.ts`/`settings.ts` shape, and built on the *now-current* `supernote-typescript` link/keyword API (#24) rather than #81's own version of that work, which never merged.

## Test plan
- [x] `npm run build` - clean
- [x] `npx eslint src/main.ts src/settings.ts` - 0 errors
- [x] `npx vitest run` - 22 passed
- [ ] Manual test in Obsidian against a `.note` file with keyword stars and internal links (e.g. the submodule's `tests/input/nomad-3.26.40-link-tag-3p.note` fixture), verifying tag placement/dedup and same-file/cross-file Wikilink anchors