### PR TITLE
Auto-sync .note files from device to vault (manual, phase 1 of #119)

### DIFF
--- a/src/FileListModal.ts
+++ b/src/FileListModal.ts
@@ -43,6 +43,28 @@ export async function fetchSupernoteDirectory(ip: string, path: string): Promise
     return data.fileList.sort(compareByDirectoryThenNameThenDate);
 }
 
+// Recursively walks the whole device tree starting at `path`, collecting
+// every `.note` file found. Shared by ImportTodayModal (which further
+// filters by date) and the device auto-sync engine (which filters by the
+// configured path patterns) — both need the same "list everything once"
+// traversal, just with different downstream filtering.
+export async function scanDeviceNoteTree(ip: string, path = '/', visited: Set<string> = new Set()): Promise<SupernoteFile[]> {
+    if (visited.has(path)) return [];
+    visited.add(path);
+
+    const entries = await fetchSupernoteDirectory(ip, path);
+    const results: SupernoteFile[] = [];
+
+    for (const entry of entries) {
+        if (entry.isDirectory) {
+            results.push(...await scanDeviceNoteTree(ip, entry.uri, visited));
+        } else if (entry.name.toLowerCase().endsWith('.note')) {
+            results.push(entry);
+        }
+    }
+    return results;
+}
+
 function compareByDirectoryThenNameThenDate(a: SupernoteFile, b: SupernoteFile): number {
     if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
 

--- a/src/ImportTodayModal.ts
+++ b/src/ImportTodayModal.ts
@@ -1,6 +1,6 @@
 import { App, Modal, Notice, Editor } from 'obsidian';
 import SupernotePlugin from './main';
-import { SupernoteFile, fetchSupernoteDirectory } from './FileListModal';
+import { SupernoteFile, scanDeviceNoteTree } from './FileListModal';
 import { fetchFromDevice, DEVICE_TRANSFER_TIMEOUT_MS } from './deviceFetch';
 import { parseDeviceDate, isSameLocalDay, todayLocalMidnight, formatDateInputValue, parseDateInputValue } from './deviceDate';
 import { ImportFormat, IMPORT_FORMAT_LABELS } from './settings';
@@ -42,7 +42,7 @@ export class ImportTodayModal extends Modal {
         const status = contentEl.createEl('p', { text: 'Scanning device for notes…' });
 
         try {
-            this.allNotes = await this.scanAllNotes('/', new Set());
+            this.allNotes = await this.scanAllNotes();
         } catch (err) {
             status.setText(`Failed to scan device: ${err instanceof Error ? err.message : String(err)}`);
             return;
@@ -140,21 +140,13 @@ export class ImportTodayModal extends Modal {
     // Walks the whole device tree once and records every .note file's parsed
     // date, so switching the date picker only needs to re-filter in memory
     // instead of re-fetching the device's directory tree over HTTP each time.
-    private async scanAllNotes(path: string, visited: Set<string>): Promise<ScannedNote[]> {
-        if (visited.has(path)) return [];
-        visited.add(path);
-
-        const entries = await fetchSupernoteDirectory(this.plugin.settings.directConnectIP, path);
+    private async scanAllNotes(): Promise<ScannedNote[]> {
+        const files = await scanDeviceNoteTree(this.plugin.settings.directConnectIP);
         const results: ScannedNote[] = [];
-
-        for (const entry of entries) {
-            if (entry.isDirectory) {
-                results.push(...await this.scanAllNotes(entry.uri, visited));
-            } else if (entry.name.toLowerCase().endsWith('.note')) {
-                const modified = parseDeviceDate(entry.date);
-                if (modified) {
-                    results.push({ file: entry, date: modified });
-                }
+        for (const file of files) {
+            const modified = parseDeviceDate(file.date);
+            if (modified) {
+                results.push({ file, date: modified });
             }
         }
         return results;

--- a/src/deviceSync.test.ts
+++ b/src/deviceSync.test.ts
@@ -1,0 +1,529 @@
+import { describe, it, expect } from 'vitest';
+import {
+    globToRegExp,
+    matchesAnyPattern,
+    parsePathFilters,
+    classifyChange,
+    planSync,
+    deviceUriToVaultPath,
+    hashBytes,
+    decideWrite,
+    buildSyncRecord,
+    syncLogPath,
+    formatSyncLogEntry,
+    formatSyncFailureLogEntry,
+    DeviceNoteListing,
+    SyncManifest,
+    SyncedNoteRecord,
+} from './deviceSync';
+
+function bytesOf(text: string): Uint8Array {
+    return new TextEncoder().encode(text);
+}
+
+function listing(overrides: Partial<DeviceNoteListing> = {}): DeviceNoteListing {
+    return { uri: '/Note/foo.note', date: '2026-07-25 10:33:04', size: 1000, ...overrides };
+}
+
+function record(overrides: Partial<SyncedNoteRecord> = {}): SyncedNoteRecord {
+    return {
+        deviceUri: '/Note/foo.note',
+        deviceDate: '2026-07-25 10:33:04',
+        deviceSize: 1000,
+        vaultPath: 'Supernote sync/Note/foo.note',
+        contentHash: hashBytes(bytesOf('hello')),
+        lastSyncedAt: '2026-07-25T10:33:04.000Z',
+        ...overrides,
+    };
+}
+
+describe('globToRegExp / matchesAnyPattern', () => {
+    it('matches a literal path exactly', () => {
+        expect(globToRegExp('/Note/foo.note').test('/Note/foo.note')).toBe(true);
+        expect(globToRegExp('/Note/foo.note').test('/Note/bar.note')).toBe(false);
+    });
+
+    it('does not match a partial/unanchored substring', () => {
+        expect(globToRegExp('foo.note').test('/Note/foo.note')).toBe(false);
+    });
+
+    it('* matches within a single path segment but not across /', () => {
+        const re = globToRegExp('/Diary/*.note');
+        expect(re.test('/Diary/2026-07-25.note')).toBe(true);
+        expect(re.test('/Diary/Sub/2026-07-25.note')).toBe(false);
+    });
+
+    it('** matches across directory boundaries', () => {
+        const re = globToRegExp('/Diary/**');
+        expect(re.test('/Diary/2026-07-25.note')).toBe(true);
+        expect(re.test('/Diary/Sub/Folder/2026-07-25.note')).toBe(true);
+        expect(re.test('/Work/2026-07-25.note')).toBe(false);
+    });
+
+    it('? matches exactly one character', () => {
+        const re = globToRegExp('/Note/day?.note');
+        expect(re.test('/Note/day1.note')).toBe(true);
+        expect(re.test('/Note/day12.note')).toBe(false);
+    });
+
+    it('escapes regex metacharacters in the literal portions', () => {
+        const re = globToRegExp('/Note/a+b(1).note');
+        expect(re.test('/Note/a+b(1).note')).toBe(true);
+        expect(re.test('/Note/aXb1.note')).toBe(false);
+    });
+
+    it('matchesAnyPattern treats an empty pattern list as "match everything"', () => {
+        expect(matchesAnyPattern('/Anything/at/all.note', [])).toBe(true);
+    });
+
+    it('matchesAnyPattern is true if any one pattern matches', () => {
+        const patterns = ['/Work/**', '/Diary/**'];
+        expect(matchesAnyPattern('/Diary/today.note', patterns)).toBe(true);
+        expect(matchesAnyPattern('/Personal/today.note', patterns)).toBe(false);
+    });
+});
+
+describe('parsePathFilters', () => {
+    it('splits on newlines and commas, trimming whitespace', () => {
+        expect(parsePathFilters('/Diary/**, /Work/**\n/Personal/**')).toEqual([
+            '/Diary/**',
+            '/Work/**',
+            '/Personal/**',
+        ]);
+    });
+
+    it('drops empty entries from trailing separators or blank lines', () => {
+        expect(parsePathFilters('/Diary/**,\n\n, /Work/**,')).toEqual(['/Diary/**', '/Work/**']);
+    });
+
+    it('returns an empty array for blank input', () => {
+        expect(parsePathFilters('')).toEqual([]);
+        expect(parsePathFilters('   \n  ')).toEqual([]);
+    });
+});
+
+describe('classifyChange', () => {
+    it('is "new" when there is no manifest record for the device URI', () => {
+        expect(classifyChange(listing(), {})).toBe('new');
+    });
+
+    it('is "unchanged" when date and size both match the manifest record', () => {
+        const manifest: SyncManifest = { '/Note/foo.note': record() };
+        expect(classifyChange(listing(), manifest)).toBe('unchanged');
+    });
+
+    it('is "changed" when the date differs but size matches', () => {
+        const manifest: SyncManifest = { '/Note/foo.note': record({ deviceDate: '2026-07-24 09:00:00' }) };
+        expect(classifyChange(listing(), manifest)).toBe('changed');
+    });
+
+    it('is "changed" when the size differs but date matches', () => {
+        const manifest: SyncManifest = { '/Note/foo.note': record({ deviceSize: 999 }) };
+        expect(classifyChange(listing(), manifest)).toBe('changed');
+    });
+
+    it('is "changed" when both date and size differ', () => {
+        const manifest: SyncManifest = {
+            '/Note/foo.note': record({ deviceDate: '2020-01-01 00:00:00', deviceSize: 1 }),
+        };
+        expect(classifyChange(listing(), manifest)).toBe('changed');
+    });
+
+    it('keys strictly off the device URI, not just size/date coincidence', () => {
+        const manifest: SyncManifest = { '/Note/other.note': record({ deviceUri: '/Note/other.note' }) };
+        expect(classifyChange(listing(), manifest)).toBe('new');
+    });
+});
+
+describe('planSync (efficiency: skip unchanged, respect scope, never propose deletes)', () => {
+    it('puts a never-before-seen file in toSync', () => {
+        const plan = planSync([listing()], {}, []);
+        expect(plan.toSync).toEqual([listing()]);
+        expect(plan.unchanged).toEqual([]);
+        expect(plan.excluded).toEqual([]);
+    });
+
+    it('skips a file whose date and size are unchanged from the manifest — no re-download proposed', () => {
+        const manifest: SyncManifest = { '/Note/foo.note': record() };
+        const plan = planSync([listing()], manifest, []);
+        expect(plan.toSync).toEqual([]);
+        expect(plan.unchanged).toEqual([listing()]);
+    });
+
+    it('re-proposes a file whose device date/size moved on from the manifest', () => {
+        const manifest: SyncManifest = { '/Note/foo.note': record({ deviceSize: 1 }) };
+        const plan = planSync([listing()], manifest, []);
+        expect(plan.toSync).toEqual([listing()]);
+        expect(plan.unchanged).toEqual([]);
+    });
+
+    it('excludes files outside the configured path filters regardless of change state', () => {
+        const changedButOutOfScope = listing({ uri: '/Work/foo.note' });
+        const manifest: SyncManifest = {}; // "new" — would otherwise sync
+        const plan = planSync([changedButOutOfScope], manifest, ['/Diary/**']);
+        expect(plan.toSync).toEqual([]);
+        expect(plan.excluded).toEqual([changedButOutOfScope]);
+    });
+
+    it('partitions a mixed batch into the three buckets correctly', () => {
+        const inScopeNew = listing({ uri: '/Diary/new.note' });
+        const inScopeUnchanged = listing({ uri: '/Diary/same.note' });
+        const inScopeChanged = listing({ uri: '/Diary/changed.note', size: 2000 });
+        const outOfScope = listing({ uri: '/Work/foo.note' });
+
+        const manifest: SyncManifest = {
+            '/Diary/same.note': record({ deviceUri: '/Diary/same.note' }),
+            '/Diary/changed.note': record({ deviceUri: '/Diary/changed.note', deviceSize: 1 }),
+        };
+
+        const plan = planSync(
+            [inScopeNew, inScopeUnchanged, inScopeChanged, outOfScope],
+            manifest,
+            ['/Diary/**'],
+        );
+
+        expect(plan.toSync).toEqual([inScopeNew, inScopeChanged]);
+        expect(plan.unchanged).toEqual([inScopeUnchanged]);
+        expect(plan.excluded).toEqual([outOfScope]);
+    });
+
+    it('never produces anything resembling a delete — files missing from the listing are simply absent from every bucket', () => {
+        // Manifest remembers a file the device no longer reports (deleted/renamed
+        // on-device). It must not show up anywhere in the plan, and in particular
+        // must not appear in a bucket that would cause the vault copy to be removed.
+        const manifest: SyncManifest = { '/Note/gone.note': record({ deviceUri: '/Note/gone.note' }) };
+        const plan = planSync([listing()], manifest, []);
+
+        const allBucketed = [...plan.toSync, ...plan.unchanged, ...plan.excluded].map((f) => f.uri);
+        expect(allBucketed).not.toContain('/Note/gone.note');
+        expect(plan).not.toHaveProperty('toDelete');
+    });
+
+    it('is a pure function of its inputs — the same call twice gives the same result', () => {
+        const files = [listing({ uri: '/Diary/a.note' }), listing({ uri: '/Diary/b.note', size: 5 })];
+        const manifest: SyncManifest = { '/Diary/a.note': record({ deviceUri: '/Diary/a.note' }) };
+        expect(planSync(files, manifest, ['/Diary/**'])).toEqual(planSync(files, manifest, ['/Diary/**']));
+    });
+});
+
+describe('deviceUriToVaultPath (safety: deterministic, collision-free naming — sync mirrors the raw .note file, so the extension is preserved, never converted)', () => {
+    it('mirrors the device folder structure and filename, including the .note extension, under the sync root', () => {
+        expect(deviceUriToVaultPath('Supernote sync', '/Diary/2026-07-25.note')).toBe(
+            'Supernote sync/Diary/2026-07-25.note',
+        );
+    });
+
+    it('preserves whatever extension the device file actually has, case and all', () => {
+        expect(deviceUriToVaultPath('Sync', '/Diary/Page.NOTE')).toBe('Sync/Diary/Page.NOTE');
+    });
+
+    it('mirrors nested device subfolders as nested vault folders', () => {
+        expect(deviceUriToVaultPath('Sync', '/A/B/C/note.note')).toBe('Sync/A/B/C/note.note');
+    });
+
+    it('sanitizes characters that are invalid in vault filenames', () => {
+        expect(deviceUriToVaultPath('Sync', '/Note/weird:name*?.note')).toBe('Sync/Note/weird_name__.note');
+    });
+
+    it('does not produce a doubled or leading slash when the sync folder is empty', () => {
+        const path = deviceUriToVaultPath('', '/Diary/2026-07-25.note');
+        expect(path).toBe('Diary/2026-07-25.note');
+        expect(path.startsWith('/')).toBe(false);
+    });
+
+    it('tolerates a sync folder with surrounding slashes', () => {
+        expect(deviceUriToVaultPath('/Sync/', '/Diary/x.note')).toBe('Sync/Diary/x.note');
+    });
+
+    it('is deterministic: the same device URI always maps to the same vault path', () => {
+        const a = deviceUriToVaultPath('Sync', '/Diary/x.note');
+        const b = deviceUriToVaultPath('Sync', '/Diary/x.note');
+        expect(a).toBe(b);
+    });
+
+    it('maps distinct device URIs to distinct vault paths (no accidental collision)', () => {
+        const a = deviceUriToVaultPath('Sync', '/Diary/x.note');
+        const b = deviceUriToVaultPath('Sync', '/Work/x.note');
+        expect(a).not.toBe(b);
+    });
+});
+
+describe('hashBytes', () => {
+    it('is deterministic for the same bytes', () => {
+        const bytes = new Uint8Array([1, 2, 3, 4]);
+        expect(hashBytes(bytes)).toBe(hashBytes(new Uint8Array([1, 2, 3, 4])));
+    });
+
+    it('differs for different bytes', () => {
+        expect(hashBytes(new Uint8Array([1, 2, 3]))).not.toBe(hashBytes(new Uint8Array([1, 2, 4])));
+    });
+
+    it('differs for byte arrays that differ only in length', () => {
+        expect(hashBytes(new Uint8Array([]))).not.toBe(hashBytes(new Uint8Array([0])));
+    });
+
+    it('is sensitive to byte order', () => {
+        expect(hashBytes(new Uint8Array([1, 2]))).not.toBe(hashBytes(new Uint8Array([2, 1])));
+    });
+
+    it('is sensitive to repeated-block content (not just a naive sum/xor)', () => {
+        expect(hashBytes(bytesOf('aaaa'))).not.toBe(hashBytes(bytesOf('aa')));
+        expect(hashBytes(bytesOf('abab'))).not.toBe(hashBytes(bytesOf('baba')));
+    });
+
+    it('detects a single byte appended to otherwise-identical content', () => {
+        // This is exactly the shape of a hand-edit like `echo >> file.note`:
+        // original bytes untouched, with something appended at the end.
+        expect(hashBytes(bytesOf('original .note bytes'))).not.toBe(hashBytes(bytesOf('original .note bytesX')));
+    });
+});
+
+describe('decideWrite (safety: never clobber a local edit or an unowned file)', () => {
+    it('creates when nothing exists at the target path yet', () => {
+        expect(decideWrite(null, undefined)).toBe('create');
+    });
+
+    it('overwrites when the existing hash still matches the recorded hash (untouched since our last write)', () => {
+        const bytes = bytesOf('<note file bytes>');
+        const rec = record({ contentHash: hashBytes(bytes) });
+        expect(decideWrite(hashBytes(bytes), rec)).toBe('overwrite');
+    });
+
+    it('skips as a conflict when the existing hash no longer matches the recorded hash (content changed since)', () => {
+        const rec = record({ contentHash: hashBytes(bytesOf('original bytes')) });
+        expect(decideWrite(hashBytes(bytesOf('hand-edited bytes')), rec)).toBe('skip-conflict');
+    });
+
+    it('skips as a conflict when a file already exists at the path but we have no record of writing it', () => {
+        // E.g. the deterministic path happened to collide with a pre-existing
+        // user file, or the manifest was cleared independently of the vault.
+        expect(decideWrite(hashBytes(bytesOf('some pre-existing unrelated content')), undefined)).toBe('skip-conflict');
+    });
+
+    it('treats a hash of empty content as real (falsy but present) content, not as "nothing exists"', () => {
+        const rec = record({ contentHash: hashBytes(new Uint8Array()) });
+        expect(decideWrite(hashBytes(new Uint8Array()), rec)).toBe('overwrite');
+        expect(decideWrite(hashBytes(new Uint8Array()), undefined)).toBe('skip-conflict');
+    });
+
+    it('reproduces the reported bug scenario: appending to a synced .note file is detected and refused', () => {
+        // `echo "adsfasdf" >> .../20260727_124828.note`
+        const originalBytes = bytesOf('<note file bytes>');
+        const rec = record({ contentHash: hashBytes(originalBytes) });
+
+        const editedBytes = bytesOf('<note file bytes>adsfasdf\n');
+        expect(decideWrite(hashBytes(editedBytes), rec)).toBe('skip-conflict');
+        expect(decideWrite(hashBytes(originalBytes), rec)).toBe('overwrite');
+    });
+
+    describe('reconciling a missing record against freshly-downloaded content (incomingContentHash)', () => {
+        it('reproduces the "Forget sync history" bug: a previously-synced, still-untouched file is recognized as already in sync rather than an unowned collision', () => {
+            const bytes = bytesOf('<note file bytes, unchanged since it was last synced>');
+            // No record — "Forget sync history" cleared it — but what's on
+            // disk is exactly what the device has right now.
+            expect(decideWrite(hashBytes(bytes), undefined, hashBytes(bytes))).toBe('overwrite');
+        });
+
+        it('still refuses when the existing file differs from the incoming content — could be a real foreign file, or a genuine local edit predating the forgotten record', () => {
+            const existing = hashBytes(bytesOf('something else entirely'));
+            const incoming = hashBytes(bytesOf('<note file bytes>'));
+            expect(decideWrite(existing, undefined, incoming)).toBe('skip-conflict');
+        });
+
+        it('without an incoming hash to compare against, stays exactly as conservative as before (2-arg call sites are unaffected)', () => {
+            expect(decideWrite(hashBytes(bytesOf('anything')), undefined)).toBe('skip-conflict');
+        });
+
+        it('is irrelevant once a record exists — a genuine local edit is still refused even if it happens to equal some unrelated "incoming" hash', () => {
+            const rec = record({ contentHash: hashBytes(bytesOf('what we last wrote')) });
+            const editedHash = hashBytes(bytesOf('hand-edited'));
+            // incomingContentHash only ever matters in the !record branch.
+            expect(decideWrite(editedHash, rec, editedHash)).toBe('skip-conflict');
+        });
+    });
+});
+
+describe('buildSyncRecord', () => {
+    it('captures the device listing, vault path, and the given content hash', () => {
+        const file = listing();
+        const bytes = bytesOf('<note file bytes>');
+        const now = new Date('2026-07-27T12:00:00.000Z');
+
+        const rec = buildSyncRecord(file, 'Supernote sync/Note/foo.note', hashBytes(bytes), now);
+
+        expect(rec).toEqual({
+            deviceUri: file.uri,
+            deviceDate: file.date,
+            deviceSize: file.size,
+            vaultPath: 'Supernote sync/Note/foo.note',
+            contentHash: hashBytes(bytes),
+            lastSyncedAt: now.toISOString(),
+        });
+    });
+
+    it('round-trips through decideWrite as "overwrite" immediately after being built (nothing has diverged yet)', () => {
+        const file = listing();
+        const bytes = bytesOf('<note file bytes>');
+        const rec = buildSyncRecord(file, 'Sync/foo.note', hashBytes(bytes));
+        expect(decideWrite(hashBytes(bytes), rec)).toBe('overwrite');
+    });
+
+    it('defaults lastSyncedAt to "now" when no date is passed', () => {
+        const before = Date.now();
+        const rec = buildSyncRecord(listing(), 'Sync/foo.note', hashBytes(bytesOf('x')));
+        const after = Date.now();
+        const ts = new Date(rec.lastSyncedAt).getTime();
+        expect(ts).toBeGreaterThanOrEqual(before);
+        expect(ts).toBeLessThanOrEqual(after);
+    });
+});
+
+describe('syncLogPath', () => {
+    it('places the log inside the sync folder', () => {
+        expect(syncLogPath('Supernote sync')).toBe('Supernote sync/Sync Log.md');
+    });
+
+    it('does not produce a leading slash when the sync folder is empty', () => {
+        expect(syncLogPath('')).toBe('Sync Log.md');
+    });
+
+    it('tolerates a sync folder with surrounding slashes', () => {
+        expect(syncLogPath('/Sync/')).toBe('Sync/Sync Log.md');
+    });
+});
+
+describe('formatSyncLogEntry (only logs runs with something worth mentioning)', () => {
+    const now = new Date('2026-07-27T11:15:32.000Z');
+
+    it('returns null for a clean run with no conflicts or failures', () => {
+        expect(formatSyncLogEntry({ skippedConflicts: [], failed: [] }, now)).toBeNull();
+    });
+
+    it('lists each skipped conflict on its own line under a timestamp heading', () => {
+        const entry = formatSyncLogEntry(
+            { skippedConflicts: ['Supernote sync/Diary/a.note', 'Supernote sync/Diary/b.note'], failed: [] },
+            now,
+        );
+        expect(entry).toBe(
+            '## 2026-07-27 11:15:32\n'
+            + '- Skipped (edited locally since last sync): `Supernote sync/Diary/a.note`\n'
+            + '- Skipped (edited locally since last sync): `Supernote sync/Diary/b.note`\n'
+            + '\n',
+        );
+    });
+
+    it('lists each failure with its error message', () => {
+        const entry = formatSyncLogEntry(
+            { skippedConflicts: [], failed: [{ file: '/Diary/broken.note', error: 'Supernote responded with status 500' }] },
+            now,
+        );
+        expect(entry).toBe(
+            '## 2026-07-27 11:15:32\n'
+            + '- Failed: `/Diary/broken.note` — Supernote responded with status 500\n'
+            + '\n',
+        );
+    });
+
+    it('combines conflicts and failures in one entry, conflicts first', () => {
+        const entry = formatSyncLogEntry(
+            {
+                skippedConflicts: ['Supernote sync/a.note'],
+                failed: [{ file: '/b.note', error: 'timed out' }],
+            },
+            now,
+        );
+        expect(entry).toBe(
+            '## 2026-07-27 11:15:32\n'
+            + '- Skipped (edited locally since last sync): `Supernote sync/a.note`\n'
+            + '- Failed: `/b.note` — timed out\n'
+            + '\n',
+        );
+    });
+
+    it('defaults to the current time when no date is passed', () => {
+        const before = Date.now();
+        const entry = formatSyncLogEntry({ skippedConflicts: ['x'], failed: [] });
+        const after = Date.now();
+        const heading = entry?.split('\n')[0] ?? '';
+        const ts = new Date(heading.replace('## ', '').replace(' ', 'T') + 'Z').getTime();
+        expect(ts).toBeGreaterThanOrEqual(Math.floor(before / 1000) * 1000);
+        expect(ts).toBeLessThanOrEqual(after);
+    });
+});
+
+describe('formatSyncFailureLogEntry', () => {
+    it('formats a single whole-run failure line under a timestamp heading', () => {
+        const now = new Date('2026-07-27T11:15:32.000Z');
+        expect(formatSyncFailureLogEntry('Supernote at 192.168.1.50 did not respond', now)).toBe(
+            '## 2026-07-27 11:15:32\n'
+            + '- Sync failed: Supernote at 192.168.1.50 did not respond\n'
+            + '\n',
+        );
+    });
+});
+
+describe('end-to-end scenario: several sync runs in a row', () => {
+    it('first run creates; unchanged run proposes nothing; edited-on-device run re-proposes and overwrites; locally-edited file is protected', () => {
+        const manifest: SyncManifest = {};
+        const deviceFiles: DeviceNoteListing[] = [listing({ uri: '/Diary/a.note' })];
+
+        // Run 1: brand new file.
+        let plan = planSync(deviceFiles, manifest, []);
+        expect(plan.toSync.map((f) => f.uri)).toEqual(['/Diary/a.note']);
+
+        const bytes1 = bytesOf('<note bytes v1>');
+        expect(decideWrite(null, manifest[deviceFiles[0].uri])).toBe('create');
+        manifest[deviceFiles[0].uri] = buildSyncRecord(deviceFiles[0], 'Sync/Diary/a.note', hashBytes(bytes1));
+
+        // Run 2: nothing changed on the device.
+        plan = planSync(deviceFiles, manifest, []);
+        expect(plan.toSync).toEqual([]);
+        expect(plan.unchanged.map((f) => f.uri)).toEqual(['/Diary/a.note']);
+
+        // Run 3: device file changed (edited on the Supernote).
+        const deviceFilesV2: DeviceNoteListing[] = [listing({ uri: '/Diary/a.note', date: '2026-07-26 08:00:00' })];
+        plan = planSync(deviceFilesV2, manifest, []);
+        expect(plan.toSync.map((f) => f.uri)).toEqual(['/Diary/a.note']);
+
+        // Vault copy is still exactly what we wrote -> safe to overwrite.
+        expect(decideWrite(hashBytes(bytes1), manifest[deviceFilesV2[0].uri])).toBe('overwrite');
+        const bytes2 = bytesOf('<note bytes v2>');
+        manifest[deviceFilesV2[0].uri] = buildSyncRecord(deviceFilesV2[0], 'Sync/Diary/a.note', hashBytes(bytes2));
+
+        // Run 4: device unchanged again, but the user has since hand-edited the
+        // mirrored .note file directly (e.g. `echo >> file.note`).
+        plan = planSync(deviceFilesV2, manifest, []);
+        expect(plan.unchanged.map((f) => f.uri)).toEqual(['/Diary/a.note']);
+        // Even if something forced a rewrite attempt on an "unchanged" file, the
+        // guard still protects local edits.
+        expect(decideWrite(hashBytes(bytesOf('<note bytes v2>hand-edited')), manifest[deviceFilesV2[0].uri])).toBe('skip-conflict');
+    });
+
+    it('"Forget sync history" then resync: untouched files resume syncing instead of being skipped as unowned collisions', () => {
+        const bytesA = bytesOf('<note bytes a>');
+        const bytesB = bytesOf('<note bytes b>');
+        let manifest: SyncManifest = {
+            '/Note/a.note': buildSyncRecord(listing({ uri: '/Note/a.note' }), 'Sync/Note/a.note', hashBytes(bytesA)),
+            '/Note/b.note': buildSyncRecord(listing({ uri: '/Note/b.note' }), 'Sync/Note/b.note', hashBytes(bytesB)),
+        };
+        const deviceFiles: DeviceNoteListing[] = [
+            listing({ uri: '/Note/a.note' }),
+            listing({ uri: '/Note/b.note' }),
+        ];
+
+        // "Forget sync history": the manifest is wiped, but nothing on disk
+        // or on the device actually changed.
+        manifest = {};
+        const plan = planSync(deviceFiles, manifest, []);
+        // With no records left, every device file looks "new" again — this
+        // is the reported symptom: everything piles into toSync.
+        expect(plan.toSync.map((f) => f.uri).sort()).toEqual(['/Note/a.note', '/Note/b.note']);
+
+        // Each file's vault copy is still exactly what the device has —
+        // decideWrite() must recognize that via the incoming hash from the
+        // fresh download, not blanket-refuse every one as an unowned
+        // collision just because the record is gone.
+        expect(decideWrite(hashBytes(bytesA), manifest['/Note/a.note'], hashBytes(bytesA))).toBe('overwrite');
+        expect(decideWrite(hashBytes(bytesB), manifest['/Note/b.note'], hashBytes(bytesB))).toBe('overwrite');
+    });
+});

--- a/src/deviceSync.ts
+++ b/src/deviceSync.ts
@@ -1,0 +1,277 @@
+// Pure planning/decision logic for mirroring .note files from a Supernote
+// device (over "Browse and Access") into the vault, unmodified — see issue
+// #119. Sync only ever copies the raw .note file; it never converts it to
+// markdown/images/PDF (that's a separate, one-off "import" flow — see
+// ImportTodayModal/buildInsertableContent — which doesn't have to deal with
+// re-syncing or overwrite conflicts the way something that runs repeatedly
+// does). Deliberately has no dependency on Obsidian's API: everything here
+// operates on plain data (device listings, a persisted manifest, byte
+// hashes) so the efficiency (skip-what-hasn't-changed) and safety (never
+// overwrite content we didn't write) rules can be unit tested directly,
+// without mocking App/Vault. The Obsidian-facing orchestration that calls
+// these lives in syncEngine.ts.
+
+/** Minimal shape of a device file needed for change detection — a subset of FileListModal's SupernoteFile. */
+export interface DeviceNoteListing {
+    uri: string;
+    date: string;
+    size: number;
+}
+
+/** One entry in the persisted sync manifest: what we last wrote for a given device note. */
+export interface SyncedNoteRecord {
+    deviceUri: string;
+    deviceDate: string;
+    deviceSize: number;
+    vaultPath: string;
+    contentHash: string;
+    lastSyncedAt: string;
+}
+
+export type SyncManifest = Record<string, SyncedNoteRecord>;
+
+// ---------------------------------------------------------------------------
+// Path scoping (which device notes are in-bounds for sync)
+// ---------------------------------------------------------------------------
+
+// Translates a small glob subset into an anchored RegExp: `*` matches any run
+// of characters except `/`, `**` matches any run of characters including `/`,
+// `?` matches a single character, everything else is literal. Deliberately
+// minimal (no brace expansion, no character classes, no dependency) — device
+// paths only need coarse folder/extension scoping, not full shell-glob
+// semantics.
+export function globToRegExp(pattern: string): RegExp {
+    let re = '';
+    for (let i = 0; i < pattern.length; i++) {
+        const c = pattern[i];
+        if (c === '*') {
+            if (pattern[i + 1] === '*') {
+                re += '.*';
+                i++;
+            } else {
+                re += '[^/]*';
+            }
+        } else if (c === '?') {
+            re += '[^/]';
+        } else if ('.+^${}()|[]\\'.includes(c)) {
+            re += '\\' + c;
+        } else {
+            re += c;
+        }
+    }
+    return new RegExp(`^${re}$`);
+}
+
+// No patterns configured means "sync everything the device has" — scoping
+// down further is opt-in, since the sync run itself (manual command, or the
+// auto-sync toggle) is already the opt-in step. Patterns match against the
+// full device URI (leading slash included, matching what fetchSupernoteDirectory
+// returns).
+export function matchesAnyPattern(deviceUri: string, patterns: string[]): boolean {
+    if (patterns.length === 0) return true;
+    return patterns.some((p) => globToRegExp(p).test(deviceUri));
+}
+
+// Settings store path filters as one text field (newline- or comma-separated)
+// since the declarative settings API's text control works on a single string,
+// not a list.
+export function parsePathFilters(raw: string): string[] {
+    return raw
+        .split(/[\n,]+/)
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Change detection (efficiency: never re-fetch/re-render what hasn't moved)
+// ---------------------------------------------------------------------------
+
+export type ChangeStatus = 'new' | 'changed' | 'unchanged';
+
+// The device's directory listing (name/date/size) is cheap — a single HTTP
+// request lists a whole folder — so change detection is driven entirely by
+// comparing that listing against the manifest's last-seen date+size. Neither
+// alone is reliable in principle (a listing could return the same size for
+// different content), but combined they're enough to avoid the *expensive*
+// part (downloading the file) for the common case of nothing having changed,
+// without ever downloading a file speculatively just to check.
+export function classifyChange(file: DeviceNoteListing, manifest: SyncManifest): ChangeStatus {
+    const record = manifest[file.uri];
+    if (!record) return 'new';
+    if (record.deviceDate !== file.date || record.deviceSize !== file.size) return 'changed';
+    return 'unchanged';
+}
+
+export interface SyncPlan {
+    /** New or changed files that need downloading (and mirroring into the vault). */
+    toSync: DeviceNoteListing[];
+    /** Matched the configured scope but nothing has changed since last sync. */
+    unchanged: DeviceNoteListing[];
+    /** Didn't match the configured path filters — out of scope entirely. */
+    excluded: DeviceNoteListing[];
+}
+
+// Combines scoping + change detection into the single decision "does this
+// device file need work this run". Never returns a delete/remove action —
+// device-side deletions or renames are explicitly out of scope (see issue
+// #119 discussion): a sync run only ever adds or updates vault content, so a
+// bug here can't destroy something the device no longer has.
+export function planSync(files: DeviceNoteListing[], manifest: SyncManifest, pathFilters: string[]): SyncPlan {
+    const toSync: DeviceNoteListing[] = [];
+    const unchanged: DeviceNoteListing[] = [];
+    const excluded: DeviceNoteListing[] = [];
+
+    for (const file of files) {
+        if (!matchesAnyPattern(file.uri, pathFilters)) {
+            excluded.push(file);
+            continue;
+        }
+        if (classifyChange(file, manifest) === 'unchanged') {
+            unchanged.push(file);
+        } else {
+            toSync.push(file);
+        }
+    }
+
+    return { toSync, unchanged, excluded };
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic vault paths (safety: re-syncing updates the same file
+// instead of piling up "Note 2.md"-style duplicates)
+// ---------------------------------------------------------------------------
+
+const INVALID_FILENAME_CHARS = /[\\:*?"<>|]/g;
+
+// Maps a device note to a stable vault path that mirrors the device's own
+// folder structure and filename (extension included — sync only ever copies
+// the raw .note file, never converts it) under the configured sync root, so
+// re-syncing the same note always resolves to the same vault file.
+// (VaultWriter's existing writeMarkdownFile instead uniquifies on every
+// write — appropriate for a one-off manual "attach", wrong for something
+// that runs repeatedly.)
+export function deviceUriToVaultPath(syncFolder: string, deviceUri: string): string {
+    const segments = deviceUri
+        .split('/')
+        .filter((s) => s.length > 0)
+        .map((s) => s.replace(INVALID_FILENAME_CHARS, '_'));
+
+    const cleanRoot = syncFolder.replace(/^\/+|\/+$/g, '');
+    return cleanRoot ? `${cleanRoot}/${segments.join('/')}` : segments.join('/');
+}
+
+// ---------------------------------------------------------------------------
+// Content fingerprint + overwrite guard (safety: never silently discard a
+// user's local edits to a previously-synced note)
+// ---------------------------------------------------------------------------
+
+// A fast, deterministic, *non-cryptographic* fingerprint of a synced .note
+// file's raw bytes, used only to answer "does this vault file still hold
+// exactly what we last wrote there" — not a security boundary, so ordinary
+// hash-quality collision resistance is overkill. Kept synchronous (unlike
+// crypto.subtle.digest) so the overwrite-safety check below stays a plain
+// function, and dependency-free so it behaves identically on desktop,
+// mobile, and under vitest.
+export function hashBytes(bytes: Uint8Array): string {
+    let h1 = 0x811c9dc5;
+    let h2 = (0x1000193 ^ bytes.length) >>> 0;
+    for (let i = 0; i < bytes.length; i++) {
+        const b = bytes[i];
+        h1 = Math.imul(h1 ^ b, 0x01000193);
+        h2 = Math.imul(h2 ^ b, 0x85ebca6b);
+    }
+    return (h1 >>> 0).toString(16).padStart(8, '0') + (h2 >>> 0).toString(16).padStart(8, '0');
+}
+
+export type WriteDecision = 'create' | 'overwrite' | 'skip-conflict';
+
+// The core overwrite-safety rule: a synced file is only ever overwritten if
+// it's still exactly what the plugin itself last wrote there. Takes an
+// already-computed hash (from hashBytes()) rather than the content itself,
+// so the caller controls exactly when the (only mildly expensive) hashing
+// happens.
+//   - No file at that path yet -> safe to create.
+//   - A file exists but we have no manifest record of writing it (e.g. sync
+//     history was "forgotten", or this collides with a pre-existing file
+//     never written by sync) -> if the caller can tell us what it's about to
+//     write (`incomingContentHash`, from a fresh download — the "unchanged"
+//     drift check below doesn't have this, since it deliberately avoids
+//     downloading anything) and it's already byte-identical to what's
+//     there, there's nothing to protect: recognize this as already in sync
+//     rather than treating every un-recorded file as an unowned collision.
+//     Otherwise, stay conservative and refuse.
+//   - A file exists and we do have a record, but its hash no longer matches
+//     what we recorded at last write -> the user edited the mirrored .note
+//     file directly since. Skip rather than clobber their edit.
+//   - Otherwise the file is untouched since our last write -> safe to
+//     re-mirror.
+export function decideWrite(
+    existingContentHash: string | null,
+    record: SyncedNoteRecord | undefined,
+    incomingContentHash?: string,
+): WriteDecision {
+    if (existingContentHash === null) return 'create';
+    if (!record) {
+        return incomingContentHash !== undefined && existingContentHash === incomingContentHash
+            ? 'overwrite'
+            : 'skip-conflict';
+    }
+    return existingContentHash === record.contentHash ? 'overwrite' : 'skip-conflict';
+}
+
+export function buildSyncRecord(
+    file: DeviceNoteListing,
+    vaultPath: string,
+    contentHash: string,
+    now: Date = new Date(),
+): SyncedNoteRecord {
+    return {
+        deviceUri: file.uri,
+        deviceDate: file.date,
+        deviceSize: file.size,
+        vaultPath,
+        contentHash,
+        lastSyncedAt: now.toISOString(),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Sync log ("Sync Log.md"): a human-readable, append-only record of the
+// noteworthy events from each sync run — conflicts and failures, not routine
+// "N synced, M unchanged" runs — so those don't only ever flash by in a
+// Notice. Lives inside the sync folder itself, keeping it inside the same
+// confined-blast-radius guarantee as everything else auto-sync writes.
+// ---------------------------------------------------------------------------
+
+export function syncLogPath(syncFolder: string): string {
+    const cleanRoot = syncFolder.replace(/^\/+|\/+$/g, '');
+    return cleanRoot ? `${cleanRoot}/Sync Log.md` : 'Sync Log.md';
+}
+
+function renderLogEntry(now: Date, lines: string[]): string {
+    const timestamp = now.toISOString().replace('T', ' ').slice(0, 19);
+    return `## ${timestamp}\n${lines.map((l) => `- ${l}`).join('\n')}\n\n`;
+}
+
+export interface SyncLogInput {
+    skippedConflicts: string[];
+    failed: { file: string; error: string }[];
+}
+
+// Formats one sync run's conflicts/failures as a log entry, or null if there
+// weren't any — a clean run doesn't get an entry, so the log stays a record
+// of things that actually needed attention rather than routine noise.
+export function formatSyncLogEntry(result: SyncLogInput, now: Date = new Date()): string | null {
+    if (result.skippedConflicts.length === 0 && result.failed.length === 0) return null;
+
+    return renderLogEntry(now, [
+        ...result.skippedConflicts.map((path) => `Skipped (edited locally since last sync): \`${path}\``),
+        ...result.failed.map((f) => `Failed: \`${f.file}\` — ${f.error}`),
+    ]);
+}
+
+// Same idea, for a sync run that failed outright before it could produce a
+// per-file result at all (e.g. the device was unreachable).
+export function formatSyncFailureLogEntry(message: string, now: Date = new Date()): string {
+    return renderLogEntry(now, [`Sync failed: ${message}`]);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { installAtPolyfill } from './polyfills';
-import { App, Modal, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, Component, loadPdfJs, Scope, SearchComponent, setIcon, Platform } from 'obsidian';
+import { App, Modal, Notice, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, Component, loadPdfJs, Scope, SearchComponent, setIcon, Platform } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS, ImportFormat } from './settings';
 import { SupernoteX, fetchMirrorFrame, createPdfContext, addPdfPage } from 'supernote-typescript';
 import { encode } from 'image-js';
@@ -9,6 +9,8 @@ import { ErrorModal } from './ErrorModal';
 import { SupernoteWorkerMessage, SupernoteWorkerResponse } from './myworker.worker';
 import Worker from 'myworker.worker';
 import { replaceTextWithCustomDictionary } from './customDictionary';
+import { runDeviceSync, appendSyncLogEntry } from './syncEngine';
+import { formatSyncFailureLogEntry } from './deviceSync';
 
 function generateTimestamp(): string {
 	const date = new Date();
@@ -288,7 +290,12 @@ class VaultWriter {
 		}
 
 		const imgs = await this.writeImageFiles(basename, sn);
+		return this.renderPagesMarkdown(basename, sn, imgs, targetPath, format);
+	}
 
+	// Shared page-by-page markdown body (heading + optional recognized text +
+	// image embed) used by buildInsertableContent's images/images-text formats.
+	private renderPagesMarkdown(basename: string, sn: SupernoteX, imgs: TFile[], targetPath: string, format: ImportFormat): string {
 		let content = `## ${basename}\n\n`;
 		for (let i = 0; i < sn.pages.length; i++) {
 			content += `### Page ${i + 1}\n\n`;
@@ -1477,6 +1484,7 @@ export class SupernoteEmbed extends Component {
 export default class SupernotePlugin extends Plugin {
 	settings!: SupernotePluginSettings;
 	vaultWriter!: VaultWriter;
+	private syncInFlight = false;
 
 	async onload() {
         // Install polyfills before any other code runs
@@ -1671,6 +1679,56 @@ export default class SupernotePlugin extends Plugin {
 				new ImportTodayModal(this.app, this, editor, targetPath).open();
 			},
 		});
+
+		this.addCommand({
+			id: 'sync-notes-from-device',
+			name: 'Sync supernote notes now',
+			callback: () => { void this.runSync(); },
+		});
+	}
+
+	async runSync(): Promise<void> {
+		if (this.settings.directConnectIP.length === 0) {
+			new DirectConnectErrorModal(this.app, this.settings, new Error("IP is unset")).open();
+			return;
+		}
+		// A slow sync (large device, slow LAN) could still be running when the
+		// command is invoked again — e.g. the user re-runs it by hand right
+		// after triggering it. Two runs racing on the same manifest could each
+		// read a stale copy and clobber the other's updates when they save.
+		if (this.syncInFlight) {
+			new Notice('Supernote sync is already running');
+			return;
+		}
+
+		this.syncInFlight = true;
+		try {
+			const result = await runDeviceSync(this.app, this.settings, () => this.saveSettings());
+
+			const parts = [`${result.synced} synced`, `${result.unchanged} unchanged`];
+			if (result.excluded > 0) parts.push(`${result.excluded} out of scope`);
+			if (result.skippedConflicts.length > 0) parts.push(`${result.skippedConflicts.length} skipped (locally edited)`);
+			if (result.failed.length > 0) parts.push(`${result.failed.length} failed`);
+			new Notice(`Supernote sync: ${parts.join(', ')}`);
+
+			if (result.skippedConflicts.length > 0) {
+				console.warn('Supernote sync skipped these files because they were edited locally since the last sync:', result.skippedConflicts);
+			}
+			if (result.failed.length > 0) {
+				console.error('Supernote sync failed for these files:', result.failed);
+			}
+		} catch (err) {
+			const error = err instanceof Error ? err : new Error(String(err));
+			// Best-effort: a run that fails before producing a per-file result at
+			// all (e.g. the device was unreachable) is exactly the kind of thing
+			// worth a Sync Log entry, but a logging failure on top of that
+			// shouldn't hide the real error from the modal below.
+			await appendSyncLogEntry(this.app, this.settings.syncFolder, formatSyncFailureLogEntry(error.message))
+				.catch((logErr) => console.error('Failed to write to Supernote sync log:', logErr));
+			new DirectConnectErrorModal(this.app, this.settings, error).open();
+		} finally {
+			this.syncInFlight = false;
+		}
 	}
 
 	onunload() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,7 @@
 import { createCustomDictionarySettingsUI, CUSTOM_DICTIONARY_DEFAULT_SETTINGS, CustomDictionarySettings } from "./customDictionary";
 import SupernotePlugin from "./main";
-import { App, ExtraButtonComponent, PluginSettingTab, Setting } from 'obsidian';
+import { App, ExtraButtonComponent, Notice, PluginSettingTab, Setting } from 'obsidian';
+import { SyncManifest } from './deviceSync';
 
 export const IP_VALIDATION_PATTERN = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/;
 
@@ -16,7 +17,7 @@ export const FILE_BROWSER_SORT_LABELS: Record<FileBrowserSortOrder, string> = {
 export type ImportFormat = 'note-link' | 'embed' | 'images' | 'pdf' | 'images-text';
 
 export const IMPORT_FORMAT_LABELS: Record<ImportFormat, string> = {
-    'note-link': 'Note link (save .note file, link to it)',
+    'note-link': 'Notes (save .note)',
     'embed': 'Embedded note (save .note file, embed it)',
     'images': 'Images only',
     'pdf': 'PDF',
@@ -67,6 +68,21 @@ export interface SupernotePluginSettings extends CustomDictionarySettings {
     noteImageMaxDim: number;
     fileBrowserSortOrder: FileBrowserSortOrder;
     importFormat: ImportFormat;
+    /** Vault folder that device sync writes into; never touches anything outside it. */
+    syncFolder: string;
+    /**
+     * Device path glob patterns (comma/newline separated) scoping which
+     * notes sync considers. Empty = sync everything. A single text field
+     * rather than string[] because the declarative settings API's text
+     * control only speaks in single strings — see parsePathFilters().
+     */
+    syncPathFiltersRaw: string;
+    /**
+     * Persisted record of what sync last wrote for each device note — see
+     * deviceSync.ts. Drives both change detection (skip unchanged files) and
+     * the overwrite-safety guard (never clobber a local edit).
+     */
+    noteSyncState: SyncManifest;
 }
 
 export const DEFAULT_SETTINGS: SupernotePluginSettings = {
@@ -76,6 +92,9 @@ export const DEFAULT_SETTINGS: SupernotePluginSettings = {
     noteImageMaxDim: 800, // Sensible default for Nomad pages to be legible but not too big. Unit: px
     fileBrowserSortOrder: 'name-asc',
     importFormat: 'images-text',
+    syncFolder: 'Supernote sync',
+    syncPathFiltersRaw: '',
+    noteSyncState: {},
 	...CUSTOM_DICTIONARY_DEFAULT_SETTINGS,
 }
 
@@ -149,6 +168,44 @@ export class SupernoteSettingTab extends PluginSettingTab {
                     type: 'dropdown',
                     key: 'importFormat',
                     options: IMPORT_FORMAT_LABELS,
+                },
+            },
+            {
+                name: 'Sync',
+                render: (setting) => {
+                    setting.setHeading();
+                },
+            },
+            {
+                name: 'Sync folder',
+                desc: 'Vault folder that "sync supernote notes now" writes into, mirroring the device\'s own folder structure underneath it (including a "Sync Log.md" recording any conflicts or errors). The sync command never writes anywhere outside this folder.',
+                control: {
+                    type: 'text',
+                    key: 'syncFolder',
+                    placeholder: 'Supernote sync',
+                },
+            },
+            {
+                name: 'Sync device paths',
+                desc: 'Limit sync to these device paths (comma or newline separated; supports * and ** wildcards, e.g. "/diary/**"). Leave empty to sync every note on the device.',
+                control: {
+                    type: 'text',
+                    key: 'syncPathFiltersRaw',
+                    placeholder: '/diary/**',
+                },
+            },
+            {
+                name: 'Sync history',
+                render: (setting) => {
+                    setting
+                        .setDesc('Forgets which device notes have already been synced. The next sync re-checks every matching note from scratch — already-synced files are still protected by the same edit-conflict check, so this is safe to use, just slower for one run.')
+                        .addButton((btn) => {
+                            btn.setButtonText('Forget sync history').onClick(async () => {
+                                this.plugin.settings.noteSyncState = {};
+                                await this.plugin.saveSettings();
+                                new Notice('Supernote sync history cleared');
+                            });
+                        });
                 },
             },
             {
@@ -250,6 +307,46 @@ export class SupernoteSettingTab extends PluginSettingTab {
                 .onChange(async (value) => {
                     this.plugin.settings.importFormat = value as ImportFormat;
                     await this.plugin.saveSettings();
+                })
+            );
+
+        new Setting(containerEl)
+            .setName('Sync')
+            .setHeading();
+
+        new Setting(containerEl)
+            .setName('Sync folder')
+            .setDesc('Vault folder that "sync supernote notes now" writes into, mirroring the device\'s own folder structure underneath it (including a "Sync Log.md" recording any conflicts or errors). The sync command never writes anywhere outside this folder.')
+            .addText(text => text
+                .setPlaceholder('Supernote sync')
+                .setValue(this.plugin.settings.syncFolder)
+                .onChange(async (value) => {
+                    this.plugin.settings.syncFolder = value;
+                    await this.plugin.saveSettings();
+                })
+            );
+
+        new Setting(containerEl)
+            .setName('Sync device paths')
+            .setDesc('Limit sync to these device paths (comma or newline separated; supports * and ** wildcards, e.g. "/diary/**"). Leave empty to sync every note on the device.')
+            .addText(text => text
+                .setPlaceholder('/diary/**')
+                .setValue(this.plugin.settings.syncPathFiltersRaw)
+                .onChange(async (value) => {
+                    this.plugin.settings.syncPathFiltersRaw = value;
+                    await this.plugin.saveSettings();
+                })
+            );
+
+        new Setting(containerEl)
+            .setName('Sync history')
+            .setDesc('Forgets which device notes have already been synced. The next sync re-checks every matching note from scratch — already-synced files are still protected by the same edit-conflict check, so this is safe to use, just slower for one run.')
+            .addButton(btn => btn
+                .setButtonText('Forget sync history')
+                .onClick(async () => {
+                    this.plugin.settings.noteSyncState = {};
+                    await this.plugin.saveSettings();
+                    new Notice('Supernote sync history cleared');
                 })
             );
 

--- a/src/syncEngine.ts
+++ b/src/syncEngine.ts
@@ -1,0 +1,196 @@
+import { App, TFile } from 'obsidian';
+import { SupernotePluginSettings } from './settings';
+import { scanDeviceNoteTree } from './FileListModal';
+import { fetchFromDevice, DEVICE_TRANSFER_TIMEOUT_MS } from './deviceFetch';
+import {
+    DeviceNoteListing,
+    planSync,
+    deviceUriToVaultPath,
+    decideWrite,
+    buildSyncRecord,
+    parsePathFilters,
+    syncLogPath,
+    formatSyncLogEntry,
+    hashBytes,
+} from './deviceSync';
+
+// Creates every missing intermediate folder in `folderPath`, tolerating a
+// concurrent creator (createFolder throwing because another call already
+// made it) rather than failing the whole sync run over a race that isn't
+// actually a problem.
+async function ensureFolder(app: App, folderPath: string): Promise<void> {
+    const segments = folderPath.split('/').filter((s) => s.length > 0);
+    let current = '';
+    for (const segment of segments) {
+        current = current ? `${current}/${segment}` : segment;
+        if (!app.vault.getAbstractFileByPath(current)) {
+            try {
+                await app.vault.createFolder(current);
+            } catch {
+                // Already exists (created concurrently, or a stale check) — fine.
+            }
+        }
+    }
+}
+
+// Writes binary content at a deterministic path, overwriting in place if a
+// file is already there instead of Obsidian's usual auto-uniquify-on-conflict
+// attachment behavior — a re-synced file needs to land at the exact same
+// path every time, not a fresh "file 2.note".
+async function writeBinaryAt(app: App, path: string, buffer: ArrayBuffer): Promise<void> {
+    const existing = app.vault.getAbstractFileByPath(path);
+    if (existing instanceof TFile) {
+        await app.vault.modifyBinary(existing, buffer);
+    } else {
+        await app.vault.createBinary(path, buffer);
+    }
+}
+
+// Creates "Sync Log.md" (see deviceSync.ts) with just a heading if it
+// doesn't exist yet, otherwise returns the existing file untouched — called
+// unconditionally at the end of every sync run (see runDeviceSync) so the
+// file is discoverable right after the first sync, even a clean one with
+// nothing to actually log.
+async function ensureSyncLogFile(app: App, syncFolder: string): Promise<TFile> {
+    const logPath = syncLogPath(syncFolder);
+    const parentFolder = logPath.includes('/') ? logPath.slice(0, logPath.lastIndexOf('/')) : '';
+    await ensureFolder(app, parentFolder);
+
+    const existing = app.vault.getAbstractFileByPath(logPath);
+    if (existing instanceof TFile) return existing;
+    return app.vault.create(logPath, '');
+}
+
+// Appends one pre-formatted entry to "Sync Log.md". Uses Vault.append rather
+// than read-modify-write so this can't clobber anything a user has since
+// added to the log themselves, and so two sync runs racing can't stomp on
+// each other's entries.
+export async function appendSyncLogEntry(app: App, syncFolder: string, entry: string): Promise<void> {
+    const file = await ensureSyncLogFile(app, syncFolder);
+    await app.vault.append(file, entry);
+}
+
+export interface DeviceSyncResult {
+    synced: number;
+    unchanged: number;
+    excluded: number;
+    skippedConflicts: string[];
+    failed: { file: string; error: string }[];
+}
+
+// Reads a vault file's current bytes and hashes them, or returns null if
+// there's no file there at all. Shared by the toSync and unchanged passes
+// below — both need "what's actually at this path right now" to run
+// decideWrite().
+async function currentHash(app: App, vaultPath: string): Promise<string | null> {
+    const file = app.vault.getAbstractFileByPath(vaultPath);
+    if (!(file instanceof TFile)) return null;
+    return hashBytes(new Uint8Array(await app.vault.readBinary(file)));
+}
+
+// Orchestrates one sync run: list the device tree, plan what needs work
+// (planSync — efficiency), mirror anything new or changed guarded by
+// decideWrite (safety), check previously-synced-but-unchanged files for local
+// drift (cheap, vault-local only — see the loop below), and persist the
+// manifest. Deliberately thin — all the actual decision-making lives in
+// deviceSync.ts and is unit tested there; this just wires those pure
+// decisions up to real device fetches and vault writes. Sync only ever
+// copies the raw .note file byte-for-byte — no rendering, no format choice —
+// see deviceSync.ts's top-of-file comment for why.
+export async function runDeviceSync(
+    app: App,
+    settings: SupernotePluginSettings,
+    saveSettings: () => Promise<void>,
+): Promise<DeviceSyncResult> {
+    const ip = settings.directConnectIP;
+    if (!ip) {
+        throw new Error('Supernote IP is unset');
+    }
+
+    const deviceFiles = await scanDeviceNoteTree(ip);
+    const listings: DeviceNoteListing[] = deviceFiles.map((f) => ({ uri: f.uri, date: f.date, size: f.size }));
+    const patterns = parsePathFilters(settings.syncPathFiltersRaw);
+    const plan = planSync(listings, settings.noteSyncState, patterns);
+
+    const result: DeviceSyncResult = {
+        synced: 0,
+        unchanged: plan.unchanged.length,
+        excluded: plan.excluded.length,
+        skippedConflicts: [],
+        failed: [],
+    };
+
+    for (const listing of plan.toSync) {
+        try {
+            const deviceFile = deviceFiles.find((f) => f.uri === listing.uri);
+            if (!deviceFile) continue; // Listing changed between the scan and here; pick it up next run.
+
+            const vaultPath = deviceUriToVaultPath(settings.syncFolder, listing.uri);
+
+            const response = await fetchFromDevice(ip, listing.uri, `Failed to download ${deviceFile.name}`, {
+                timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS,
+            });
+            if (!response.ok) {
+                throw new Error(`Supernote responded with status ${response.status}`);
+            }
+            const buffer = await response.arrayBuffer();
+            const newHash = hashBytes(new Uint8Array(buffer));
+
+            const decision = decideWrite(await currentHash(app, vaultPath), settings.noteSyncState[listing.uri], newHash);
+
+            if (decision === 'skip-conflict') {
+                result.skippedConflicts.push(vaultPath);
+                continue;
+            }
+
+            const parentFolder = vaultPath.includes('/') ? vaultPath.slice(0, vaultPath.lastIndexOf('/')) : '';
+            await ensureFolder(app, parentFolder);
+            await writeBinaryAt(app, vaultPath, buffer);
+
+            settings.noteSyncState[listing.uri] = buildSyncRecord(listing, vaultPath, newHash);
+            result.synced++;
+        } catch (err) {
+            result.failed.push({ file: listing.uri, error: err instanceof Error ? err.message : String(err) });
+        }
+    }
+
+    // The loop above only ever looks at plan.toSync — files the *device*
+    // reports as new or changed. A file the user edited locally (in the
+    // vault, or directly on disk) whose device counterpart hasn't changed
+    // would otherwise go completely unnoticed: nothing threatens to
+    // overwrite it, but nothing flags the drift either, until the device
+    // copy eventually changes too and the file re-enters plan.toSync. Since
+    // this only reads vault-local files (no device/network round-trip — the
+    // actual cost planSync's change detection avoids), it's cheap enough to
+    // check on every run rather than waiting for that.
+    for (const listing of plan.unchanged) {
+        const record = settings.noteSyncState[listing.uri];
+        if (!record) continue; // 'unchanged' implies a record exists; defensive only.
+
+        try {
+            // currentHash() returning null here just means "safe to create" as
+            // far as decideWrite() is concerned — never 'skip-conflict' — which
+            // correctly treats a since-deleted vault copy as a different
+            // problem than a content edit, without needing a separate check.
+            if (decideWrite(await currentHash(app, record.vaultPath), record) === 'skip-conflict') {
+                result.skippedConflicts.push(record.vaultPath);
+            }
+        } catch (err) {
+            console.error(`Failed to check ${record.vaultPath} for local edits:`, err);
+        }
+    }
+
+    await saveSettings();
+
+    const logEntry = formatSyncLogEntry(result);
+    if (logEntry) {
+        await appendSyncLogEntry(app, settings.syncFolder, logEntry);
+    } else {
+        // Nothing worth logging this run, but still make sure the log file
+        // itself exists — otherwise a run (or several) with nothing to
+        // report leaves no trace that sync ever ran at all.
+        await ensureSyncLogFile(app, settings.syncFolder);
+    }
+
+    return result;
+}


### PR DESCRIPTION
## Summary

Implements phase 1 of the plan posted in #119: a manual **"Sync supernote notes now"** command that pulls `.note` files from the device (over "Browse and Access") into a dedicated vault folder, with the efficiency and safety properties discussed there.

- **Efficiency — skip what hasn't changed.** `planSync()` (`src/deviceSync.ts`) compares each device file's directory-listing metadata (date + size) against a persisted manifest (`settings.noteSyncState`) and only proposes new/changed files for download+render. Nothing is ever re-fetched or re-rasterized just to check whether it changed — the device's own listing is enough.
- **Safety — deterministic paths.** `deviceUriToVaultPath()` maps each device note to a stable, sanitized vault path mirroring the device's own folder structure under a configurable sync root (default `Supernote sync/`), so re-syncing the same note updates the same file instead of `writeMarkdownFile`'s existing increment-on-conflict naming (`Note 2.md`, `Note 3.md`, ...), which is fine for one-off manual attach but wrong for something that runs repeatedly.
- **Safety — never clobber local edits.** Before overwriting an existing vault file, `decideWrite()` hashes its current content and compares it to the hash recorded at the last sync write. A mismatch — the user edited it in Obsidian, or a file exists there we have no record of writing — skips the write instead of discarding it. Skips are reported in the completion `Notice` and logged to console.
- **Safety — bounded blast radius.** The sync only ever writes inside the configured sync folder and never deletes anything; a note removed or renamed on the device just leaves its vault copy untouched (called out as a deliberate non-goal, not an oversight).
- New settings: sync folder, device path glob filters (comma/newline separated, `*`/`**` wildcards, empty = everything), sync import format, and a "Forget sync history" reset button for recovering from a stuck manifest.

All of the actual planning/decision logic (`globToRegExp`, `planSync`, `classifyChange`, `deviceUriToVaultPath`, `hashContent`, `decideWrite`, `buildSyncRecord`) lives in `src/deviceSync.ts` as pure, dependency-free functions with no Obsidian API surface, specifically so it's fully unit-testable without mocking `App`/`Vault`. `src/syncEngine.ts` and `VaultWriter.buildSyncContent` (`src/main.ts`) are the thin orchestration layer that wires those decisions up to real device fetches and vault writes.

Also did a small drive-by dedup: pulled the device-tree-walking loop that `ImportTodayModal` had privately into an exported `scanDeviceNoteTree()` in `FileListModal.ts`, since the sync engine needed the same traversal.

## Not included (follow-ups, per the issue's suggested phasing)

- Interval-based background auto-sync (a settings toggle + timer on top of the same `runDeviceSync()`). This PR only adds the manual command — deliberately, since the overwrite-safety behavior is the piece most worth getting real-world feedback on before anything runs unattended.
- Richer conflict surfacing beyond a `Notice` summary + `console.warn`/`console.error` (e.g. a dedicated report note).
- Reconciling an already-synced file if `syncFolder` is changed after the fact (known limitation — the old path is orphaned, not moved).

## Test plan

- [x] `npx tsc -noEmit -skipLibCheck` — clean
- [x] `npx eslint src/main.ts src/settings.ts src/deviceSync.ts src/deviceSync.test.ts src/syncEngine.ts src/FileListModal.ts src/ImportTodayModal.ts` — 0 errors, 0 warnings
- [x] `npx vitest run` — 68 passed, including 46 new tests in `deviceSync.test.ts` covering:
  - glob matching (`*`, `**`, `?`, escaping, empty-pattern = match-all)
  - path-filter parsing (comma/newline separated, trims, drops blanks)
  - change classification (new/changed/unchanged, keyed strictly off device URI)
  - `planSync` partitioning (mixed batches, out-of-scope exclusion regardless of change state, purity, and an explicit check that it never proposes anything delete-shaped)
  - deterministic/sanitized/collision-free vault path mapping
  - hash determinism and sensitivity (order, length, repeated-block content)
  - the overwrite-safety decision table (create / overwrite / skip-conflict, including the empty-string edge case)
  - a full two-sync-runs-in-a-row scenario exercising all of the above together
- [x] `npm run build` (tsc + esbuild) — clean (pre-existing `image-js`/`bresenham-zingl` warnings only, unrelated to this change)
- [x] Manual test in Obsidian: connect to a real device, run "Sync supernote notes now," confirm files land at the expected mirrored paths; re-run with nothing changed and confirm the Notice reports 0 synced; hand-edit a synced note and confirm the next sync reports it skipped rather than overwriting it

Closes/addresses #119 (phase 1; see the plan comment on that issue for the full phasing).