### PR TITLE
Render clickable Supernote internal links in SupernoteView

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
           cache: npm
+      - name: Build supernote-typescript
+        working-directory: supernote-typescript
+        run: |
+          npm install --include=dev || npm install --include=dev --ignore-scripts
+          npm run build
       - run: npm ci
       - run: npm test
 

--- a/docs/supernote-links.md
+++ b/docs/supernote-links.md
@@ -1,0 +1,114 @@
+# Supernote internal links: field semantics in practice
+
+`supernote-typescript` exposes Supernote's own internal note-linking feature
+(the tappable link tags you can place on a page, e.g. for table-of-contents
+style navigation) as `SupernoteX.links: Record<string, ILink[]>`. This
+documents what building `SupernoteView`'s clickable link overlay
+([main.ts](../src/main.ts), [linkOverlay.ts](../src/linkOverlay.ts)) found
+about how that data actually behaves, since some of it doesn't match the
+library's own doc comments. Verified against two real notes: this repo's
+submodule test fixture (`supernote-typescript/tests/input/nomad-3.26.40-link-tag-3p.note`)
+and a second, independently device-created note with two internal links on
+different pages.
+
+## What's reliable
+
+- **`LINKRECT`** — `"x,y,w,h"`, the link's clickable region in the page's own
+  native pixel coordinate space (same space as `pageWidth`/`pageHeight`).
+  Parsed by `parseLinkRect()`.
+- **`LINKFILE`** — base64-encoded absolute device path to the target `.note`
+  file (e.g. `/storage/emulated/0/Note/Folder/MyNote.note`). The library
+  already decodes this into a plain basename via `text`, which is what this
+  plugin resolves against the vault rather than decoding `LINKFILE` itself
+  (see "Resolution recipe" below).
+- **`PAGEID`** — matches `IPage.PAGEID`. For a same-document target, the
+  library already resolves this into a `#Page N` suffix on `text`; for a
+  cross-file target it doesn't (it can't, without opening the other file), so
+  `text` stays a bare basename.
+- **`sn.links`' Record key** — its first 4 characters, parsed as an integer,
+  are the **1-indexed page the link is physically drawn on**. Not documented
+  anywhere we could find, but it's what's actually reliable — see
+  "Verification" below. (The remaining characters appear to be the link's own
+  `LINKRECT` `y,x,h,w` digits, zero-padded to 4 each, concatenated — cosmetic,
+  just enough to make the key unique.)
+
+## What's not reliable
+
+- **`LINKTYPE`** (doc comment: "1 = internal note link") — filtering to
+  `LINKTYPE === '1'` drops real, genuine internal links. In the submodule's
+  own fixture, 2 of its 3 links have `LINKTYPE: '0'`; the second real note
+  checked had `LINKTYPE: '0'` on both of its links. Whatever this field
+  actually distinguishes, it isn't "is this a real internal link" — anything
+  present in `sn.links` was already resolved as a genuine link by the parser,
+  so `bucketLinksByPage()` doesn't filter on it at all.
+- **`OBJPAGE`** (doc comment: "0-indexed page number this link appears on")
+  — does not match the link's actual source page. See below.
+
+## Verification: why OBJPAGE looked right but wasn't
+
+The submodule's own fixture wasn't enough to catch this: all 3 of its links
+share the same `sn.links` key prefix (`0002`), i.e. they're all on the same
+page, so both the OBJPAGE-based and key-prefix-based bucketing schemes
+happened to look plausible against it in isolation.
+
+A second real note (4 pages, one link on page array-index 0, one on array-index 3)
+settled it. Rendered both pages via `toImage()`, drew each link's `LINKRECT`
+as a box on every page, and measured ink coverage under each box to find
+where each link is *actually* drawn:
+
+| link | `OBJPAGE` | `LINKRECT` | verified source page (array index) | `sn.links` key prefix |
+|---|---|---|---|---|
+| A | `4` | `672,220,800,87` | `0` (12.8% ink under the box) | `0001` |
+| B | `1` | `564,500,791,87` | `3` (12.7% ink under the box) | `0004` |
+
+`OBJPAGE` doesn't match the verified page under any indexing convention —
+`4` and `1` aren't `0` and `3` whether you read them as 0- or 1-indexed. The
+key prefix matches exactly (`1` → index `0`, `4` → index `3`). Best guess:
+`OBJPAGE` tracks something closer to the page's own template/display label,
+which can drift from its current position in the `pages` array (e.g. after
+page reordering) — unconfirmed, filed as
+[philips/supernote-typescript#32](https://github.com/philips/supernote-typescript/issues/32).
+
+**Takeaway for future changes here**: don't trust a single fixture (or a
+field's doc comment) for page-bucketing logic like this — a fixture where
+every link happens to land on one page can't distinguish between a correct
+and an incorrect theory. Cross-check against a note with links on more than
+one page, ideally by rendering and measuring pixel content the way this was
+verified, not just by checking that bucketed indices are merely in-bounds.
+
+## Resolution recipe (as implemented)
+
+1. **Bucket by source page**: `bucketLinksByPage(sn.links)` — keys by the
+   `sn.links` Record key's page-prefix convention above.
+2. **Resolve target, same-file vs cross-file**: `handleLinkClick()` in
+   `main.ts` compares `link.text`'s basename against the currently open
+   file's basename (matching `VaultWriter.resolvePageAnchor()`'s export-time
+   resolution, from PR #122, so a link resolves to the same note whether
+   you're viewing it live or exporting it).
+   - **Same-file**: match `link.PAGEID` against this file's own
+     `sn.pages.map(p => p.PAGEID)` to get a page number, then jump in place.
+   - **Cross-file**: find a vault `.note` file with a matching basename
+     (ambiguous if two vault notes share a basename in different folders —
+     an accepted, known limitation, same one PR #122 already has). Load and
+     parse it, match `PAGEID` against *its* `pages` array to get a target
+     page number, then open it via the existing `#page=N` ephemeral-state
+     anchor — the same mechanism a regular `[[note#page=N]]` link already
+     uses.
+
+This deliberately doesn't decode `LINKFILE` itself for resolution — matching
+by basename (already decoded into `text` by the library) is simpler and
+works regardless of whether the note was synced from a device or imported
+some other way. If you do need the raw device path (e.g. to cross-reference
+against device-sync's `deviceUriToVaultPath()`), note that `LINKFILE` decodes
+to a full Android filesystem path (`/storage/emulated/0/Note/...`), not the
+browser-relative form (`/Note/...`) that `SupernoteFile.uri`/device-sync use
+— it needs that storage-root prefix stripped first.
+
+## Code pointers
+
+- `src/linkOverlay.ts` — pure bucketing/rect-parsing logic, obsidian-free so
+  it's unit tested (including a real-fixture check) in `linkOverlay.test.ts`.
+- `src/main.ts` — `SupernoteView.handleLinkClick()`/`positionLinkOverlay()`
+  for the actual rendering and click navigation.
+- `supernote-typescript/src/parsing.ts` — `_parseLinks()`/`_parseLink()`,
+  where `ILink` is built from the raw footer/buffer data.

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -36,10 +36,14 @@ export default defineConfig(
 		// obsidianmd/no-global-this exists for popout-window compatibility in
 		// plugin runtime code; it doesn't apply to test setup, where `globalThis`
 		// is the only thing available to stand in for the `window` Vitest's node
-		// environment doesn't provide.
+		// environment doesn't provide. Likewise obsidianmd/no-nodejs-modules
+		// (mobile has no Node APIs) doesn't apply here either — test files run
+		// under Vitest's real Node process and are never bundled into the
+		// plugin (see linkOverlay.test.ts's fs-based fixture read).
 		files: ['**/*.test.ts'],
 		rules: {
 			'obsidianmd/no-global-this': 'off',
+			'obsidianmd/no-nodejs-modules': 'off',
 		},
 	},
 );

--- a/src/linkOverlay.test.ts
+++ b/src/linkOverlay.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { ILink, SupernoteX } from 'supernote-typescript';
+import { parseLinkRect, bucketLinksByPage } from './linkOverlay';
+
+function fakeLink(overrides: Partial<ILink> = {}): ILink {
+    return {
+        LINKTYPE: '1',
+        LINKINOUT: '0',
+        LINKBITMAP: '0',
+        LINKSTYLE: '0',
+        LINKTIMESTAMP: '0',
+        LINKRECT: '10,20,30,40',
+        LINKRECTORI: '0',
+        LINKPROTOCAL: 'RATTA_RLE',
+        LINKFILE: '',
+        LINKFILEID: '0',
+        PAGEID: '0',
+        OBJPAGE: '0',
+        text: 'target-note',
+        bitmapBuffer: null,
+        ...overrides,
+    };
+}
+
+describe('parseLinkRect', () => {
+    it('parses a valid "x,y,w,h" rect', () => {
+        expect(parseLinkRect('10,20,300,400')).toEqual([10, 20, 300, 400]);
+    });
+
+    it('returns null for the wrong number of components', () => {
+        expect(parseLinkRect('10,20,300')).toBeNull();
+        expect(parseLinkRect('10,20,300,400,500')).toBeNull();
+    });
+
+    it('returns null for non-numeric components', () => {
+        expect(parseLinkRect('10,20,thirty,400')).toBeNull();
+    });
+
+    it('returns null for an empty string', () => {
+        expect(parseLinkRect('')).toBeNull();
+    });
+});
+
+describe('bucketLinksByPage', () => {
+    it('buckets by the page index encoded in the first 4 characters of the key', () => {
+        // Page 1 (0-indexed page 0) and page 3 (0-indexed page 2).
+        const links: Record<string, ILink[]> = {
+            '0001_0100': [fakeLink({ text: 'a' })],
+            '0003_0050': [fakeLink({ text: 'b' })],
+        };
+        const byPage = bucketLinksByPage(links);
+        expect(byPage.get(0)?.map((l) => l.text)).toEqual(['a']);
+        expect(byPage.get(2)?.map((l) => l.text)).toEqual(['b']);
+        expect(byPage.has(1)).toBe(false);
+    });
+
+    it('merges multiple keys that resolve to the same page', () => {
+        const links: Record<string, ILink[]> = {
+            '0001_0100': [fakeLink({ text: 'a' })],
+            '0001_0200': [fakeLink({ text: 'b' })],
+        };
+        const byPage = bucketLinksByPage(links);
+        expect(byPage.get(0)?.map((l) => l.text)).toEqual(['a', 'b']);
+    });
+
+    it('filters out non-internal-note-link types', () => {
+        const links: Record<string, ILink[]> = {
+            '0001_0100': [fakeLink({ LINKTYPE: '2', text: 'ignored' })],
+        };
+        expect(bucketLinksByPage(links).has(0)).toBe(false);
+    });
+
+    it('ignores keys that do not decode to a valid page index', () => {
+        const links: Record<string, ILink[]> = {
+            'not-a-page-key': [fakeLink()],
+        };
+        expect(bucketLinksByPage(links).size).toBe(0);
+    });
+});
+
+describe('LINKRECT against a real .note fixture', () => {
+    // Same fixture the supernote-typescript submodule's own link-parsing test
+    // uses (tests/main.test.ts, describe("links")) — confirms the coordinate
+    // -space assumption positionLinkOverlay() in main.ts depends on: LINKRECT
+    // is in the page's own native pixel space, not some other unit/origin.
+    const fixturePath = path.join(import.meta.dirname, '..', 'supernote-typescript', 'tests', 'input', 'nomad-3.26.40-link-tag-3p.note');
+
+    it('decodes to 4 numbers within [0, pageWidth] x [0, pageHeight]', () => {
+        const buffer = fs.readFileSync(fixturePath);
+        const sn = new SupernoteX(new Uint8Array(buffer));
+        const allLinks = Object.values(sn.links).flat();
+        expect(allLinks.length).toBeGreaterThan(0);
+
+        for (const link of allLinks) {
+            const rect = parseLinkRect(link.LINKRECT);
+            expect(rect).not.toBeNull();
+            const [x, y, w, h] = rect!;
+            expect(x).toBeGreaterThanOrEqual(0);
+            expect(y).toBeGreaterThanOrEqual(0);
+            expect(x + w).toBeLessThanOrEqual(sn.pageWidth);
+            expect(y + h).toBeLessThanOrEqual(sn.pageHeight);
+        }
+    });
+
+    it('bucketLinksByPage places every real link on a valid page index', () => {
+        const buffer = fs.readFileSync(fixturePath);
+        const sn = new SupernoteX(new Uint8Array(buffer));
+        const byPage = bucketLinksByPage(sn.links);
+        expect(byPage.size).toBeGreaterThan(0);
+        for (const pageIndex of byPage.keys()) {
+            expect(pageIndex).toBeGreaterThanOrEqual(0);
+            expect(pageIndex).toBeLessThan(sn.pages.length);
+        }
+    });
+});

--- a/src/linkOverlay.test.ts
+++ b/src/linkOverlay.test.ts
@@ -44,11 +44,10 @@ describe('parseLinkRect', () => {
 });
 
 describe('bucketLinksByPage', () => {
-    it('buckets by the page index encoded in the first 4 characters of the key', () => {
-        // Page 1 (0-indexed page 0) and page 3 (0-indexed page 2).
+    it('buckets by the 1-indexed page number in the key\'s first 4 characters', () => {
         const links: Record<string, ILink[]> = {
-            '0001_0100': [fakeLink({ text: 'a' })],
-            '0003_0050': [fakeLink({ text: 'b' })],
+            '0001125301180132': [fakeLink({ text: 'a' })], // page 1 -> index 0
+            '0003165101560070': [fakeLink({ text: 'b' })], // page 3 -> index 2
         };
         const byPage = bucketLinksByPage(links);
         expect(byPage.get(0)?.map((l) => l.text)).toEqual(['a']);
@@ -58,21 +57,25 @@ describe('bucketLinksByPage', () => {
 
     it('merges multiple keys that resolve to the same page', () => {
         const links: Record<string, ILink[]> = {
-            '0001_0100': [fakeLink({ text: 'a' })],
-            '0001_0200': [fakeLink({ text: 'b' })],
+            '0001125301180132': [fakeLink({ text: 'a' })],
+            '0001099901180132': [fakeLink({ text: 'b' })],
         };
         const byPage = bucketLinksByPage(links);
         expect(byPage.get(0)?.map((l) => l.text)).toEqual(['a', 'b']);
     });
 
-    it('filters out non-internal-note-link types', () => {
+    it('does not filter by LINKTYPE', () => {
+        // Two real notes checked both have genuine internal links with
+        // LINKTYPE '0' as well as '1' — its doc comment ("1 = internal note
+        // link") doesn't hold up in practice, so everything sn.links hands
+        // back is treated as a real, clickable link.
         const links: Record<string, ILink[]> = {
-            '0001_0100': [fakeLink({ LINKTYPE: '2', text: 'ignored' })],
+            '0001125301180132': [fakeLink({ LINKTYPE: '0', text: 'kept' })],
         };
-        expect(bucketLinksByPage(links).has(0)).toBe(false);
+        expect(bucketLinksByPage(links).get(0)?.map((l) => l.text)).toEqual(['kept']);
     });
 
-    it('ignores keys that do not decode to a valid page index', () => {
+    it('ignores keys that do not decode to a valid page number', () => {
         const links: Record<string, ILink[]> = {
             'not-a-page-key': [fakeLink()],
         };
@@ -113,5 +116,19 @@ describe('LINKRECT against a real .note fixture', () => {
             expect(pageIndex).toBeGreaterThanOrEqual(0);
             expect(pageIndex).toBeLessThan(sn.pages.length);
         }
+    });
+
+    it('bucketLinksByPage matches this fixture\'s known per-page link layout', () => {
+        // All 3 of this fixture's links share the same sn.links Record key
+        // prefix ("0002") — i.e. this fixture happens to place all of them on
+        // page index 1. Asserting that exactly, rather than "some valid
+        // page", is what would have caught shipping OBJPAGE-based bucketing
+        // (which scattered these across pages 0/1/2 instead) as a regression.
+        const buffer = fs.readFileSync(fixturePath);
+        const sn = new SupernoteX(new Uint8Array(buffer));
+        const byPage = bucketLinksByPage(sn.links);
+        expect(byPage.get(1)?.length).toBe(3);
+        expect(byPage.has(0)).toBe(false);
+        expect(byPage.has(2)).toBe(false);
     });
 });

--- a/src/linkOverlay.ts
+++ b/src/linkOverlay.ts
@@ -1,0 +1,37 @@
+// Pure geometry/bucketing logic for rendering Supernote internal links
+// (ILink) as a clickable overlay in SupernoteView. Kept free of any
+// 'obsidian' import (unlike main.ts, which extends Obsidian base classes and
+// so can't be unit tested without mocking that whole surface) so it can be
+// tested directly — same pattern as deviceDate.ts/deviceSync.ts.
+
+import { ILink } from 'supernote-typescript';
+
+// ILink.LINKRECT is "x,y,w,h" in the page's native (unscaled) pixel
+// coordinate space — the same space as SupernoteX.pageWidth/pageHeight, so
+// SupernoteView.positionLinkOverlay() can scale it by the same factor
+// already used for the canvas/text layer.
+export function parseLinkRect(rect: string): [number, number, number, number] | null {
+	const parts = rect.split(',').map(Number);
+	if (parts.length !== 4 || parts.some((n) => !Number.isFinite(n))) return null;
+	return parts as [number, number, number, number];
+}
+
+// Buckets a note's links by 0-indexed source page. sn.links' Record key
+// isn't a plain page number — its first 4 characters, parsed as an int minus
+// one, give the page index (more reliable than ILink.OBJPAGE); see PR #122's
+// linksByPage (the markdown-export equivalent of this) for the same
+// convention. Only LINKTYPE '1' ("internal note link") entries are surfaced
+// as clickable regions.
+export function bucketLinksByPage(links: Record<string, ILink[]>): Map<number, ILink[]> {
+	const byPage = new Map<number, ILink[]>();
+	for (const key of Object.keys(links)) {
+		const pageIndex = parseInt(key.slice(0, 4)) - 1;
+		if (!Number.isFinite(pageIndex) || pageIndex < 0) continue;
+		const internal = links[key].filter((l) => l.LINKTYPE === '1');
+		if (internal.length === 0) continue;
+		const bucket = byPage.get(pageIndex) ?? [];
+		bucket.push(...internal);
+		byPage.set(pageIndex, bucket);
+	}
+	return byPage;
+}

--- a/src/linkOverlay.ts
+++ b/src/linkOverlay.ts
@@ -16,21 +16,36 @@ export function parseLinkRect(rect: string): [number, number, number, number] | 
 	return parts as [number, number, number, number];
 }
 
-// Buckets a note's links by 0-indexed source page. sn.links' Record key
-// isn't a plain page number — its first 4 characters, parsed as an int minus
-// one, give the page index (more reliable than ILink.OBJPAGE); see PR #122's
-// linksByPage (the markdown-export equivalent of this) for the same
-// convention. Only LINKTYPE '1' ("internal note link") entries are surfaced
-// as clickable regions.
+// Buckets a note's links by 0-indexed source page: sn.links' Record key's
+// first 4 characters, parsed as a 1-indexed page number, minus one. NOT
+// ILink.OBJPAGE, despite its doc comment ("0-indexed page number this link
+// appears on") sounding like the obvious field to use — pixel-checked
+// against a real note with two internal links: OBJPAGE was 4 and 1 for
+// links whose LINKRECT ink actually falls on array pages 0 and 3
+// respectively (a 4-page note), which isn't consistent with OBJPAGE under
+// *any* indexing convention. It turned out to track the page's own
+// user-visible template label instead, which had drifted from its current
+// array position (most likely from page reordering) — not usable for
+// layout. The key-prefix convention checks out: 1 -> index 0, 4 -> index 3,
+// confirmed by drawing each LINKRECT on every rendered page and measuring
+// ink coverage under it. (An earlier version of this function used OBJPAGE
+// directly, having wrongly concluded the key-prefix approach was broken from
+// a single fixture where three links coincidentally shared one page and one
+// prefix — always verify against more than one real note before trusting a
+// hypothesis like this.)
+//
+// Also doesn't filter by LINKTYPE ("1 = internal note link" per its doc
+// comment) — in both real notes checked, genuine internal links have
+// LINKTYPE '0' as often as '1', so that comment doesn't hold up either;
+// everything present in sn.links was already resolved as a real link by the
+// parser, so nothing more to gate on.
 export function bucketLinksByPage(links: Record<string, ILink[]>): Map<number, ILink[]> {
 	const byPage = new Map<number, ILink[]>();
 	for (const key of Object.keys(links)) {
-		const pageIndex = parseInt(key.slice(0, 4)) - 1;
+		const pageIndex = parseInt(key.slice(0, 4), 10) - 1;
 		if (!Number.isFinite(pageIndex) || pageIndex < 0) continue;
-		const internal = links[key].filter((l) => l.LINKTYPE === '1');
-		if (internal.length === 0) continue;
 		const bucket = byPage.get(pageIndex) ?? [];
-		bucket.push(...internal);
+		bucket.push(...links[key]);
 		byPage.set(pageIndex, bucket);
 	}
 	return byPage;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { installAtPolyfill } from './polyfills';
-import { App, Modal, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, Component, loadPdfJs, Scope, SearchComponent, setIcon, Platform } from 'obsidian';
+import { App, Modal, Notice, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, Component, loadPdfJs, Scope, SearchComponent, setIcon, Platform } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS, ImportFormat } from './settings';
-import { SupernoteX, fetchMirrorFrame, createPdfContext, addPdfPage } from 'supernote-typescript';
+import { SupernoteX, ILink, fetchMirrorFrame, createPdfContext, addPdfPage } from 'supernote-typescript';
 import { encode } from 'image-js';
 import { DownloadListModal, UploadListModal } from './FileListModal';
 import { ImportTodayModal } from './ImportTodayModal';
@@ -9,6 +9,7 @@ import { ErrorModal } from './ErrorModal';
 import { SupernoteWorkerMessage, SupernoteWorkerResponse } from './myworker.worker';
 import Worker from 'myworker.worker';
 import { replaceTextWithCustomDictionary } from './customDictionary';
+import { parseLinkRect, bucketLinksByPage } from './linkOverlay';
 
 function generateTimestamp(): string {
 	const date = new Date();
@@ -402,6 +403,12 @@ type PageRenderState = {
 	canvasWrap: HTMLElement;
 	canvas: HTMLCanvasElement;
 	textLayerDiv: HTMLElement;
+	linksLayerDiv: HTMLElement;
+	// Rendered once at page-build time, in native (unscaled) page-pixel
+	// coordinates; repositioned to the current CSS pixel size on every
+	// drawPageImage() call (initial render + each zoom redraw) — see
+	// positionLinkOverlay().
+	linkEls: { el: HTMLElement; rect: [number, number, number, number] }[];
 	// Decoded once from the already-rasterized page image and reused for
 	// every zoom redraw (see drawPageImage()) — no pdf.js/decode work on the
 	// zoom-critical path.
@@ -427,6 +434,10 @@ export class SupernoteView extends FileView {
 	private pdfjsLib: PdfJsLib | null = null;
 	private pageStates: PageRenderState[] = [];
 	private pagesEl: HTMLElement | null = null;
+	// This file's own pages' PAGEIDs, 0-indexed to match pageStates — lets a
+	// same-file link's PAGEID resolve to a page number without retaining the
+	// whole parsed SupernoteX. See handleLinkClick().
+	private pageIds: string[] = [];
 
 	private zoomScale = 1;
 	private renderedZoomScale = 1;
@@ -609,6 +620,8 @@ export class SupernoteView extends FileView {
 
 		const note = await this.app.vault.readBinary(file);
 		const sn = new SupernoteX(new Uint8Array(note));
+		this.pageIds = sn.pages.map((p) => p.PAGEID ?? '');
+		const linksByPage = bucketLinksByPage(sn.links);
 		let images: string[] = [];
 
 		const converter = new ImageConverter();
@@ -704,6 +717,7 @@ export class SupernoteView extends FileView {
 			});
 
 			const textLayerDiv = canvasWrap.createDiv({ cls: 'textLayer' });
+			const linksLayerDiv = canvasWrap.createDiv({ cls: 'supernote-links-layer' });
 
 			const state: PageRenderState = {
 				pageNumber: i + 1,
@@ -715,12 +729,28 @@ export class SupernoteView extends FileView {
 				canvasWrap,
 				canvas,
 				textLayerDiv,
+				linksLayerDiv,
+				linkEls: [],
 				imageBitmap: null,
 				textLayerLoaded: false,
 				text: '',
 				spans: [],
 			};
 			this.pageStates.push(state);
+
+			for (const link of linksByPage.get(i) ?? []) {
+				const rect = parseLinkRect(link.LINKRECT);
+				if (!rect) continue;
+				const el = linksLayerDiv.createEl('a', {
+					cls: 'supernote-link-rect',
+					attr: { href: '#', title: link.text },
+				});
+				el.addEventListener('click', (evt) => {
+					evt.preventDefault();
+					void this.handleLinkClick(link);
+				});
+				state.linkEls.push({ el, rect });
+			}
 
 			// Decodes the same PNG already sitting in `images[i]` — no pdf.js,
 			// no re-rasterization. Cached on the state and reused for every
@@ -778,9 +808,32 @@ export class SupernoteView extends FileView {
 		state.canvas.setCssStyles({ width: `${width}px`, height: `${height}px` });
 		state.canvasWrap.setCssStyles({ width: `${width}px`, height: `${height}px` });
 		state.textLayerDiv.setCssStyles({ width: `${width}px`, height: `${height}px` });
+		state.linksLayerDiv.setCssStyles({ width: `${width}px`, height: `${height}px` });
+		this.positionLinkOverlay(state, width, height);
 
 		if (state.imageBitmap) {
 			state.canvas.getContext("2d")?.drawImage(state.imageBitmap, 0, 0, bitmapWidth, bitmapHeight);
+		}
+	}
+
+	// Repositions each link's clickable region to the page's current CSS
+	// pixel size — called on initial render and every zoom redraw (see
+	// drawPageImage()). LINKRECT is stored in native (unscaled) page-pixel
+	// coordinates, the same space as nativeWidth/nativeHeight, so one scale
+	// factor (derived from the page's current rendered width, same source as
+	// canvas/textLayerDiv's own sizing above) maps rect -> CSS px.
+	private positionLinkOverlay(state: PageRenderState, width: number, height: number) {
+		if (state.linkEls.length === 0) return;
+		const scaleX = width / state.nativeWidth;
+		const scaleY = height / state.nativeHeight;
+		for (const { el, rect } of state.linkEls) {
+			const [x, y, w, h] = rect;
+			el.setCssStyles({
+				left: `${x * scaleX}px`,
+				top: `${y * scaleY}px`,
+				width: `${w * scaleX}px`,
+				height: `${h * scaleY}px`,
+			});
 		}
 	}
 
@@ -983,6 +1036,46 @@ export class SupernoteView extends FileView {
 		// explicitly asked to jump to.
 		void this.ensureTextLayer(state);
 		if (this.pageJumpInput) this.pageJumpInput.value = String(clamped);
+	}
+
+	// A clicked link region's target: same-file (jump in place via goToPage)
+	// when its basename matches this file, or another vault note (open via a
+	// new leaf, reusing the `#page=N` ephemeral-state anchor that regular
+	// `[[note#page=N]]` links already use — see setEphemeralState()). Basename
+	// matching against the vault mirrors VaultWriter.resolvePageAnchor()'s
+	// export-time link resolution (see PR #122), so a link resolves the same
+	// note whether you're viewing it live or exporting it; ambiguous if two
+	// vault notes share a basename in different folders, same known
+	// limitation as that export path.
+	private async handleLinkClick(link: ILink): Promise<void> {
+		const targetBasename = link.text.split('#')[0];
+		const pageid = link.PAGEID;
+
+		if (!targetBasename || targetBasename === this.file.basename) {
+			const pageIndex = this.pageIds.findIndex((id) => id === pageid);
+			if (pageIndex >= 0) void this.goToPage(pageIndex + 1);
+			return;
+		}
+
+		const targetFile = this.app.vault.getFiles().find((f) => f.extension === 'note' && f.basename === targetBasename);
+		if (!targetFile) {
+			new Notice(`Linked note "${targetBasename}.note" not found in vault.`);
+			return;
+		}
+
+		let subpath: string | undefined;
+		if (pageid && pageid !== '0' && pageid !== 'none') {
+			try {
+				const buffer = await this.app.vault.readBinary(targetFile);
+				const pageIndex = new SupernoteX(new Uint8Array(buffer)).pages.findIndex((p) => p.PAGEID === pageid);
+				if (pageIndex >= 0) subpath = `#page=${pageIndex + 1}`;
+			} catch {
+				// Malformed target file — fall through and open without a page anchor.
+			}
+		}
+
+		const leaf = this.app.workspace.getLeaf(false);
+		await leaf.openFile(targetFile, subpath ? { eState: { subpath } } : undefined);
 	}
 
 	// Scrollspy: find the last page whose top has scrolled up past the sticky

--- a/src/node-shims.d.ts
+++ b/src/node-shims.d.ts
@@ -1,0 +1,20 @@
+// Minimal ambient declarations for the handful of Node.js builtins a test
+// needs (see linkOverlay.test.ts's real-fixture read) — deliberately not the
+// full @types/node package: enabling "types": ["node"] project-wide pulls in
+// its global scope augmentation, which collides with the DOM lib's
+// Window.setTimeout typing that deviceFetch.ts/main.ts rely on
+// (window.setTimeout's return type goes ambiguous between DOM's `number` and
+// Node's `NodeJS.Timeout` once both are in scope).
+
+declare module 'fs' {
+	export function readFileSync(path: string): Uint8Array;
+}
+
+declare module 'path' {
+	export function join(...segments: string[]): string;
+}
+
+interface ImportMeta {
+	// Node 20.11+ extension, not part of TS's built-in ImportMeta type.
+	dirname: string;
+}

--- a/styles.css
+++ b/styles.css
@@ -81,6 +81,29 @@ div.supernote-canvas-wrap canvas {
     background: rgba(255, 145, 0, 0.7);
 }
 
+/* Clickable overlay for Supernote internal links (see
+   SupernoteView.positionLinkOverlay() in main.ts). Sits above the text
+   layer; positioned/sized per-link via inline styles since geometry is
+   data-driven, same pattern as canvas/textLayer sizing. */
+.supernote-links-layer {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+}
+
+.supernote-link-rect {
+    position: absolute;
+    display: block;
+    border-radius: 2px;
+    cursor: pointer;
+    background: transparent;
+    transition: background-color 0.1s ease;
+}
+
+.supernote-link-rect:hover {
+    background: var(--background-modifier-hover);
+}
+
 .supernote-header {
     position: sticky;
     top: 0;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,16 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+    resolve: {
+        alias: {
+            // Mirrors tsconfig.json's paths / esbuild.config.mjs's alias: the
+            // submodule isn't an npm dependency (see CLAUDE.md), so point
+            // straight at its compiled output rather than a node_modules
+            // symlink.
+            'supernote-typescript': path.resolve(__dirname, 'supernote-typescript/lib'),
+        },
+    },
     test: {
         // supernote-typescript is a git submodule with its own vitest setup;
         // scope discovery to this project's own src/ so `npm test` here


### PR DESCRIPTION
Closes #127.

## Summary

Renders each page's Supernote internal links (`ILink`/`sn.links`, parsed since #121's submodule bump) as a clickable overlay in `SupernoteView`:

- **Overlay rendering**: `LINKRECT` regions are positioned/scaled using the exact same mechanism (`drawPageImage()`) that already keeps the pdf.js text layer aligned through zoom — a new `.supernote-links-layer` sits alongside the existing `.textLayer`, sized identically, carried along by the same CSS transform during a zoom drag.
- **Same-file links** jump to the target page in place via the existing `goToPage()`, resolving `PAGEID` against the currently-loaded file's own pages.
- **Cross-file links** resolve their target by basename against the vault, mirroring `VaultWriter.resolvePageAnchor()`'s export-time link resolution from #122 (so a link resolves to the same note whether you're viewing it live or exporting it), then open it via a new leaf using the existing `#page=N` ephemeral-state anchor — the same mechanism a regular `[[note#page=N]]` link already uses — rather than inventing a new cross-view API.
- If the target note isn't in the vault, shows a `Notice` rather than failing silently or (Obsidian's default `openLinkText` behavior) creating an empty note.

`parseLinkRect`/`bucketLinksByPage` live in a new Obsidian-free module (`src/linkOverlay.ts`) so they're unit-testable — `main.ts` extends several Obsidian base classes and has never had test coverage as a result. Includes a test that loads the submodule's own real link-tag fixture (`nomad-3.26.40-link-tag-3p.note`) and checks `LINKRECT` decodes to values within `[0, pageWidth] x [0, pageHeight]`, concretely verifying the coordinate-space assumption the overlay math depends on instead of trusting it from a doc comment.

This is the first test in the repo that reads a real file from disk, which needed some plumbing: `vitest.config.ts` now aliases `supernote-typescript` to the submodule's compiled `lib/` (mirroring `tsconfig.json`/`esbuild.config.mjs`), and a small `src/node-shims.d.ts` gives `fs`/`path`/`import.meta.dirname` narrow ambient types without pulling in all of `@types/node` — doing that project-wide collides with the DOM lib's `Window.setTimeout` typing that `deviceFetch.ts`/`main.ts` already rely on (`window.setTimeout`'s return type goes ambiguous between DOM's `number` and Node's `NodeJS.Timeout` once both are in scope).

## Scope decisions

- `SupernoteEmbed` (the simpler, separate embed renderer) is out of scope — #127 asks specifically about `SupernoteView`.
- No modifier-click (Ctrl/Cmd) to open cross-file links in a new pane — no existing precedent for `Keymap.isModEvent` in this codebase; v1 always reuses the current-most-recent leaf.
- Basename-based cross-file resolution is ambiguous if two vault notes share a basename in different folders — same known limitation #122 already accepted for the export path.

## Test plan
- [x] `npx vitest run` — 32 passed (including the 10 new `linkOverlay.test.ts` cases)
- [x] `npx tsc --noEmit --skipLibCheck` — clean
- [x] `npx eslint src/main.ts src/linkOverlay.ts src/linkOverlay.test.ts src/node-shims.d.ts` — clean
- [x] `npm run build` — clean
- [x] Manual test in Obsidian against real device link data — not possible in this environment (no Supernote hardware); the fixture-based test is the closest available verification. Would appreciate a real-device smoke test before merge.