### PR TITLE
Add a persistent, size-bounded rasterization cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ main.js
 
 # obsidian
 data.json
+# Runtime rasterization cache — created under manifest.dir at plugin runtime,
+# not source. Lands at the repo root when this repo is symlinked in directly
+# as a test vault's plugin folder.
+rasterCache/
 
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,11 @@ data.json
 # as a test vault's plugin folder.
 rasterCache/
 
+# Personal .note test files dropped at repo root for manual testing — not
+# fixtures (those live under supernote-typescript/tests/input/), and too
+# large/private to belong in git history.
+/*.note
+
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { replaceTextWithCustomDictionary } from './customDictionary';
 import { runDeviceSync, appendSyncLogEntry } from './syncEngine';
 import { formatSyncFailureLogEntry } from './deviceSync';
 import { parseLinkRect, bucketLinksByPage } from './linkOverlay';
+import { RasterCache, hashBytes, DEFAULT_MAX_CACHE_BYTES } from './rasterCache';
 
 function generateTimestamp(): string {
 	const date = new Date();
@@ -169,13 +170,44 @@ export class WorkerPool {
 export class ImageConverter {
     private workerPool: WorkerPool;
 
-    constructor(maxWorkers = navigator.hardwareConcurrency) {  // Default to 4 workers
+    constructor(private cache?: RasterCache, maxWorkers = navigator.hardwareConcurrency) {  // Default to 4 workers
         this.workerPool = new WorkerPool(maxWorkers);
     }
 
-    async convertToImages(note: SupernoteX, pageNumbers?: number[]): Promise<string[]> {
+    // `rawBytes` (the .note file's own bytes, already read by every caller to
+    // construct `note` in the first place) is what gets content-hashed for
+    // the cache key — passing it is what turns caching on; omit it (or
+    // construct without a cache) to always rasterize fresh, e.g. in tests.
+    async convertToImages(note: SupernoteX, rawBytes?: Uint8Array, pageNumbers?: number[]): Promise<string[]> {
         const pages = pageNumbers ?? Array.from({length: note.pages.length}, (_, i) => i+1);
-        const results = await this.workerPool.processPages(note, pages);
+
+        if (!this.cache || !rawBytes) {
+            return this.workerPool.processPages(note, pages);
+        }
+
+        const noteHash = hashBytes(rawBytes);
+        const results = new Array<string>(pages.length);
+        const missingPages: number[] = [];
+        const missingIndices: number[] = [];
+
+        await Promise.all(pages.map(async (pageNumber, i) => {
+            const cached = await this.cache!.get(noteHash, pageNumber);
+            if (cached !== null) {
+                results[i] = cached;
+            } else {
+                missingIndices.push(i);
+                missingPages.push(pageNumber);
+            }
+        }));
+
+        if (missingPages.length > 0) {
+            const rendered = await this.workerPool.processPages(note, missingPages);
+            await Promise.all(rendered.map((dataUrl, j) => {
+                results[missingIndices[j]] = dataUrl;
+                return this.cache!.put(noteHash, missingPages[j], dataUrl);
+            }));
+        }
+
         return results;
     }
 
@@ -228,11 +260,13 @@ class VaultWriter {
 	app: App;
 	settings: SupernotePluginSettings;
 	processors: Set<PageTextProcessor>;
+	cache?: RasterCache;
 
-	constructor(app: App, settings: SupernotePluginSettings, processors: Set<PageTextProcessor>) {
+	constructor(app: App, settings: SupernotePluginSettings, processors: Set<PageTextProcessor>, cache?: RasterCache) {
 		this.app = app;
 		this.settings = settings;
 		this.processors = processors;
+		this.cache = cache;
 	}
 
 	// `imageDataUrl` comes from the in-memory rasterization pass
@@ -262,13 +296,15 @@ class VaultWriter {
 		return result;
 	}
 
-	// Rasterizes every page once via the worker pool. Callers that also need
-	// the images written to the vault pass the result to writeImageFiles()
-	// rather than rasterizing a second time.
-	private async rasterizePages(sn: SupernoteX): Promise<string[]> {
-		const converter = new ImageConverter();
+	// Rasterizes every page once via the worker pool (or the persistent
+	// on-disk cache, if pages for this exact .note content have already been
+	// rendered before). Callers that also need the images written to the
+	// vault pass the result to writeImageFiles() rather than rasterizing a
+	// second time.
+	private async rasterizePages(sn: SupernoteX, rawBytes: Uint8Array): Promise<string[]> {
+		const converter = new ImageConverter(this.cache);
 		try {
-			return await converter.convertToImages(sn);
+			return await converter.convertToImages(sn, rawBytes);
 		} finally {
 			converter.terminate();
 		}
@@ -329,20 +365,22 @@ class VaultWriter {
 
 	async attachMarkdownFile(file: TFile) {
 		const note = await this.app.vault.readBinary(file);
-		const sn = new SupernoteX(new Uint8Array(note));
+		const rawBytes = new Uint8Array(note);
+		const sn = new SupernoteX(rawBytes);
 
 		// This export doesn't otherwise touch images at all, but a registered
 		// processor still needs one to work with — rasterize only when
 		// there's actually a processor to hand it to.
-		const images = this.processors.size > 0 ? await this.rasterizePages(sn) : null;
+		const images = this.processors.size > 0 ? await this.rasterizePages(sn, rawBytes) : null;
 		await this.writeMarkdownFile(file, sn, null, images);
 	}
 
 	async attachNoteFiles(file: TFile) {
 		const note = await this.app.vault.readBinary(file);
-		const sn = new SupernoteX(new Uint8Array(note));
+		const rawBytes = new Uint8Array(note);
+		const sn = new SupernoteX(rawBytes);
 
-		const images = await this.rasterizePages(sn);
+		const images = await this.rasterizePages(sn, rawBytes);
 		const imgs = await this.writeImageFiles(file.basename, images);
 		await this.writeMarkdownFile(file, sn, imgs, images);
 	}
@@ -365,10 +403,11 @@ class VaultWriter {
 			return `${format === 'embed' ? '!' : ''}${link}\n`;
 		}
 
-		const sn = new SupernoteX(new Uint8Array(noteBuffer));
+		const rawBytes = new Uint8Array(noteBuffer);
+		const sn = new SupernoteX(rawBytes);
 
 		if (format === 'pdf') {
-			const images = await this.rasterizePages(sn);
+			const images = await this.rasterizePages(sn, rawBytes);
 			const pdfBytes = await assemblePdfFromImages(sn, images);
 			const filename = await this.app.fileManager.getAvailablePathForAttachment(`${basename}.pdf`);
 			const tfile = await this.app.vault.createBinary(filename, toArrayBuffer(pdfBytes));
@@ -376,7 +415,7 @@ class VaultWriter {
 			return `${link}\n`;
 		}
 
-		const rasterized = await this.rasterizePages(sn);
+		const rasterized = await this.rasterizePages(sn, rawBytes);
 		const imgs = await this.writeImageFiles(basename, rasterized);
 		return this.renderPagesMarkdown(basename, sn, imgs, targetPath, format, deviceFileName, rasterized);
 	}
@@ -409,18 +448,13 @@ class VaultWriter {
 
 	async exportToPDF(file: TFile) {
 		const note = await this.app.vault.readBinary(file);
-		const sn = new SupernoteX(new Uint8Array(note));
+		const rawBytes = new Uint8Array(note);
+		const sn = new SupernoteX(rawBytes);
 
 		// Rasterizes across the Worker pool in parallel (same pass the other
 		// export paths use), then assembles the PDF from those images rather
 		// than rendering a second time.
-		const converter = new ImageConverter();
-		let images: string[] = [];
-		try {
-			images = await converter.convertToImages(sn);
-		} finally {
-			converter.terminate();
-		}
+		const images = await this.rasterizePages(sn, rawBytes);
 
 		const pdfBytes = await assemblePdfFromImages(sn, images);
 
@@ -525,6 +559,12 @@ type FindMatch = {
 };
 
 let vw: VaultWriter;
+// Shared across every SupernoteView/SupernoteEmbed instance and VaultWriter —
+// set once in SupernotePlugin.onload() (there's exactly one on-disk cache
+// directory per vault, so one RasterCache instance is what should be writing
+// to it). Undefined until onload() finishes initializing it (or if that
+// initialization fails), in which case ImageConverter just skips caching.
+let rasterCache: RasterCache | undefined;
 export const VIEW_TYPE_SUPERNOTE = "supernote-view";
 
 export class SupernoteView extends FileView {
@@ -719,14 +759,15 @@ export class SupernoteView extends FileView {
 		this.findRequestId++;
 
 		const note = await this.app.vault.readBinary(file);
-		const sn = new SupernoteX(new Uint8Array(note));
+		const rawBytes = new Uint8Array(note);
+		const sn = new SupernoteX(rawBytes);
 		this.pageIds = sn.pages.map((p) => p.PAGEID ?? '');
 		const linksByPage = bucketLinksByPage(sn.links);
 		let images: string[] = [];
 
-		const converter = new ImageConverter();
+		const converter = new ImageConverter(rasterCache);
 		try {
-			images = await converter.convertToImages(sn);
+			images = await converter.convertToImages(sn, rawBytes);
 		} finally {
 			// Clean up the worker when done
 			converter.terminate();
@@ -1537,10 +1578,12 @@ export class SupernoteEmbed extends Component {
 		this.lastMinHeightWidth = -1;
 
 		let sn: SupernoteX;
+		let rawBytes: Uint8Array;
 		try {
 			const note = await this.app.vault.readBinary(this.file);
 			if (this.destroyed) return;
-			sn = new SupernoteX(new Uint8Array(note));
+			rawBytes = new Uint8Array(note);
+			sn = new SupernoteX(rawBytes);
 		} catch (err) {
 			this.renderError(err);
 			return;
@@ -1553,10 +1596,10 @@ export class SupernoteEmbed extends Component {
 			: null;
 		this.pageAspectRatio = sn.pageHeight / sn.pageWidth;
 
-		const converter = new ImageConverter();
+		const converter = new ImageConverter(rasterCache);
 		let images: string[];
 		try {
-			images = await converter.convertToImages(sn, singlePage !== null ? [singlePage] : undefined);
+			images = await converter.convertToImages(sn, rawBytes, singlePage !== null ? [singlePage] : undefined);
 		} catch (err) {
 			if (!this.destroyed) this.renderError(err);
 			return;
@@ -1670,6 +1713,11 @@ export class SupernoteEmbed extends Component {
 export default class SupernotePlugin extends Plugin {
 	settings!: SupernotePluginSettings;
 	vaultWriter!: VaultWriter;
+	// Same instance as the module-level `rasterCache` used by SupernoteView/
+	// SupernoteEmbed/VaultWriter — exposed here too so the settings tab can
+	// show cache stats and offer a "clear cache" action without reaching into
+	// this module's internals.
+	rasterCache?: RasterCache;
 	private syncInFlight = false;
 	// Live reference handed to VaultWriter — registering/unregistering here
 	// after construction still takes effect, since both hold the same Set.
@@ -1698,7 +1746,20 @@ export default class SupernotePlugin extends Plugin {
         installAtPolyfill();
 
 		await this.loadSettings();
-		vw = new VaultWriter(this.app, this.settings, this.pageTextProcessors);
+
+		// A missing manifest.dir would mean no stable, plugin-private vault
+		// folder to keep cache blobs in — shouldn't happen for an installed
+		// plugin, but if it does, skip caching rather than fail to load.
+		if (this.manifest.dir) {
+			try {
+				rasterCache = await RasterCache.open(this.app.vault.adapter, `${this.manifest.dir}/rasterCache`, DEFAULT_MAX_CACHE_BYTES);
+				this.rasterCache = rasterCache;
+			} catch (err) {
+				console.error('Supernote: failed to initialize rasterization cache, continuing without it', err);
+			}
+		}
+
+		vw = new VaultWriter(this.app, this.settings, this.pageTextProcessors, rasterCache);
 		this.vaultWriter = vw;
 
 		this.addSettingTab(new SupernoteSettingTab(this.app, this));

--- a/src/main.ts
+++ b/src/main.ts
@@ -832,6 +832,18 @@ export class SupernoteView extends FileView {
 		// or rasterization needed just to know how big to lay pages out.
 		const baseScale = this.settings.noteImageMaxDim / Math.max(sn.pageWidth, sn.pageHeight);
 
+		// Decoded up front, all at once via Promise.all, rather than one at a
+		// time inside the loop below — createImageBitmap() previously being
+		// awaited per-page meant a note's pages were decoded strictly one
+		// after another regardless of how the rasterized PNGs themselves were
+		// obtained (worker, disk cache, or memory cache), so this was still a
+		// real, page-count-scaling cost on every open, "cache-warm" or not.
+		const renderStart = performance.now();
+		const bitmaps = await Promise.all(images.map(async (imageDataUrl) => {
+			const blob = new Blob([dataUrlToBuffer(imageDataUrl)], { type: 'image/png' });
+			return createImageBitmap(blob);
+		}));
+
 		for (let i = 0; i < images.length; i++) {
 			const imageDataUrl = images[i];
 
@@ -894,11 +906,9 @@ export class SupernoteView extends FileView {
 				state.linkEls.push({ el, rect });
 			}
 
-			// Decodes the same PNG already sitting in `images[i]` — no pdf.js,
-			// no re-rasterization. Cached on the state and reused for every
-			// zoom redraw (drawPageImage()).
-			const blob = new Blob([dataUrlToBuffer(imageDataUrl)], { type: 'image/png' });
-			state.imageBitmap = await createImageBitmap(blob);
+			// Already decoded above (in parallel, before this loop). Cached on
+			// the state and reused for every zoom redraw (drawPageImage()).
+			state.imageBitmap = bitmaps[i];
 			this.drawPageImage(state, baseScale * this.zoomScale);
 
 			this.pageObserver?.observe(pageContainer);
@@ -917,6 +927,8 @@ export class SupernoteView extends FileView {
 				})());
 			}
 		}
+
+		console.debug(`Supernote: page render (bitmap decode + DOM) — ${images.length} page(s) in ${(performance.now() - renderStart).toFixed(1)}ms`);
 
 		if (this.fitWidthEnabled) {
 			this.applyFitWidth();

--- a/src/main.ts
+++ b/src/main.ts
@@ -167,12 +167,28 @@ export class WorkerPool {
     }
 }
 
-export class ImageConverter {
-    private workerPool: WorkerPool;
-
-    constructor(private cache?: RasterCache, maxWorkers = navigator.hardwareConcurrency) {  // Default to 4 workers
-        this.workerPool = new WorkerPool(maxWorkers);
+// Shared for the plugin's lifetime instead of every ImageConverter owning
+// (and tearing down) its own WorkerPool. Spinning up hardwareConcurrency new
+// Web Workers is real, fixed-cost work — previously paid on *every single*
+// rasterization call regardless of outcome, so even a full raster-cache hit
+// (zero pages actually rendered) still spun up and terminated a whole pool
+// for nothing. Created lazily (on first actual use) so plugin activation
+// itself doesn't spin up workers before any note is opened; torn down once
+// in SupernotePlugin.onunload().
+let sharedWorkerPool: WorkerPool | undefined;
+function getSharedWorkerPool(): WorkerPool {
+    if (!sharedWorkerPool) {
+        sharedWorkerPool = new WorkerPool();
     }
+    return sharedWorkerPool;
+}
+function terminateSharedWorkerPool(): void {
+    sharedWorkerPool?.terminate();
+    sharedWorkerPool = undefined;
+}
+
+export class ImageConverter {
+    constructor(private cache?: RasterCache) {}
 
     // `rawBytes` (the .note file's own bytes, already read by every caller to
     // construct `note` in the first place) is what gets content-hashed for
@@ -182,7 +198,7 @@ export class ImageConverter {
         const pages = pageNumbers ?? Array.from({length: note.pages.length}, (_, i) => i+1);
 
         if (!this.cache || !rawBytes) {
-            return this.workerPool.processPages(note, pages);
+            return getSharedWorkerPool().processPages(note, pages);
         }
 
         const start = performance.now();
@@ -202,7 +218,7 @@ export class ImageConverter {
         }));
 
         if (missingPages.length > 0) {
-            const rendered = await this.workerPool.processPages(note, missingPages);
+            const rendered = await getSharedWorkerPool().processPages(note, missingPages);
             await Promise.all(rendered.map((dataUrl, j) => {
                 results[missingIndices[j]] = dataUrl;
                 return this.cache!.put(noteHash, missingPages[j], dataUrl);
@@ -211,10 +227,6 @@ export class ImageConverter {
 
         console.debug(`Supernote: rasterization cache — ${pages.length - missingPages.length}/${pages.length} page(s) from cache, ${missingPages.length} rendered fresh, ${(performance.now() - start).toFixed(1)}ms total`);
         return results;
-    }
-
-    terminate() {
-        this.workerPool.terminate();
     }
 }
 
@@ -304,12 +316,7 @@ class VaultWriter {
 	// vault pass the result to writeImageFiles() rather than rasterizing a
 	// second time.
 	private async rasterizePages(sn: SupernoteX, rawBytes: Uint8Array): Promise<string[]> {
-		const converter = new ImageConverter(this.cache);
-		try {
-			return await converter.convertToImages(sn, rawBytes);
-		} finally {
-			converter.terminate();
-		}
+		return new ImageConverter(this.cache).convertToImages(sn, rawBytes);
 	}
 
 	// `images` (raw rasterized page data URLs, for processors) is independent
@@ -765,15 +772,7 @@ export class SupernoteView extends FileView {
 		const sn = new SupernoteX(rawBytes);
 		this.pageIds = sn.pages.map((p) => p.PAGEID ?? '');
 		const linksByPage = bucketLinksByPage(sn.links);
-		let images: string[] = [];
-
-		const converter = new ImageConverter(rasterCache);
-		try {
-			images = await converter.convertToImages(sn, rawBytes);
-		} finally {
-			// Clean up the worker when done
-			converter.terminate();
-		}
+		const images = await new ImageConverter(rasterCache).convertToImages(sn, rawBytes);
 
 		// Kicked off now but not awaited: pages are visible immediately from
 		// their own rasterized image (drawPageImage(), no pdf.js involved at
@@ -1598,15 +1597,12 @@ export class SupernoteEmbed extends Component {
 			: null;
 		this.pageAspectRatio = sn.pageHeight / sn.pageWidth;
 
-		const converter = new ImageConverter(rasterCache);
 		let images: string[];
 		try {
-			images = await converter.convertToImages(sn, rawBytes, singlePage !== null ? [singlePage] : undefined);
+			images = await new ImageConverter(rasterCache).convertToImages(sn, rawBytes, singlePage !== null ? [singlePage] : undefined);
 		} catch (err) {
 			if (!this.destroyed) this.renderError(err);
 			return;
-		} finally {
-			converter.terminate();
 		}
 		if (this.destroyed) return;
 
@@ -2005,7 +2001,7 @@ export default class SupernotePlugin extends Plugin {
 	}
 
 	onunload() {
-
+		terminateSharedWorkerPool();
 	}
 
 	async activateView() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -185,6 +185,7 @@ export class ImageConverter {
             return this.workerPool.processPages(note, pages);
         }
 
+        const start = performance.now();
         const noteHash = hashBytes(rawBytes);
         const results = new Array<string>(pages.length);
         const missingPages: number[] = [];
@@ -208,6 +209,7 @@ export class ImageConverter {
             }));
         }
 
+        console.debug(`Supernote: rasterization cache — ${pages.length - missingPages.length}/${pages.length} page(s) from cache, ${missingPages.length} rendered fresh, ${(performance.now() - start).toFixed(1)}ms total`);
         return results;
     }
 
@@ -1754,9 +1756,12 @@ export default class SupernotePlugin extends Plugin {
 			try {
 				rasterCache = await RasterCache.open(this.app.vault.adapter, `${this.manifest.dir}/rasterCache`, DEFAULT_MAX_CACHE_BYTES);
 				this.rasterCache = rasterCache;
+				console.debug(`Supernote: rasterization cache ready (${rasterCache.entryCount} entries, ${rasterCache.totalCachedBytes} bytes)`);
 			} catch (err) {
 				console.error('Supernote: failed to initialize rasterization cache, continuing without it', err);
 			}
+		} else {
+			console.warn('Supernote: manifest.dir is unset, rasterization cache disabled');
 		}
 
 		vw = new VaultWriter(this.app, this.settings, this.pageTextProcessors, rasterCache);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { installAtPolyfill } from './polyfills';
 import { App, Modal, Notice, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, Component, loadPdfJs, Scope, SearchComponent, setIcon, Platform } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS, ImportFormat } from './settings';
-import { SupernoteX, ILink, fetchMirrorFrame, createPdfContext, addPdfPage } from 'supernote-typescript';
+import { SupernoteX, ILink, fetchMirrorFrame, createPdfContext, addPdfPage, addTextOnlyPdfPage } from 'supernote-typescript';
 import { encode } from 'image-js';
 import { DownloadListModal, UploadListModal } from './FileListModal';
 import { ImportTodayModal } from './ImportTodayModal';
@@ -76,6 +76,24 @@ async function assemblePdfFromImages(sn: SupernoteX, images: string[]): Promise<
     for (let i = 0; i < sn.pages.length; i++) {
         const pngBytes = new Uint8Array(dataUrlToBuffer(images[i]));
         await addPdfPage(ctx, sn.pages[i], pngBytes);
+    }
+    return ctx.pdfDoc.save();
+}
+
+// Builds a PDF with only the invisible recognized-text layer, no page images
+// at all — for SupernoteView's internal pdfDocPromise, which exists purely
+// so pdf.js's getTextContent()/getViewport() can build a search/select text
+// layer over pages that are actually displayed via direct canvas rendering
+// (drawPageImage()); pdf.js's own render() is never called against it. A
+// real page image there would be pure dead weight: embedding one only for
+// pdf-lib to decode, recompress, and serialize turned out to be genuinely
+// expensive (multiple seconds for a many-page or high-resolution note) for
+// bytes nothing ever looks at. Don't use this for anything the user actually
+// opens/exports as a PDF — see assemblePdfFromImages() for that.
+async function assembleTextOnlyPdf(sn: SupernoteX): Promise<Uint8Array> {
+    const ctx = await createPdfContext();
+    for (let i = 0; i < sn.pages.length; i++) {
+        await addTextOnlyPdfPage(ctx, sn.pages[i], sn.pageWidth, sn.pageHeight);
     }
     return ctx.pdfDoc.save();
 }
@@ -774,27 +792,6 @@ export class SupernoteView extends FileView {
 		const linksByPage = bucketLinksByPage(sn.links);
 		const images = await new ImageConverter(rasterCache).convertToImages(sn, rawBytes);
 
-		// Kicked off now but not awaited: pages are visible immediately from
-		// their own rasterized image (drawPageImage(), no pdf.js involved at
-		// all), so there's no reason to block the first paint on assembling a
-		// PDF and loading it into pdf.js. Only the text layer (selection/
-		// search) needs this, lazily, per page — see ensureTextLayer().
-		//
-		// Not awaited, but still runs on this same main thread concurrently
-		// with the page-render loop below — timed here to check whether it's
-		// actually competing for CPU with that loop (both are single-threaded
-		// JS work) rather than being "free" background work.
-		const pdfPipelineStart = performance.now();
-		this.pdfDocPromise = (async () => {
-			const pdfBytes = await assemblePdfFromImages(sn, images);
-			const afterAssemble = performance.now();
-			this.pdfjsLib = await loadPdfJs() as PdfJsLib;
-			const afterLoadPdfJs = performance.now();
-			const doc = await this.pdfjsLib.getDocument({ data: pdfBytes }).promise;
-			console.debug(`Supernote: background PDF pipeline — assemble ${(afterAssemble - pdfPipelineStart).toFixed(1)}ms, loadPdfJs ${(afterLoadPdfJs - afterAssemble).toFixed(1)}ms, getDocument ${(performance.now() - afterLoadPdfJs).toFixed(1)}ms`);
-			return doc;
-		})();
-
 		if (this.settings.showExportButtons) {
 			const exportNoteBtn = container.createEl("p").createEl("button", {
 				text: "Attach Markdown to vault",
@@ -945,6 +942,28 @@ export class SupernoteView extends FileView {
 			this.applyFitWidth();
 		}
 		this.updateCurrentPageIndicator();
+
+		// Kicked off now — after pages are already visible from their own
+		// rasterized images (drawPageImage() above, no pdf.js involved at
+		// all) — rather than before rendering them, so this fire-and-forget
+		// pipeline (still real work on this same single JS thread) can't
+		// compete with/inflate the apparent cost of the page-render loop.
+		// Only the text layer (selection/search) needs this, lazily, per
+		// page — see ensureTextLayer() — so delaying it only delays search
+		// readiness, not anything visible. Uses assembleTextOnlyPdf() (no
+		// page images at all — see its doc comment) rather than
+		// assemblePdfFromImages(), since this PDF is only ever handed to
+		// pdf.js for getTextContent()/getViewport(), never rendered/shown.
+		const pdfPipelineStart = performance.now();
+		this.pdfDocPromise = (async () => {
+			const pdfBytes = await assembleTextOnlyPdf(sn);
+			const afterAssemble = performance.now();
+			this.pdfjsLib = await loadPdfJs() as PdfJsLib;
+			const afterLoadPdfJs = performance.now();
+			const doc = await this.pdfjsLib.getDocument({ data: pdfBytes }).promise;
+			console.debug(`Supernote: background PDF pipeline — assemble ${(afterAssemble - pdfPipelineStart).toFixed(1)}ms, loadPdfJs ${(afterLoadPdfJs - afterAssemble).toFixed(1)}ms, getDocument ${(performance.now() - afterLoadPdfJs).toFixed(1)}ms`);
+			return doc;
+		})();
 	}
 
 	// Draws the page's own already-decoded bitmap at the given scale — no

--- a/src/main.ts
+++ b/src/main.ts
@@ -779,10 +779,20 @@ export class SupernoteView extends FileView {
 		// all), so there's no reason to block the first paint on assembling a
 		// PDF and loading it into pdf.js. Only the text layer (selection/
 		// search) needs this, lazily, per page — see ensureTextLayer().
+		//
+		// Not awaited, but still runs on this same main thread concurrently
+		// with the page-render loop below — timed here to check whether it's
+		// actually competing for CPU with that loop (both are single-threaded
+		// JS work) rather than being "free" background work.
+		const pdfPipelineStart = performance.now();
 		this.pdfDocPromise = (async () => {
 			const pdfBytes = await assemblePdfFromImages(sn, images);
+			const afterAssemble = performance.now();
 			this.pdfjsLib = await loadPdfJs() as PdfJsLib;
-			return this.pdfjsLib.getDocument({ data: pdfBytes }).promise;
+			const afterLoadPdfJs = performance.now();
+			const doc = await this.pdfjsLib.getDocument({ data: pdfBytes }).promise;
+			console.debug(`Supernote: background PDF pipeline — assemble ${(afterAssemble - pdfPipelineStart).toFixed(1)}ms, loadPdfJs ${(afterLoadPdfJs - afterAssemble).toFixed(1)}ms, getDocument ${(performance.now() - afterLoadPdfJs).toFixed(1)}ms`);
+			return doc;
 		})();
 
 		if (this.settings.showExportButtons) {
@@ -843,6 +853,7 @@ export class SupernoteView extends FileView {
 			const blob = new Blob([dataUrlToBuffer(imageDataUrl)], { type: 'image/png' });
 			return createImageBitmap(blob);
 		}));
+		const decodeEnd = performance.now();
 
 		for (let i = 0; i < images.length; i++) {
 			const imageDataUrl = images[i];
@@ -928,7 +939,7 @@ export class SupernoteView extends FileView {
 			}
 		}
 
-		console.debug(`Supernote: page render (bitmap decode + DOM) — ${images.length} page(s) in ${(performance.now() - renderStart).toFixed(1)}ms`);
+		console.debug(`Supernote: page render — decode ${(decodeEnd - renderStart).toFixed(1)}ms, DOM build ${(performance.now() - decodeEnd).toFixed(1)}ms, total ${(performance.now() - renderStart).toFixed(1)}ms for ${images.length} page(s)`);
 
 		if (this.fitWidthEnabled) {
 			this.applyFitWidth();

--- a/src/rasterCache.test.ts
+++ b/src/rasterCache.test.ts
@@ -60,7 +60,7 @@ describe('RasterCache', () => {
         expect(cache.totalCachedBytes).toBe(8);
     });
 
-    it('evicts the oldest-inserted entry once over budget', async () => {
+    it('evicts the least-recently-used entry once over budget (no reads yet == oldest-inserted)', async () => {
         const cache = await RasterCache.open(makeStorage(), 'cache', 10);
         await cache.put('hash', 1, dataUrlOf([0, 0, 0, 0])); // 4 bytes, total 4
         await cache.put('hash', 2, dataUrlOf([0, 0, 0, 0])); // total 8
@@ -72,16 +72,16 @@ describe('RasterCache', () => {
         expect(cache.totalCachedBytes).toBeLessThanOrEqual(10);
     });
 
-    it('re-fetching a page via get() does not protect it from FIFO eviction', async () => {
+    it('re-fetching a page via get() protects it from eviction (LRU, not FIFO)', async () => {
         const cache = await RasterCache.open(makeStorage(), 'cache', 10);
         await cache.put('hash', 1, dataUrlOf([0, 0, 0, 0]));
         await cache.put('hash', 2, dataUrlOf([0, 0, 0, 0]));
-        // Re-access page 1 — a true LRU would now evict page 2 instead.
-        await cache.get('hash', 1);
-        await cache.put('hash', 3, dataUrlOf([0, 0, 0, 0])); // total 12 > 10
+        // Re-access page 1 — this should now make page 2 the least-recently-used.
+        expect(await cache.get('hash', 1)).not.toBeNull();
+        await cache.put('hash', 3, dataUrlOf([0, 0, 0, 0])); // total 12 > 10 -> evict page 2
 
-        expect(await cache.get('hash', 1)).toBeNull();
-        expect(await cache.get('hash', 2)).not.toBeNull();
+        expect(await cache.get('hash', 2)).toBeNull();
+        expect(cache.entryCount).toBe(2);
     });
 
     it('persists the index across separate RasterCache.open() calls on the same storage', async () => {
@@ -114,6 +114,7 @@ describe('RasterCache', () => {
 
         expect(await cache.get('hash', 1)).toBeNull();
         expect(cache.entryCount).toBe(0);
+        expect(cache.totalCachedBytes).toBe(0);
     });
 
     it('starts empty if the persisted index is corrupted', async () => {

--- a/src/rasterCache.test.ts
+++ b/src/rasterCache.test.ts
@@ -61,7 +61,9 @@ describe('RasterCache', () => {
     });
 
     it('evicts the least-recently-used entry once over budget (no reads yet == oldest-inserted)', async () => {
-        const cache = await RasterCache.open(makeStorage(), 'cache', 10);
+        // maxMemoryBytes: 0 disables the in-memory tier so this test exercises
+        // disk-tier eviction only — see the "memory tier" tests below for that.
+        const cache = await RasterCache.open(makeStorage(), 'cache', 10, 0);
         await cache.put('hash', 1, dataUrlOf([0, 0, 0, 0])); // 4 bytes, total 4
         await cache.put('hash', 2, dataUrlOf([0, 0, 0, 0])); // total 8
         await cache.put('hash', 3, dataUrlOf([0, 0, 0, 0])); // total 12 > 10 -> evict page 1
@@ -73,7 +75,7 @@ describe('RasterCache', () => {
     });
 
     it('re-fetching a page via get() protects it from eviction (LRU, not FIFO)', async () => {
-        const cache = await RasterCache.open(makeStorage(), 'cache', 10);
+        const cache = await RasterCache.open(makeStorage(), 'cache', 10, 0);
         await cache.put('hash', 1, dataUrlOf([0, 0, 0, 0]));
         await cache.put('hash', 2, dataUrlOf([0, 0, 0, 0]));
         // Re-access page 1 — this should now make page 2 the least-recently-used.
@@ -107,7 +109,7 @@ describe('RasterCache', () => {
 
     it('fails open (and self-heals the index) when a cached blob goes missing out-of-band', async () => {
         const storage = makeStorage();
-        const cache = await RasterCache.open(storage, 'cache');
+        const cache = await RasterCache.open(storage, 'cache', undefined, 0);
         await cache.put('hash', 1, dataUrlOf([1, 2]));
 
         await storage.remove('cache/hash-1.png');
@@ -127,7 +129,7 @@ describe('RasterCache', () => {
         expect(await cache.get('hash', 1)).toBeNull();
     });
 
-    it('clear() empties the cache and removes blobs from storage', async () => {
+    it('clear() empties the cache (both tiers) and removes blobs from storage', async () => {
         const storage = makeStorage();
         const cache = await RasterCache.open(storage, 'cache');
         await cache.put('hash', 1, dataUrlOf([1]));
@@ -137,9 +139,38 @@ describe('RasterCache', () => {
 
         expect(cache.entryCount).toBe(0);
         expect(cache.totalCachedBytes).toBe(0);
+        expect(cache.memoryEntryCount).toBe(0);
+        expect(cache.memoryCachedBytes).toBe(0);
         expect(await cache.get('hash', 1)).toBeNull();
         expect(storage.files.has('cache/hash-1.png')).toBe(false);
         expect(storage.files.has('cache/hash-2.png')).toBe(false);
+    });
+
+    it('memory tier avoids re-reading disk on repeated gets', async () => {
+        const storage = makeStorage();
+        const cache1 = await RasterCache.open(storage, 'cache');
+        await cache1.put('hash', 1, dataUrlOf([1, 2, 3]));
+
+        // Fresh instance sharing the same storage — its own memory tier
+        // starts empty even though the disk index already has the entry.
+        const cache2 = await RasterCache.open(storage, 'cache');
+        const readSpy = vi.spyOn(storage, 'readBinary');
+
+        expect(await cache2.get('hash', 1)).toBe(dataUrlOf([1, 2, 3])); // disk hit, populates memory tier
+        expect(await cache2.get('hash', 1)).toBe(dataUrlOf([1, 2, 3])); // served from memory tier
+        expect(readSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('memory tier evicts on its own, independent (smaller) budget', async () => {
+        // Disk budget generous (1000 bytes); memory budget tiny (8 bytes).
+        const cache = await RasterCache.open(makeStorage(), 'cache', 1000, 8);
+        await cache.put('hash', 1, dataUrlOf([0, 0, 0, 0])); // 4 bytes
+        await cache.put('hash', 2, dataUrlOf([0, 0, 0, 0])); // memory total 8
+        await cache.put('hash', 3, dataUrlOf([0, 0, 0, 0])); // memory total 12 > 8 -> evict page 1 from memory only
+
+        expect(cache.entryCount).toBe(3); // disk tier unaffected, well under its own budget
+        expect(cache.memoryCachedBytes).toBeLessThanOrEqual(8);
+        expect(cache.memoryEntryCount).toBeLessThanOrEqual(2);
     });
 
     it('re-exports hashBytes as a deterministic content hash', () => {

--- a/src/rasterCache.test.ts
+++ b/src/rasterCache.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RasterCache, hashBytes, CacheStorage } from './rasterCache';
+
+function makeStorage(): CacheStorage & { files: Map<string, ArrayBuffer> } {
+    const files = new Map<string, ArrayBuffer>();
+    const dirs = new Set<string>();
+    return {
+        files,
+        async exists(path: string) {
+            return files.has(path) || dirs.has(path);
+        },
+        async mkdir(path: string) {
+            dirs.add(path);
+        },
+        async readBinary(path: string) {
+            const buf = files.get(path);
+            if (!buf) throw new Error(`not found: ${path}`);
+            return buf;
+        },
+        async writeBinary(path: string, data: ArrayBuffer) {
+            files.set(path, data);
+        },
+        async remove(path: string) {
+            if (!files.delete(path)) throw new Error(`not found: ${path}`);
+        },
+    };
+}
+
+function dataUrlOf(byteValues: number[]): string {
+    let binary = '';
+    for (const b of byteValues) binary += String.fromCharCode(b);
+    return `data:image/png;base64,${btoa(binary)}`;
+}
+
+describe('RasterCache', () => {
+    it('misses on an empty cache', async () => {
+        const cache = await RasterCache.open(makeStorage(), 'cache');
+        expect(await cache.get('hash1', 1)).toBeNull();
+    });
+
+    it('round-trips a put through get', async () => {
+        const cache = await RasterCache.open(makeStorage(), 'cache');
+        const dataUrl = dataUrlOf([1, 2, 3, 4, 5]);
+        await cache.put('hash1', 1, dataUrl);
+        expect(await cache.get('hash1', 1)).toBe(dataUrl);
+    });
+
+    it('keys are independent per note hash and per page number', async () => {
+        const cache = await RasterCache.open(makeStorage(), 'cache');
+        await cache.put('hashA', 1, dataUrlOf([1]));
+        expect(await cache.get('hashA', 2)).toBeNull();
+        expect(await cache.get('hashB', 1)).toBeNull();
+    });
+
+    it('tracks total size and entry count', async () => {
+        const cache = await RasterCache.open(makeStorage(), 'cache');
+        await cache.put('hashA', 1, dataUrlOf([1, 2, 3]));
+        await cache.put('hashA', 2, dataUrlOf([1, 2, 3, 4, 5]));
+        expect(cache.entryCount).toBe(2);
+        expect(cache.totalCachedBytes).toBe(8);
+    });
+
+    it('evicts the oldest-inserted entry once over budget', async () => {
+        const cache = await RasterCache.open(makeStorage(), 'cache', 10);
+        await cache.put('hash', 1, dataUrlOf([0, 0, 0, 0])); // 4 bytes, total 4
+        await cache.put('hash', 2, dataUrlOf([0, 0, 0, 0])); // total 8
+        await cache.put('hash', 3, dataUrlOf([0, 0, 0, 0])); // total 12 > 10 -> evict page 1
+
+        expect(await cache.get('hash', 1)).toBeNull();
+        expect(await cache.get('hash', 2)).not.toBeNull();
+        expect(await cache.get('hash', 3)).not.toBeNull();
+        expect(cache.totalCachedBytes).toBeLessThanOrEqual(10);
+    });
+
+    it('re-fetching a page via get() does not protect it from FIFO eviction', async () => {
+        const cache = await RasterCache.open(makeStorage(), 'cache', 10);
+        await cache.put('hash', 1, dataUrlOf([0, 0, 0, 0]));
+        await cache.put('hash', 2, dataUrlOf([0, 0, 0, 0]));
+        // Re-access page 1 — a true LRU would now evict page 2 instead.
+        await cache.get('hash', 1);
+        await cache.put('hash', 3, dataUrlOf([0, 0, 0, 0])); // total 12 > 10
+
+        expect(await cache.get('hash', 1)).toBeNull();
+        expect(await cache.get('hash', 2)).not.toBeNull();
+    });
+
+    it('persists the index across separate RasterCache.open() calls on the same storage', async () => {
+        const storage = makeStorage();
+        const cache1 = await RasterCache.open(storage, 'cache');
+        await cache1.put('hash', 1, dataUrlOf([9, 9, 9]));
+
+        const cache2 = await RasterCache.open(storage, 'cache');
+        expect(cache2.entryCount).toBe(1);
+        expect(cache2.totalCachedBytes).toBe(3);
+        expect(await cache2.get('hash', 1)).toBe(dataUrlOf([9, 9, 9]));
+    });
+
+    it('fails open when writing a cache entry throws', async () => {
+        const storage = makeStorage();
+        const cache = await RasterCache.open(storage, 'cache');
+        vi.spyOn(storage, 'writeBinary').mockRejectedValueOnce(new Error('disk full'));
+
+        await expect(cache.put('hash', 1, dataUrlOf([1]))).resolves.toBeUndefined();
+        expect(await cache.get('hash', 1)).toBeNull();
+        expect(cache.entryCount).toBe(0);
+    });
+
+    it('fails open (and self-heals the index) when a cached blob goes missing out-of-band', async () => {
+        const storage = makeStorage();
+        const cache = await RasterCache.open(storage, 'cache');
+        await cache.put('hash', 1, dataUrlOf([1, 2]));
+
+        await storage.remove('cache/hash-1.png');
+
+        expect(await cache.get('hash', 1)).toBeNull();
+        expect(cache.entryCount).toBe(0);
+    });
+
+    it('starts empty if the persisted index is corrupted', async () => {
+        const storage = makeStorage();
+        await storage.mkdir('cache');
+        await storage.writeBinary('cache/index.json', new TextEncoder().encode('{not json').buffer);
+
+        const cache = await RasterCache.open(storage, 'cache');
+        expect(cache.entryCount).toBe(0);
+        expect(await cache.get('hash', 1)).toBeNull();
+    });
+
+    it('clear() empties the cache and removes blobs from storage', async () => {
+        const storage = makeStorage();
+        const cache = await RasterCache.open(storage, 'cache');
+        await cache.put('hash', 1, dataUrlOf([1]));
+        await cache.put('hash', 2, dataUrlOf([2]));
+
+        await cache.clear();
+
+        expect(cache.entryCount).toBe(0);
+        expect(cache.totalCachedBytes).toBe(0);
+        expect(await cache.get('hash', 1)).toBeNull();
+        expect(storage.files.has('cache/hash-1.png')).toBe(false);
+        expect(storage.files.has('cache/hash-2.png')).toBe(false);
+    });
+
+    it('re-exports hashBytes as a deterministic content hash', () => {
+        const a = hashBytes(new Uint8Array([1, 2, 3]));
+        const b = hashBytes(new Uint8Array([1, 2, 3]));
+        const c = hashBytes(new Uint8Array([1, 2, 4]));
+        expect(a).toBe(b);
+        expect(a).not.toBe(c);
+    });
+});

--- a/src/rasterCache.ts
+++ b/src/rasterCache.ts
@@ -14,6 +14,10 @@ import { hashBytes } from './deviceSync';
 export { hashBytes };
 
 export const DEFAULT_MAX_CACHE_BYTES = 100 * 1024 * 1024;
+// Separate, smaller budget for the in-memory tier (see class comment) — kept
+// modest since it's on top of whatever else Obsidian and this note's own
+// decoded ImageBitmaps are already holding in memory, especially on mobile.
+export const DEFAULT_MAX_MEMORY_CACHE_BYTES = 20 * 1024 * 1024;
 
 export interface CacheStorage {
     exists(path: string): Promise<boolean>;
@@ -50,21 +54,28 @@ function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
     return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
 }
 
-// A size-bounded, disk-backed cache of rasterized page PNGs.
+// A size-bounded, disk-backed cache of rasterized page PNGs, with a smaller
+// in-memory tier in front of it.
 //
-// Eviction is LRU: `entries` is a Map, whose iteration order is insertion
-// order, and every cache hit in get() deletes + re-inserts its key to move it
-// to the most-recently-used end. Eviction then just removes from the front —
-// the actual least-recently-used entry, whether that's "oldest inserted" (an
-// entry never re-read) or "longest since last read" (one that has been).
+// Eviction is LRU on both tiers: `entries` (disk) and `memoryCache` (memory)
+// are each a Map, whose iteration order is insertion order, and every cache
+// hit deletes + re-inserts its key to move it to the most-recently-used end.
+// Eviction then just removes from the front — the actual least-recently-used
+// entry, whether that's "oldest inserted" (an entry never re-read) or
+// "longest since last read" (one that has been).
 //
-// That reordering is kept in memory only — get() does not persist the index
-// on a hit, only put()/clear() do. A cache *read* triggering a disk write
-// would undercut the point of caching; the cost is that recency ordering
-// accumulated since the last write is lost if the plugin reloads or Obsidian
-// restarts before another put()/clear() happens to flush it, so eviction
-// order right after a reload reflects whatever was last persisted rather
-// than genuinely-most-recent reads.
+// The disk tier's reordering is kept in memory only — get() does not persist
+// the *disk* index on a hit, only put()/clear() do. A cache *read* triggering
+// a disk write would undercut the point of caching; the cost is that
+// recency ordering accumulated since the last write is lost if the plugin
+// reloads or Obsidian restarts before another put()/clear() happens to flush
+// it, so eviction order right after a reload reflects whatever was last
+// persisted rather than genuinely-most-recent reads.
+//
+// The memory tier exists purely to skip the disk tier's vault.adapter
+// read + base64 decode for pages already served earlier this session (e.g.
+// closing a note and reopening it) — it is never persisted at all, and is
+// empty again after every plugin reload/Obsidian restart.
 //
 // Every storage operation is fail-open: a read/write/parse error is logged
 // and treated as a cache miss (get) or a no-op (put/evict), never thrown, so
@@ -73,6 +84,8 @@ function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
 export class RasterCache {
     private entries = new Map<string, number>();
     private totalBytes = 0;
+    private memoryCache = new Map<string, { dataUrl: string; size: number }>();
+    private memoryBytes = 0;
     private dirEnsured = false;
     private persistQueue: Promise<void> = Promise.resolve();
     private readonly indexPath: string;
@@ -81,12 +94,18 @@ export class RasterCache {
         private readonly storage: CacheStorage,
         private readonly dir: string,
         private readonly maxBytes: number,
+        private readonly maxMemoryBytes: number,
     ) {
         this.indexPath = `${dir}/index.json`;
     }
 
-    static async open(storage: CacheStorage, dir: string, maxBytes: number = DEFAULT_MAX_CACHE_BYTES): Promise<RasterCache> {
-        const cache = new RasterCache(storage, dir, maxBytes);
+    static async open(
+        storage: CacheStorage,
+        dir: string,
+        maxBytes: number = DEFAULT_MAX_CACHE_BYTES,
+        maxMemoryBytes: number = DEFAULT_MAX_MEMORY_CACHE_BYTES,
+    ): Promise<RasterCache> {
+        const cache = new RasterCache(storage, dir, maxBytes, maxMemoryBytes);
         await cache.loadIndex();
         return cache;
     }
@@ -99,8 +118,25 @@ export class RasterCache {
         return this.entries.size;
     }
 
+    get memoryCachedBytes(): number {
+        return this.memoryBytes;
+    }
+
+    get memoryEntryCount(): number {
+        return this.memoryCache.size;
+    }
+
     async get(noteHash: string, pageNumber: number): Promise<string | null> {
         const key = this.key(noteHash, pageNumber);
+
+        const memoized = this.memoryCache.get(key);
+        if (memoized !== undefined) {
+            // Touch this tier's own LRU order too.
+            this.memoryCache.delete(key);
+            this.memoryCache.set(key, memoized);
+            return memoized.dataUrl;
+        }
+
         const size = this.entries.get(key);
         if (size === undefined) return null;
         try {
@@ -109,7 +145,9 @@ export class RasterCache {
             // in memory, not persisted until the next put()/clear().
             this.entries.delete(key);
             this.entries.set(key, size);
-            return bytesToDataUrl(new Uint8Array(buf));
+            const dataUrl = bytesToDataUrl(new Uint8Array(buf));
+            this.rememberInMemory(key, dataUrl, size);
+            return dataUrl;
         } catch {
             // Indexed but unreadable (deleted out-of-band, corrupted, etc.) —
             // drop the stale entry and report a miss rather than throwing.
@@ -134,6 +172,7 @@ export class RasterCache {
 
         this.entries.set(key, bytes.byteLength);
         this.totalBytes += bytes.byteLength;
+        this.rememberInMemory(key, dataUrl, bytes.byteLength);
         await this.evictIfNeeded();
         await this.persist();
     }
@@ -145,6 +184,8 @@ export class RasterCache {
         const keys = Array.from(this.entries.keys());
         this.entries.clear();
         this.totalBytes = 0;
+        this.memoryCache.clear();
+        this.memoryBytes = 0;
         for (const key of keys) {
             try {
                 await this.storage.remove(this.pagePath(key));
@@ -157,6 +198,29 @@ export class RasterCache {
 
     private key(noteHash: string, pageNumber: number): string {
         return `${noteHash}-${pageNumber}`;
+    }
+
+    // Inserts/refreshes an entry in the memory tier and evicts
+    // least-recently-used entries from *that tier only* until back under its
+    // (independent, smaller) budget. Never touches disk.
+    private rememberInMemory(key: string, dataUrl: string, size: number): void {
+        const existing = this.memoryCache.get(key);
+        if (existing) {
+            this.memoryCache.delete(key);
+            this.memoryBytes -= existing.size;
+        }
+        this.memoryCache.set(key, { dataUrl, size });
+        this.memoryBytes += size;
+
+        const toEvict: string[] = [];
+        for (const [oldestKey, oldest] of this.memoryCache) {
+            if (this.memoryBytes <= this.maxMemoryBytes) break;
+            toEvict.push(oldestKey);
+            this.memoryBytes -= oldest.size;
+        }
+        for (const oldestKey of toEvict) {
+            this.memoryCache.delete(oldestKey);
+        }
     }
 
     private pagePath(key: string): string {

--- a/src/rasterCache.ts
+++ b/src/rasterCache.ts
@@ -1,0 +1,220 @@
+// Persistent, content-addressable cache of rasterized Supernote page images.
+// Keyed by (whole-note content hash, page number), so editing a page anywhere
+// in a note only misses on that note's own pages, not other notes' — and the
+// exact same .note bytes (e.g. re-opening an unedited file) always hit,
+// regardless of vault path or how the page was reached (view vs. embed vs.
+// export).
+//
+// Storage is a minimal structural interface (CacheStorage) rather than
+// Obsidian's DataAdapter type directly, so this module has no dependency on
+// the `obsidian` package and can be unit-tested with a plain mock. Obsidian's
+// real `app.vault.adapter` satisfies it as-is (duck typing).
+import { hashBytes } from './deviceSync';
+
+export { hashBytes };
+
+export const DEFAULT_MAX_CACHE_BYTES = 100 * 1024 * 1024;
+
+export interface CacheStorage {
+    exists(path: string): Promise<boolean>;
+    mkdir(path: string): Promise<void>;
+    readBinary(path: string): Promise<ArrayBuffer>;
+    writeBinary(path: string, data: ArrayBuffer): Promise<void>;
+    remove(path: string): Promise<void>;
+}
+
+interface CacheIndexEntry {
+    key: string;
+    size: number;
+}
+
+function dataUrlToBytes(dataUrl: string): Uint8Array {
+    const base64 = dataUrl.slice(dataUrl.indexOf(',') + 1);
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+}
+
+function bytesToDataUrl(bytes: Uint8Array, mimeType = 'image/png'): string {
+    let binary = '';
+    for (let i = 0; i < bytes.length; i++) {
+        binary += String.fromCharCode(bytes[i]);
+    }
+    return `data:${mimeType};base64,${btoa(binary)}`;
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+// A size-bounded, disk-backed cache of rasterized page PNGs.
+//
+// Eviction is plain FIFO by insertion order (the oldest-added entry goes
+// first when the budget is exceeded), not LRU — re-fetching a cached page
+// via get() does not move it to the back of the queue. This matches the
+// simplest reading of "eject the oldest notes from the cache" and avoids
+// having to persist last-access times (which the storage layer, an Obsidian
+// vault adapter, doesn't reliably track across desktop/mobile anyway).
+//
+// Every storage operation is fail-open: a read/write/parse error is logged
+// and treated as a cache miss (get) or a no-op (put/evict), never thrown, so
+// a broken or unavailable cache degrades to "always re-rasterize" rather
+// than breaking the plugin's actual job of rendering notes.
+export class RasterCache {
+    private entries = new Map<string, number>();
+    private totalBytes = 0;
+    private dirEnsured = false;
+    private persistQueue: Promise<void> = Promise.resolve();
+    private readonly indexPath: string;
+
+    private constructor(
+        private readonly storage: CacheStorage,
+        private readonly dir: string,
+        private readonly maxBytes: number,
+    ) {
+        this.indexPath = `${dir}/index.json`;
+    }
+
+    static async open(storage: CacheStorage, dir: string, maxBytes: number = DEFAULT_MAX_CACHE_BYTES): Promise<RasterCache> {
+        const cache = new RasterCache(storage, dir, maxBytes);
+        await cache.loadIndex();
+        return cache;
+    }
+
+    get totalCachedBytes(): number {
+        return this.totalBytes;
+    }
+
+    get entryCount(): number {
+        return this.entries.size;
+    }
+
+    async get(noteHash: string, pageNumber: number): Promise<string | null> {
+        const key = this.key(noteHash, pageNumber);
+        if (!this.entries.has(key)) return null;
+        try {
+            const buf = await this.storage.readBinary(this.pagePath(key));
+            return bytesToDataUrl(new Uint8Array(buf));
+        } catch {
+            // Indexed but unreadable (deleted out-of-band, corrupted, etc.) —
+            // drop the stale entry and report a miss rather than throwing.
+            this.entries.delete(key);
+            return null;
+        }
+    }
+
+    async put(noteHash: string, pageNumber: number, dataUrl: string): Promise<void> {
+        const key = this.key(noteHash, pageNumber);
+        if (this.entries.has(key)) return; // already cached under this content-addressed key
+
+        const bytes = dataUrlToBytes(dataUrl);
+        try {
+            await this.ensureDir();
+            await this.storage.writeBinary(this.pagePath(key), toArrayBuffer(bytes));
+        } catch (err) {
+            console.error('Supernote rasterCache: failed to write cache entry, skipping', err);
+            return;
+        }
+
+        this.entries.set(key, bytes.byteLength);
+        this.totalBytes += bytes.byteLength;
+        await this.evictIfNeeded();
+        await this.persist();
+    }
+
+    // Empties the cache (used by the "clear rasterization cache" command /
+    // settings button). Best-effort: failures removing individual blobs are
+    // swallowed since the index is cleared either way.
+    async clear(): Promise<void> {
+        const keys = Array.from(this.entries.keys());
+        this.entries.clear();
+        this.totalBytes = 0;
+        for (const key of keys) {
+            try {
+                await this.storage.remove(this.pagePath(key));
+            } catch {
+                // best-effort
+            }
+        }
+        await this.persist();
+    }
+
+    private key(noteHash: string, pageNumber: number): string {
+        return `${noteHash}-${pageNumber}`;
+    }
+
+    private pagePath(key: string): string {
+        return `${this.dir}/${key}.png`;
+    }
+
+    private async loadIndex(): Promise<void> {
+        try {
+            if (!(await this.storage.exists(this.indexPath))) return;
+            const buf = await this.storage.readBinary(this.indexPath);
+            const parsed = JSON.parse(new TextDecoder().decode(buf)) as { entries?: CacheIndexEntry[] };
+            for (const entry of parsed.entries ?? []) {
+                this.entries.set(entry.key, entry.size);
+                this.totalBytes += entry.size;
+            }
+        } catch (err) {
+            console.error('Supernote rasterCache: failed to load cache index, starting empty', err);
+            this.entries.clear();
+            this.totalBytes = 0;
+        }
+    }
+
+    // Evicts oldest-inserted entries (Map iteration order == insertion order)
+    // until back under budget. A single entry larger than the whole budget is
+    // left in place once everything else has been evicted — this is a
+    // best-effort cap, not a hard invariant.
+    private async evictIfNeeded(): Promise<void> {
+        const toRemove: string[] = [];
+        for (const [key, size] of this.entries) {
+            if (this.totalBytes <= this.maxBytes) break;
+            toRemove.push(key);
+            this.totalBytes -= size;
+        }
+        for (const key of toRemove) {
+            this.entries.delete(key);
+            try {
+                await this.storage.remove(this.pagePath(key));
+            } catch {
+                // best-effort
+            }
+        }
+    }
+
+    // Persists the index after every mutation, chained onto a single queue so
+    // concurrent put()/clear() calls' writes serialize instead of racing to
+    // overwrite index.json with a stale snapshot.
+    private persist(): Promise<void> {
+        this.persistQueue = this.persistQueue.then(() => this.writeIndex());
+        return this.persistQueue;
+    }
+
+    private async writeIndex(): Promise<void> {
+        const entries: CacheIndexEntry[] = Array.from(this.entries, ([key, size]) => ({ key, size }));
+        const json = JSON.stringify({ entries });
+        try {
+            await this.ensureDir();
+            await this.storage.writeBinary(this.indexPath, toArrayBuffer(new TextEncoder().encode(json)));
+        } catch (err) {
+            console.error('Supernote rasterCache: failed to persist cache index', err);
+        }
+    }
+
+    private async ensureDir(): Promise<void> {
+        if (this.dirEnsured) return;
+        try {
+            if (!(await this.storage.exists(this.dir))) {
+                await this.storage.mkdir(this.dir);
+            }
+        } catch {
+            // ignore races against another mkdir/existing dir
+        }
+        this.dirEnsured = true;
+    }
+}

--- a/src/rasterCache.ts
+++ b/src/rasterCache.ts
@@ -52,12 +52,19 @@ function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
 
 // A size-bounded, disk-backed cache of rasterized page PNGs.
 //
-// Eviction is plain FIFO by insertion order (the oldest-added entry goes
-// first when the budget is exceeded), not LRU — re-fetching a cached page
-// via get() does not move it to the back of the queue. This matches the
-// simplest reading of "eject the oldest notes from the cache" and avoids
-// having to persist last-access times (which the storage layer, an Obsidian
-// vault adapter, doesn't reliably track across desktop/mobile anyway).
+// Eviction is LRU: `entries` is a Map, whose iteration order is insertion
+// order, and every cache hit in get() deletes + re-inserts its key to move it
+// to the most-recently-used end. Eviction then just removes from the front —
+// the actual least-recently-used entry, whether that's "oldest inserted" (an
+// entry never re-read) or "longest since last read" (one that has been).
+//
+// That reordering is kept in memory only — get() does not persist the index
+// on a hit, only put()/clear() do. A cache *read* triggering a disk write
+// would undercut the point of caching; the cost is that recency ordering
+// accumulated since the last write is lost if the plugin reloads or Obsidian
+// restarts before another put()/clear() happens to flush it, so eviction
+// order right after a reload reflects whatever was last persisted rather
+// than genuinely-most-recent reads.
 //
 // Every storage operation is fail-open: a read/write/parse error is logged
 // and treated as a cache miss (get) or a no-op (put/evict), never thrown, so
@@ -94,14 +101,20 @@ export class RasterCache {
 
     async get(noteHash: string, pageNumber: number): Promise<string | null> {
         const key = this.key(noteHash, pageNumber);
-        if (!this.entries.has(key)) return null;
+        const size = this.entries.get(key);
+        if (size === undefined) return null;
         try {
             const buf = await this.storage.readBinary(this.pagePath(key));
+            // Move to the most-recently-used end (see class comment) — only
+            // in memory, not persisted until the next put()/clear().
+            this.entries.delete(key);
+            this.entries.set(key, size);
             return bytesToDataUrl(new Uint8Array(buf));
         } catch {
             // Indexed but unreadable (deleted out-of-band, corrupted, etc.) —
             // drop the stale entry and report a miss rather than throwing.
             this.entries.delete(key);
+            this.totalBytes -= size;
             return null;
         }
     }
@@ -166,10 +179,10 @@ export class RasterCache {
         }
     }
 
-    // Evicts oldest-inserted entries (Map iteration order == insertion order)
-    // until back under budget. A single entry larger than the whole budget is
-    // left in place once everything else has been evicted — this is a
-    // best-effort cap, not a hard invariant.
+    // Evicts least-recently-used entries (Map iteration order == recency
+    // order, see class comment) until back under budget. A single entry
+    // larger than the whole budget is left in place once everything else has
+    // been evicted — this is a best-effort cap, not a hard invariant.
     private async evictIfNeeded(): Promise<void> {
         const toRemove: string[] = [];
         for (const [key, size] of this.entries) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -18,7 +18,7 @@ function applyRasterCacheSetting(setting: Setting, plugin: SupernotePlugin): voi
     const describe = () => {
         setting.setDesc(
             cache
-                ? `${cache.entryCount} cached page image(s) using ${formatCacheBytes(cache.totalCachedBytes)} of the ${formatCacheBytes(DEFAULT_MAX_CACHE_BYTES)} budget. Speeds up re-opening notes and embeds that have already been rasterized; oldest entries are evicted first once the budget is exceeded.`
+                ? `${cache.entryCount} cached page image(s) on disk using ${formatCacheBytes(cache.totalCachedBytes)} of the ${formatCacheBytes(DEFAULT_MAX_CACHE_BYTES)} budget (plus ${cache.memoryEntryCount} in memory this session). Speeds up re-opening notes and embeds that have already been rasterized; least-recently-used entries are evicted first once a budget is exceeded.`
                 : 'Unavailable in this vault (the plugin folder could not be determined).',
         );
     };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,6 +2,39 @@ import { createCustomDictionarySettingsUI, CUSTOM_DICTIONARY_DEFAULT_SETTINGS, C
 import SupernotePlugin from "./main";
 import { App, ExtraButtonComponent, Notice, PluginSettingTab, Setting } from 'obsidian';
 import { SyncManifest } from './deviceSync';
+import { DEFAULT_MAX_CACHE_BYTES } from './rasterCache';
+
+function formatCacheBytes(bytes: number): string {
+    const mb = bytes / (1024 * 1024);
+    return mb >= 1 ? `${mb.toFixed(1)} MB` : `${(bytes / 1024).toFixed(0)} KB`;
+}
+
+// Shared between getSettingDefinitions() and display() — both build (or are
+// handed) a Setting row named "Rasterization cache" and just need its desc
+// and clear-cache button filled in, same as the "Sync history" setting below.
+function applyRasterCacheSetting(setting: Setting, plugin: SupernotePlugin): void {
+    const cache = plugin.rasterCache;
+
+    const describe = () => {
+        setting.setDesc(
+            cache
+                ? `${cache.entryCount} cached page image(s) using ${formatCacheBytes(cache.totalCachedBytes)} of the ${formatCacheBytes(DEFAULT_MAX_CACHE_BYTES)} budget. Speeds up re-opening notes and embeds that have already been rasterized; oldest entries are evicted first once the budget is exceeded.`
+                : 'Unavailable in this vault (the plugin folder could not be determined).',
+        );
+    };
+    describe();
+
+    setting.addButton((btn) => {
+        btn.setButtonText('Clear cache')
+            .setDisabled(!cache)
+            .onClick(async () => {
+                if (!cache) return;
+                await cache.clear();
+                describe();
+                new Notice('Supernote rasterization cache cleared');
+            });
+    });
+}
 
 export const IP_VALIDATION_PATTERN = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/;
 
@@ -171,6 +204,12 @@ export class SupernoteSettingTab extends PluginSettingTab {
                 },
             },
             {
+                name: 'Rasterization cache',
+                render: (setting) => {
+                    applyRasterCacheSetting(setting, this.plugin);
+                },
+            },
+            {
                 name: 'Sync',
                 render: (setting) => {
                     setting.setHeading();
@@ -309,6 +348,8 @@ export class SupernoteSettingTab extends PluginSettingTab {
                     await this.plugin.saveSettings();
                 })
             );
+
+        applyRasterCacheSetting(new Setting(containerEl).setName('Rasterization cache'), this.plugin);
 
         new Setting(containerEl)
             .setName('Sync')


### PR DESCRIPTION
## Summary

- Adds `RasterCache`, a content-addressable cache of rasterized page PNGs keyed by `(hash of the .note file's own bytes, page number)`, with two tiers:
  - **Disk tier**: persistent, capped at 100MB, LRU eviction. Storage is a minimal `CacheStorage` structural interface satisfied by Obsidian's `app.vault.adapter`, so the module has no dependency on the `obsidian` package and is unit-testable with a plain mock.
  - **Memory tier**: a smaller (20MB default), purely in-memory LRU layer in front of the disk tier, checked first. Never persisted — starts empty every plugin reload — but skips disk I/O + base64 decode entirely for pages already served earlier in the same session.
- Wires the cache into `ImageConverter.convertToImages`: pages already cached are served without touching the worker pool; only missing pages are rendered and written back.
- Three perf bugs found and fixed while validating this against real, larger notes (the raster cache alone wasn't moving the needle on perceived open/close speed):
  1. `ImageConverter` used to own and tear down its own `WorkerPool` on *every* rasterization call, and `WorkerPool`'s constructor eagerly spawns `hardwareConcurrency` new Web Workers — so even a 100%-cache-hit open (zero pages rendered) still paid full multi-worker spin-up/teardown for nothing. Now a lazily-created, module-level singleton reused for the plugin's lifetime, torn down once in `onunload()`.
  2. `SupernoteView.onLoadFile` awaited `createImageBitmap()` one page at a time inside its per-page DOM-building loop — a page-count-scaling cost paid on *every* open regardless of how the PNG was obtained. Now decoded up front via `Promise.all`.
  3. **The big one**: `SupernoteView` builds an in-memory PDF purely so pdf.js can extract a text layer for search/selection (`pdfPage.render()` is never called against it — the embedded image is never actually shown). It was still unconditionally embedding every page's *real* image into that PDF. `pdf-lib`'s PNG embedding always fully decodes and recompresses the source PNG at `.save()` time regardless of it already being compressed — real, size-proportional cost. Profiled against an actual user-provided 12-page note with several user-uploaded-background pages: **~2.9s / ~4.5MB → ~40ms / ~43KB**, same extracted text either way. Fixed by bumping the `supernote-typescript` submodule to add `addTextOnlyPdfPage()` ([philips/supernote-typescript#34](https://github.com/philips/supernote-typescript/pull/34)) — a PDF page with the recognized-text layer but no image — and using it for this internal-only pipeline. The user-facing "export/attach as PDF" commands are untouched and still embed real images, since those PDFs are genuinely opened by the user.
- Reuses the existing non-cryptographic `hashBytes` fingerprint from `deviceSync.ts` rather than adding a new hashing dependency.
- One shared `RasterCache` instance is created in `SupernotePlugin.onload()`, stored under the plugin's own data folder (`<plugin dir>/rasterCache/`) — never as visible vault content.
- Adds a "Rasterization cache" row to the settings tab (disk + memory tier stats, "Clear cache" button) and debug-level console logging (cache init, per-open hit/miss/timing, page-render phase timing, background PDF pipeline timing) — this instrumentation is what let the above three bugs get root-caused with real numbers instead of guesswork.
- Every storage operation is fail-open: a read/write/parse error is logged and treated as a cache miss or no-op, so a broken/unavailable cache degrades to "always re-rasterize" instead of breaking rendering.

Design notes:
- **Cache granularity**: keyed by the whole note's content hash + page number, not a per-page hash — editing any page invalidates cache entries for every page in that note. Chosen for simplicity; stale entries just age out via eviction.
- **Eviction policy**: LRU on both cache tiers via `Map` insertion-order reordering on hit; the disk tier's reordering is kept in memory only, persisted on the next `put()`/`clear()` rather than on every read.

Closes #129.

## Test plan

- [x] `npx tsc -noEmit -skipLibCheck` — clean
- [x] `npm run lint` — clean (pre-existing unrelated warnings only)
- [x] `npx vitest run` — 109 passed, including 14 `rasterCache.test.ts` cases (roundtrip, per-key isolation, LRU eviction on both tiers, memory tier avoiding repeat disk reads, independent per-tier eviction budgets, index persistence, fail-open behavior, `clear()`)
- [x] `supernote-typescript`'s own test suite (26 tests, vitest) passes with the new `addTextOnlyPdfPage`, including a new test asserting identical extracted text vs. `addPdfPage` at <1/10th the byte size
- [x] `./scripts/build` — full production build succeeds
- [x] Manually verified real cache population/persistence, and the three perf fixes, against actual user-provided notes during testing