### PR TITLE
Fix zoom percentage tied to arbitrary max-image-dim setting

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -511,7 +511,6 @@ type PageRenderState = {
 	pageNumber: number;
 	// Fetched lazily — see SupernoteView.ensureTextLayer(). null until then.
 	pdfPage: PdfJsPage | null;
-	baseScale: number;
 	nativeWidth: number;
 	nativeHeight: number;
 	pageContainer: HTMLElement;
@@ -781,11 +780,6 @@ export class SupernoteView extends FileView {
 		this.pagesEl = body.createDiv({ cls: 'supernote-pages' });
 		this.pagesEl.toggleClass('supernote-mode-text', this.layerMode === 'text');
 
-		// Same for every page in a note (sn.pageWidth/pageHeight are note-level,
-		// not per-page) — computed once from data already in memory, no pdf.js
-		// or rasterization needed just to know how big to lay pages out.
-		const baseScale = this.settings.noteImageMaxDim / Math.max(sn.pageWidth, sn.pageHeight);
-
 		// Decoded up front, all at once via Promise.all, rather than one at a
 		// time inside the loop below — createImageBitmap() previously being
 		// awaited per-page meant a note's pages were decoded strictly one
@@ -829,7 +823,6 @@ export class SupernoteView extends FileView {
 			const state: PageRenderState = {
 				pageNumber: i + 1,
 				pdfPage: null,
-				baseScale,
 				nativeWidth: sn.pageWidth,
 				nativeHeight: sn.pageHeight,
 				pageContainer,
@@ -862,7 +855,7 @@ export class SupernoteView extends FileView {
 			// Already decoded above (in parallel, before this loop). Cached on
 			// the state and reused for every zoom redraw (drawPageImage()).
 			state.imageBitmap = bitmaps[i];
-			this.drawPageImage(state, baseScale * this.zoomScale);
+			this.drawPageImage(state, this.zoomScale);
 
 			this.pageObserver?.observe(pageContainer);
 
@@ -991,7 +984,7 @@ export class SupernoteView extends FileView {
 			}
 			const pdfPage = state.pdfPage;
 
-			const viewport = pdfPage.getViewport({ scale: state.baseScale * this.zoomScale });
+			const viewport = pdfPage.getViewport({ scale: this.zoomScale });
 			await this.buildTextLayerForState(pdfPage, state, viewport);
 		} catch (error) {
 			console.error(`Failed to build text layer for page ${state.pageNumber}:`, error);
@@ -1243,16 +1236,16 @@ export class SupernoteView extends FileView {
 		// 25%. Clamping it there just forced horizontal scrolling instead.
 		//
 		// The 500% ceiling only makes sense for *manual* zoom (a sanity cap on
-		// how far a user should zoom in by hand). "100%" here is only ever
-		// relative to noteImageMaxDim — an arbitrary default render size, not
-		// the note's true resolution or the available viewport — so a large or
-		// high-resolution display can legitimately need well over 5x to
-		// actually fill it with "Fit width". Applying the same 500% ceiling
-		// there just left the page stuck at a fixed pixel width regardless of
-		// how much wider the pane actually was, while showing a confusing
-		// pinned "500%" (see issue #108). Fit width instead gets a much higher
-		// ceiling, purely as a guard against a pathological render (e.g. a
-		// zero-width native page) rather than a real intended limit.
+		// how far a user should zoom in by hand). "100%" here is one canvas
+		// pixel per native rasterized page pixel (see nativeWidth/nativeHeight),
+		// not anything tied to the available viewport — so a page with a small
+		// native resolution on a large or high-DPI display can legitimately
+		// need well over 5x to fill it with "Fit width". Applying the same
+		// 500% ceiling there just left the page stuck at a fixed pixel width
+		// regardless of how much wider the pane actually was, while showing a
+		// confusing pinned "500%" (see issue #108). Fit width instead gets a
+		// much higher ceiling, purely as a guard against a pathological render
+		// (e.g. a zero-width native page) rather than a real intended limit.
 		const ceiling = isManual ? 5 : 20;
 		this.zoomScale = Math.min(ceiling, Math.max(0.05, newScale));
 		this.zoomLabelEl?.setText(`${Math.round(this.zoomScale * 100)}%`);
@@ -1273,7 +1266,7 @@ export class SupernoteView extends FileView {
 	private async commitZoom(): Promise<void> {
 		const targetZoom = this.zoomScale;
 		for (const state of this.pageStates) {
-			this.drawPageImage(state, state.baseScale * targetZoom);
+			this.drawPageImage(state, targetZoom);
 			state.canvasWrap.setCssStyles({ transform: '', transformOrigin: '' });
 
 			// Only rebuild the text layer for pages that already had one —
@@ -1281,7 +1274,7 @@ export class SupernoteView extends FileView {
 			// theirs at whatever zoom is current when they eventually do.
 			if (state.textLayerLoaded && state.pdfPage) {
 				const pdfPage = state.pdfPage;
-				const viewport = pdfPage.getViewport({ scale: state.baseScale * targetZoom });
+				const viewport = pdfPage.getViewport({ scale: targetZoom });
 				await this.buildTextLayerForState(pdfPage, state, viewport);
 			}
 		}
@@ -1312,7 +1305,7 @@ export class SupernoteView extends FileView {
 	// Scales the page so its rendered width matches however much horizontal
 	// space is actually available (pagesEl's content box, which already
 	// accounts for the thumbnail sidebar if it's open) minus the page
-	// container's own margin, rather than the fixed noteImageMaxDim cap.
+	// container's own margin.
 	private applyFitWidth() {
 		const state = this.pageStates[0];
 		if (!state || !this.pagesEl || state.nativeWidth <= 0) return;
@@ -1324,7 +1317,7 @@ export class SupernoteView extends FileView {
 		const horizontalMargin = parseFloat(containerStyle.marginLeft || '0') + parseFloat(containerStyle.marginRight || '0');
 		const targetWidth = Math.max(availableWidth - horizontalMargin, 1);
 
-		this.setZoom(targetWidth / (state.nativeWidth * state.baseScale), { manual: false });
+		this.setZoom(targetWidth / state.nativeWidth, { manual: false });
 	}
 
 	private updateFitWidthButton() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -65,7 +65,6 @@ export interface SupernotePluginSettings extends CustomDictionarySettings {
     directConnectIP: string;
     invertColorsWhenDark: boolean;
     showExportButtons: boolean;
-    noteImageMaxDim: number;
     fileBrowserSortOrder: FileBrowserSortOrder;
     importFormat: ImportFormat;
     /** Vault folder that device sync writes into; never touches anything outside it. */
@@ -89,7 +88,6 @@ export const DEFAULT_SETTINGS: SupernotePluginSettings = {
     directConnectIP: '',
     invertColorsWhenDark: true,
     showExportButtons: false,
-    noteImageMaxDim: 800, // Sensible default for Nomad pages to be legible but not too big. Unit: px
     fileBrowserSortOrder: 'name-asc',
     importFormat: 'images-text',
     syncFolder: 'Supernote sync',
@@ -139,17 +137,6 @@ export class SupernoteSettingTab extends PluginSettingTab {
                 control: {
                     type: 'toggle',
                     key: 'showExportButtons',
-                },
-            },
-            {
-                name: 'Max image side length in .note files',
-                desc: 'Maximum width and height (in pixels) of the note image when viewing .note files. Does not affect exported images and markdown.',
-                control: {
-                    type: 'slider',
-                    key: 'noteImageMaxDim',
-                    min: 200,
-                    max: 1900,
-                    step: 100, // Resolution of an A5X/A6X2/Nomad page is 1404 x 1872 px (with no upscaling)
                 },
             },
             {
@@ -271,19 +258,6 @@ export class SupernoteSettingTab extends PluginSettingTab {
                         this.plugin.settings.showExportButtons = value;
                         await this.plugin.saveSettings();
                     }),
-            );
-
-        new Setting(containerEl)
-            .setName('Max image side length in .note files')
-            .setDesc('Maximum width and height (in pixels) of the note image when viewing .note files. Does not affect exported images and markdown.')
-            .addSlider(text => text
-                .setLimits(200, 1900, 100) // Resolution of an A5X/A6X2/Nomad page is 1404 x 1872 px (with no upscaling)
-                .setDynamicTooltip()
-                .setValue(this.plugin.settings.noteImageMaxDim)
-                .onChange(async (value) => {
-                    this.plugin.settings.noteImageMaxDim = value;
-                    await this.plugin.saveSettings();
-                })
             );
 
         new Setting(containerEl)


### PR DESCRIPTION
## Summary
- Fixes #130 — Fit width's displayed zoom percentage was arbitrary and could show absurd values (e.g. 712% on a 13" MacBook) because "100%" was defined relative to the "max image side length in .note files" setting instead of the note's actual resolution.
- Removes that setting (`noteImageMaxDim`) entirely, per the issue discussion — it only ever existed to feed this now-removed `baseScale` calculation and had no effect on exports.
- `zoomScale` is now the direct pixel scale: 100% means one canvas pixel per native rasterized page pixel.

## Test plan
- [x] `npm test` (95 tests passed)
- [x] `npm run build` (tsc + esbuild, no new warnings/errors)
- [x] `npm run lint` (no new warnings/errors)