### PR TITLE
Prototype .spd (Supernote Atelier) file support

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -30,6 +30,13 @@ const context = await esbuild.context({
 		'supernote-typescript': path.join(__dirname, 'supernote-typescript'),
 	},
 	bundle: true,
+	loader: {
+		// sql.js's wasm binary (used by SupernoteAtelier for .spd files) is
+		// embedded directly in the bundle rather than fetched/read at
+		// runtime, so it works the same on desktop (Node/Electron) and
+		// mobile (browser) Obsidian without a locateFile() callback.
+		'.wasm': 'binary',
+	},
 	plugins: [inlineWorkerPlugin()],
 	external: [
 		"obsidian",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
 			"dependencies": {
 				"esbuild-plugin-inline-worker": "^0.1.1",
 				"fast-png": "^7.0.1",
-				"image-js": "^1.7.0"
+				"image-js": "^1.7.0",
+				"sql.js": "^1.14.1"
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.39.5",
@@ -6224,6 +6225,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/sql.js": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
+			"integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
+			"license": "MIT"
 		},
 		"node_modules/ssim.js": {
 			"version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 	"dependencies": {
 		"esbuild-plugin-inline-worker": "^0.1.1",
 		"fast-png": "^7.0.1",
-		"image-js": "^1.7.0"
+		"image-js": "^1.7.0",
+		"sql.js": "^1.14.1"
 	}
 }

--- a/src/atelierView.ts
+++ b/src/atelierView.ts
@@ -1,0 +1,72 @@
+import { FileView, TFile } from 'obsidian';
+import { SupernoteAtelier } from 'supernote-typescript';
+import { encodeDataURL } from 'image-js';
+// esbuild's "binary" loader (see esbuild.config.mjs) embeds the wasm file as
+// a base64 string and decodes it to a Uint8Array at load time, so sql.js
+// never needs to fetch()/readFileSync() a sibling file at runtime — the one
+// thing that would otherwise differ between desktop (Node/Electron) and
+// mobile (browser) Obsidian.
+import sqlWasmBinary from 'sql.js/dist/sql-wasm.wasm';
+
+export const VIEW_TYPE_SUPERNOTE_ATELIER = "supernote-atelier-view";
+
+// Prototype viewer for `.spd` files (Supernote Atelier app), built on top of
+// supernote-typescript's SupernoteAtelier parser
+// (https://github.com/philips/supernote-typescript/pull/33). Deliberately
+// minimal compared to SupernoteView (the `.note` viewer): `.spd` has no page
+// concept, just layered tiles on one canvas, so this just flattens every
+// layer with toCompositeImage() and shows the result as a single image. No
+// zoom/find/thumbnail toolbar, no embed registration, no vault-writing
+// commands yet.
+export class SupernoteAtelierView extends FileView {
+	declare file: TFile;
+
+	getViewType() {
+		return VIEW_TYPE_SUPERNOTE_ATELIER;
+	}
+
+	getDisplayText() {
+		return this.file ? this.file.basename : "Supernote Atelier";
+	}
+
+	getIcon() {
+		return "image";
+	}
+
+	async onLoadFile(file: TFile): Promise<void> {
+		const container = this.contentEl;
+		container.empty();
+		container.addClass('supernote-atelier-view-content');
+
+		let buffer: ArrayBuffer;
+		try {
+			buffer = await this.app.vault.readBinary(file);
+		} catch (err) {
+			this.renderError(container, err);
+			return;
+		}
+
+		try {
+			const wasmBinary = sqlWasmBinary.buffer.slice(
+				sqlWasmBinary.byteOffset,
+				sqlWasmBinary.byteOffset + sqlWasmBinary.byteLength,
+			) as ArrayBuffer;
+			const spd = await SupernoteAtelier.open(new Uint8Array(buffer), { wasmBinary });
+			const image = await spd.toCompositeImage();
+			if (!image) {
+				container.createDiv({ cls: 'supernote-atelier-empty', text: 'This .spd file has no drawn content.' });
+				return;
+			}
+			container.createEl('img', { cls: 'supernote-atelier-image', attr: { src: encodeDataURL(image) } });
+		} catch (err) {
+			this.renderError(container, err);
+		}
+	}
+
+	private renderError(container: HTMLElement, err: unknown): void {
+		container.createDiv({
+			cls: 'supernote-embed-error',
+			text: `Failed to render Supernote Atelier file: ${err instanceof Error ? err.message : String(err)}`,
+		});
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { replaceTextWithCustomDictionary } from './customDictionary';
 import { runDeviceSync, appendSyncLogEntry } from './syncEngine';
 import { formatSyncFailureLogEntry } from './deviceSync';
 import { parseLinkRect, bucketLinksByPage } from './linkOverlay';
+import { SupernoteAtelierView, VIEW_TYPE_SUPERNOTE_ATELIER } from './atelierView';
 
 function generateTimestamp(): string {
 	const date = new Date();
@@ -1749,6 +1750,13 @@ export default class SupernotePlugin extends Plugin {
 			(leaf) => new SupernoteView(leaf, this.settings)
 		);
 		this.registerExtensions(['note'], VIEW_TYPE_SUPERNOTE);
+
+		// Prototype: `.spd` files (Supernote Atelier app) — see atelierView.ts.
+		this.registerView(
+			VIEW_TYPE_SUPERNOTE_ATELIER,
+			(leaf) => new SupernoteAtelierView(leaf)
+		);
+		this.registerExtensions(['spd'], VIEW_TYPE_SUPERNOTE_ATELIER);
 
 		// Wires up `![[example.note]]` embeds via Obsidian's internal
 		// app.embedRegistry (undocumented — not in obsidian.d.ts, see

--- a/src/wasm.d.ts
+++ b/src/wasm.d.ts
@@ -1,0 +1,6 @@
+// esbuild's "binary" loader (see esbuild.config.mjs) turns a `.wasm` import
+// into a decoded Uint8Array at bundle time.
+declare module '*.wasm' {
+	const bytes: Uint8Array;
+	export default bytes;
+}

--- a/styles.css
+++ b/styles.css
@@ -295,6 +295,22 @@ div.supernote-canvas-wrap canvas {
     padding: 0.5em;
 }
 
+/* Prototype .spd (Supernote Atelier) viewer, see src/atelierView.ts */
+.supernote-atelier-view-content {
+    padding: 1em;
+    overflow: auto;
+}
+
+.supernote-atelier-image {
+    display: block;
+    max-width: 100%;
+}
+
+.supernote-atelier-empty {
+    color: var(--text-muted);
+    padding: 1em;
+}
+
 /* Custom dictionary settings styles */
 .supernote-settings-custom-dictionary-subtitle {
 	padding: 0 0 0.75em;


### PR DESCRIPTION
## Summary

Prototype for #136: a minimal read-only viewer for `.spd` files (the
Supernote Atelier app's format), built on top of
[supernote-typescript#33](https://github.com/philips/supernote-typescript/pull/33)'s
`SupernoteAtelier` parser.

- Registers the `spd` extension to a new `SupernoteAtelierView`
  (`src/atelierView.ts`) — opens the file, calls `toCompositeImage()` to
  flatten every layer, and shows the result as one image.
- Deliberately minimal compared to `SupernoteView` (the `.note` viewer):
  `.spd` has no page concept, just layered tiles on one canvas, so there's
  no zoom/find/thumbnail toolbar, no embed registration
  (`![[file.spd]]`), and no vault-writing commands yet.
- `sql.js`'s wasm binary is embedded directly into the bundle via
  esbuild's `binary` loader (`esbuild.config.mjs`) instead of being
  fetched/read at runtime, so it works the same on desktop and mobile
  without a `locateFile()` callback.
- Points the `supernote-typescript` submodule at that repo's `main`
  (PR #33 has since merged — published to npm as `0.5.2`, though that repo
  doesn't have a corresponding git tag yet).

## What's not here yet

- No embed (`![[file.spd]]`) support.
- No per-layer view/toggle — only the flattened composite.
- No "attach/upload to device" integration for `.spd`.
- `SupernoteAtelier.viewport`/`canvasSize` aren't used (no zoom/pan yet).

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` — all 95 existing tests still pass
- [x] `npm run lint` — no new warnings/errors
- [x] Verified `SupernoteAtelier.open()` + `toCompositeImage()` against
      `supernote-typescript/tests/input/real-device.spd` outside the
      plugin (same code path the view uses) and visually confirmed the
      layered strokes composite correctly over the reference background
- [x] Manually verified inside a running Obsidian vault — .spd file renders correctly

