### PR TITLE
Add ![[file.spd]] embed support

### DIFF
--- a/src/atelierView.ts
+++ b/src/atelierView.ts
@@ -1,4 +1,4 @@
-import { FileView, TFile } from 'obsidian';
+import { App, Component, FileView, TFile } from 'obsidian';
 import { SupernoteAtelier } from 'supernote-typescript';
 import { encodeDataURL } from 'image-js';
 // esbuild's "binary" loader (see esbuild.config.mjs) embeds the wasm file as
@@ -10,14 +10,39 @@ import sqlWasmBinary from 'sql.js/dist/sql-wasm.wasm';
 
 export const VIEW_TYPE_SUPERNOTE_ATELIER = "supernote-atelier-view";
 
-// Prototype viewer for `.spd` files (Supernote Atelier app), built on top of
-// supernote-typescript's SupernoteAtelier parser
-// (https://github.com/philips/supernote-typescript/pull/33). Deliberately
-// minimal compared to SupernoteView (the `.note` viewer): `.spd` has no page
-// concept, just layered tiles on one canvas, so this just flattens every
-// layer with toCompositeImage() and shows the result as a single image. No
-// zoom/find/thumbnail toolbar, no embed registration, no vault-writing
-// commands yet.
+// Opens a `.spd` file (Supernote Atelier app) and flattens every layer into
+// one composite image via SupernoteAtelier.toCompositeImage()
+// (supernote-typescript#33), pre-encoded as a data URL for an <img> src.
+// Shared by SupernoteAtelierView and SupernoteAtelierEmbed. Returns null if
+// the file has no drawn content anywhere (an empty canvas).
+async function renderAtelierCompositeDataUrl(app: App, file: TFile): Promise<string | null> {
+	const buffer = await app.vault.readBinary(file);
+	// Uint8Array.buffer is typed ArrayBufferLike (could be a SharedArrayBuffer
+	// view) but sql.js's wasmBinary wants a plain ArrayBuffer; slice() always
+	// returns one sized to exactly this array's bytes.
+	const wasmBinary = sqlWasmBinary.buffer.slice(
+		sqlWasmBinary.byteOffset,
+		sqlWasmBinary.byteOffset + sqlWasmBinary.byteLength,
+	) as ArrayBuffer;
+	const spd = await SupernoteAtelier.open(new Uint8Array(buffer), { wasmBinary });
+	const image = await spd.toCompositeImage();
+	return image ? encodeDataURL(image) : null;
+}
+
+function renderAtelierError(container: HTMLElement, err: unknown): void {
+	container.empty();
+	container.createDiv({
+		cls: 'supernote-embed-error',
+		text: `Failed to render Supernote Atelier file: ${err instanceof Error ? err.message : String(err)}`,
+	});
+}
+
+// Viewer for `.spd` files (Supernote Atelier app). Deliberately minimal
+// compared to SupernoteView (the `.note` viewer): `.spd` has no page
+// concept, just layered tiles on one canvas, so this just shows the
+// flattened composite as a single image. No zoom/find/thumbnail toolbar, no
+// layer on/off toggle, no vault-writing commands yet — see
+// https://github.com/philips/supernote-obsidian-plugin/issues/138.
 export class SupernoteAtelierView extends FileView {
 	declare file: TFile;
 
@@ -38,35 +63,68 @@ export class SupernoteAtelierView extends FileView {
 		container.empty();
 		container.addClass('supernote-atelier-view-content');
 
-		let buffer: ArrayBuffer;
+		let dataUrl: string | null;
 		try {
-			buffer = await this.app.vault.readBinary(file);
+			dataUrl = await renderAtelierCompositeDataUrl(this.app, file);
 		} catch (err) {
-			this.renderError(container, err);
+			renderAtelierError(container, err);
 			return;
 		}
 
-		try {
-			const wasmBinary = sqlWasmBinary.buffer.slice(
-				sqlWasmBinary.byteOffset,
-				sqlWasmBinary.byteOffset + sqlWasmBinary.byteLength,
-			) as ArrayBuffer;
-			const spd = await SupernoteAtelier.open(new Uint8Array(buffer), { wasmBinary });
-			const image = await spd.toCompositeImage();
-			if (!image) {
-				container.createDiv({ cls: 'supernote-atelier-empty', text: 'This .spd file has no drawn content.' });
-				return;
-			}
-			container.createEl('img', { cls: 'supernote-atelier-image', attr: { src: encodeDataURL(image) } });
-		} catch (err) {
-			this.renderError(container, err);
+		if (dataUrl === null) {
+			container.createDiv({ cls: 'supernote-atelier-empty', text: 'This .spd file has no drawn content.' });
+			return;
 		}
+		container.createEl('img', { cls: 'supernote-atelier-image', attr: { src: dataUrl } });
+	}
+}
+
+// Renders a `.spd` file into an `![[example.spd]]` embed via Obsidian's
+// undocumented app.embedRegistry API (see registration in
+// SupernotePlugin.onload, and SupernoteEmbed's doc comment in main.ts for
+// why this internal API is the only option). Simpler than SupernoteEmbed:
+// `.spd` has no pages to navigate, so this is just the composite image, no
+// toolbar.
+export class SupernoteAtelierEmbed extends Component {
+	private destroyed = false;
+
+	constructor(
+		private app: App,
+		private containerEl: HTMLElement,
+		private file: TFile,
+	) {
+		super();
 	}
 
-	private renderError(container: HTMLElement, err: unknown): void {
-		container.createDiv({
-			cls: 'supernote-embed-error',
-			text: `Failed to render Supernote Atelier file: ${err instanceof Error ? err.message : String(err)}`,
-		});
+	// Called by Obsidian's embed system once this component has been mounted
+	// into context.containerEl (separate from Component's own load(), since
+	// the same embed component can be asked to loadFile() again if the
+	// underlying link changes without being recreated).
+	loadFile(): void {
+		void this.render();
+	}
+
+	onunload(): void {
+		this.destroyed = true;
+	}
+
+	private async render(): Promise<void> {
+		this.containerEl.empty();
+		this.containerEl.addClass('supernote-atelier-embed');
+
+		let dataUrl: string | null;
+		try {
+			dataUrl = await renderAtelierCompositeDataUrl(this.app, this.file);
+		} catch (err) {
+			if (!this.destroyed) renderAtelierError(this.containerEl, err);
+			return;
+		}
+		if (this.destroyed) return;
+
+		if (dataUrl === null) {
+			this.containerEl.createDiv({ cls: 'supernote-atelier-empty', text: 'This .spd file has no drawn content.' });
+			return;
+		}
+		this.containerEl.createEl('img', { cls: 'supernote-atelier-image', attr: { src: dataUrl } });
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ import { replaceTextWithCustomDictionary } from './customDictionary';
 import { runDeviceSync, appendSyncLogEntry } from './syncEngine';
 import { formatSyncFailureLogEntry } from './deviceSync';
 import { parseLinkRect, bucketLinksByPage } from './linkOverlay';
-import { SupernoteAtelierView, VIEW_TYPE_SUPERNOTE_ATELIER } from './atelierView';
+import { SupernoteAtelierEmbed, SupernoteAtelierView, VIEW_TYPE_SUPERNOTE_ATELIER } from './atelierView';
 
 function generateTimestamp(): string {
 	const date = new Date();
@@ -1770,6 +1770,11 @@ export default class SupernotePlugin extends Plugin {
 				new SupernoteEmbed(this.app, this.settings, context.containerEl, file, parsePageAnchor(subpath))
 			);
 			this.register(() => this.app.embedRegistry?.unregisterExtension('note'));
+
+			this.app.embedRegistry.registerExtension('spd', (context, file) =>
+				new SupernoteAtelierEmbed(this.app, context.containerEl, file)
+			);
+			this.register(() => this.app.embedRegistry?.unregisterExtension('spd'));
 		}
 
 		this.addCommand({

--- a/styles.css
+++ b/styles.css
@@ -295,10 +295,20 @@ div.supernote-canvas-wrap canvas {
     padding: 0.5em;
 }
 
-/* Prototype .spd (Supernote Atelier) viewer, see src/atelierView.ts */
+/* .spd (Supernote Atelier) viewer/embed, see src/atelierView.ts */
 .supernote-atelier-view-content {
     padding: 1em;
     overflow: auto;
+}
+
+.supernote-atelier-embed {
+    display: flex;
+    flex-direction: column;
+    max-height: 800px;
+    overflow: auto;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-s);
+    padding: 1em;
 }
 
 .supernote-atelier-image {


### PR DESCRIPTION
## Summary

First slice of #138: `![[file.spd]]` embed support, mirroring how `![[file.note]]` embeds already work.

- `SupernoteAtelierEmbed` (new, in `src/atelierView.ts`) registers `spd` with `app.embedRegistry` the same way `SupernoteEmbed` does for `note` (see `SupernotePlugin.onload` in `src/main.ts`).
- Simpler than `SupernoteEmbed`: `.spd` has no page concept, just layered tiles flattened into one composite image via `SupernoteAtelier.toCompositeImage()`, so there's no page-nav toolbar to build — just the image (or an empty/error message).
- Extracted the render logic (read file → `SupernoteAtelier.open()` → `toCompositeImage()` → data URL) that `SupernoteAtelierView` (#137) already had into a shared `renderAtelierCompositeDataUrl()` helper, so the view and the new embed don't duplicate it.

Scoped deliberately narrow: the other items in #138 (layer on/off toggle, export/conversion commands, viewport/zoom, device attach/upload) are separate follow-up work, not part of this PR.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` — all 95 existing tests still pass
- [x] `npm run lint` — no new warnings/errors
- [x] Not yet manually verified inside a running Obsidian vault (e.g. `![[somefile.spd]]` in a note) — no automated Electron/GUI harness for this repo yet, same as #137's manual verification step