### PR TITLE
Add .spd export commands (PNG, PDF)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"esbuild-plugin-inline-worker": "^0.1.1",
 				"fast-png": "^7.0.1",
 				"image-js": "^1.7.0",
+				"pdf-lib": "^1.17.1",
 				"sql.js": "^1.14.1"
 			},
 			"devDependencies": {
@@ -936,6 +937,36 @@
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
 			}
+		},
+		"node_modules/@pdf-lib/standard-fonts": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+			"integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+			"license": "MIT",
+			"dependencies": {
+				"pako": "^1.0.6"
+			}
+		},
+		"node_modules/@pdf-lib/standard-fonts/node_modules/pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"license": "(MIT AND Zlib)"
+		},
+		"node_modules/@pdf-lib/upng": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+			"integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+			"license": "MIT",
+			"dependencies": {
+				"pako": "^1.0.10"
+			}
+		},
+		"node_modules/@pdf-lib/upng/node_modules/pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"license": "(MIT AND Zlib)"
 		},
 		"node_modules/@pkgr/core": {
 			"version": "0.1.2",
@@ -5557,6 +5588,30 @@
 			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/pdf-lib": {
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+			"integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+			"license": "MIT",
+			"dependencies": {
+				"@pdf-lib/standard-fonts": "^1.0.0",
+				"@pdf-lib/upng": "^1.0.1",
+				"pako": "^1.0.11",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/pdf-lib/node_modules/pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"license": "(MIT AND Zlib)"
+		},
+		"node_modules/pdf-lib/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"license": "0BSD"
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"esbuild-plugin-inline-worker": "^0.1.1",
 		"fast-png": "^7.0.1",
 		"image-js": "^1.7.0",
+		"pdf-lib": "^1.17.1",
 		"sql.js": "^1.14.1"
 	}
 }

--- a/src/atelierView.ts
+++ b/src/atelierView.ts
@@ -13,9 +13,10 @@ export const VIEW_TYPE_SUPERNOTE_ATELIER = "supernote-atelier-view";
 // Opens a `.spd` file (Supernote Atelier app) and flattens every layer into
 // one composite image via SupernoteAtelier.toCompositeImage()
 // (supernote-typescript#33), pre-encoded as a data URL for an <img> src.
-// Shared by SupernoteAtelierView and SupernoteAtelierEmbed. Returns null if
-// the file has no drawn content anywhere (an empty canvas).
-async function renderAtelierCompositeDataUrl(app: App, file: TFile): Promise<string | null> {
+// Shared by SupernoteAtelierView, SupernoteAtelierEmbed, and VaultWriter's
+// .spd export commands (see main.ts). Returns null if the file has no drawn
+// content anywhere (an empty canvas).
+export async function renderAtelierCompositeDataUrl(app: App, file: TFile): Promise<string | null> {
 	const buffer = await app.vault.readBinary(file);
 	// Uint8Array.buffer is typed ArrayBufferLike (could be a SharedArrayBuffer
 	// view) but sql.js's wasmBinary wants a plain ArrayBuffer; slice() always

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,8 @@ import { replaceTextWithCustomDictionary } from './customDictionary';
 import { runDeviceSync, appendSyncLogEntry } from './syncEngine';
 import { formatSyncFailureLogEntry } from './deviceSync';
 import { parseLinkRect, bucketLinksByPage } from './linkOverlay';
-import { SupernoteAtelierEmbed, SupernoteAtelierView, VIEW_TYPE_SUPERNOTE_ATELIER } from './atelierView';
+import { SupernoteAtelierEmbed, SupernoteAtelierView, VIEW_TYPE_SUPERNOTE_ATELIER, renderAtelierCompositeDataUrl } from './atelierView';
+import { PDFDocument } from 'pdf-lib';
 
 function generateTimestamp(): string {
 	const date = new Date();
@@ -441,6 +442,46 @@ class VaultWriter {
 		const pdfBytes = await assemblePdfFromImages(sn, images);
 
 		// Generate filename and save
+		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}.pdf`);
+		await this.app.vault.createBinary(filename, toArrayBuffer(pdfBytes));
+	}
+
+	// `.spd` (Supernote Atelier) equivalents of the exports above. Unlike
+	// `.note`, `.spd` has no pages and no recognized/OCR text — just one
+	// flattened composite image (see renderAtelierCompositeDataUrl).
+	private async rasterizeAtelier(file: TFile): Promise<string> {
+		const dataUrl = await renderAtelierCompositeDataUrl(this.app, file);
+		if (dataUrl === null) {
+			throw new Error(`"${file.basename}.spd" has no drawn content to export.`);
+		}
+		return dataUrl;
+	}
+
+	async attachAtelierImage(file: TFile): Promise<TFile> {
+		const dataUrl = await this.rasterizeAtelier(file);
+		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}.png`);
+		return this.app.vault.createBinary(filename, dataUrlToBuffer(dataUrl));
+	}
+
+	async exportAtelierToPDF(file: TFile) {
+		const dataUrl = await this.rasterizeAtelier(file);
+
+		// A single full-page image, same sizing convention
+		// createPdfContext/addPdfPage use for `.note` pages (see pdf.ts in
+		// supernote-typescript): 300dpi assumed source density, converted to
+		// PDF points (72/inch). `.spd` has no recognition/OCR text to lay an
+		// invisible text layer under, so this builds the PDF directly with
+		// pdf-lib rather than going through that `.note`-specific machinery.
+		const pdfDoc = await PDFDocument.create();
+		const pngImage = await pdfDoc.embedPng(dataUrlToBuffer(dataUrl));
+		const dpi = 300;
+		const pointsPerPixel = 72 / dpi;
+		const widthPts = pngImage.width * pointsPerPixel;
+		const heightPts = pngImage.height * pointsPerPixel;
+		const pdfPage = pdfDoc.addPage([widthPts, heightPts]);
+		pdfPage.drawImage(pngImage, { x: 0, y: 0, width: widthPts, height: heightPts });
+		const pdfBytes = await pdfDoc.save();
+
 		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}.pdf`);
 		await this.app.vault.createBinary(filename, toArrayBuffer(pdfBytes));
 	}
@@ -1887,6 +1928,56 @@ export default class SupernotePlugin extends Plugin {
 						new ErrorModal(this.app, new Error("No file to attach")).open();
 					} else {
 						vw.attachMarkdownFile(file).catch((err: unknown) => {
+							new ErrorModal(this.app, err instanceof Error ? err : new Error(String(err))).open();
+						});
+					}
+					return true;
+				}
+
+				return false;
+			},
+		});
+
+		this.addCommand({
+			id: 'export-atelier-as-png',
+			name: 'Export this .spd file as a PNG attachment',
+			checkCallback: (checking: boolean) => {
+				const file = this.app.workspace.getActiveFile();
+				const ext = file?.extension;
+
+				if (ext === "spd") {
+					if (checking) {
+						return true
+					}
+					if (!file) {
+						new ErrorModal(this.app, new Error("No file to attach")).open();
+					} else {
+						vw.attachAtelierImage(file).catch((err: unknown) => {
+							new ErrorModal(this.app, err instanceof Error ? err : new Error(String(err))).open();
+						});
+					}
+					return true;
+				}
+
+				return false;
+			},
+		});
+
+		this.addCommand({
+			id: 'export-atelier-as-pdf',
+			name: 'Export this .spd file as PDF',
+			checkCallback: (checking: boolean) => {
+				const file = this.app.workspace.getActiveFile();
+				const ext = file?.extension;
+
+				if (ext === "spd") {
+					if (checking) {
+						return true
+					}
+					if (!file) {
+						new ErrorModal(this.app, new Error("No file to attach")).open();
+					} else {
+						vw.exportAtelierToPDF(file).catch((err: unknown) => {
 							new ErrorModal(this.app, err instanceof Error ? err : new Error(String(err))).open();
 						});
 					}


### PR DESCRIPTION
## Summary

Next slice of #138: `.spd` equivalents of the existing `.note` export commands.

- **`export-atelier-as-png`** — writes the flattened composite image (`SupernoteAtelier.toCompositeImage()`) as a PNG attachment.
- **`export-atelier-as-pdf`** — wraps that same image in a single-page PDF. Built directly with `pdf-lib` (added as a plugin dependency, matching the version already pinned in the `supernote-typescript` submodule) rather than through `supernote-typescript`'s `createPdfContext`/`addPdfPage`, which are built around `.note`'s per-page recognized-text layer — `.spd` has no equivalent of that, so reusing those would mean threading a bunch of irrelevant text-layer machinery through for nothing. Same page-sizing convention as `.note`'s PDF export (300dpi assumed source density → 72pt/inch).
- No `.spd` equivalent of `export-note-as-markdown` (the `.note` command that writes markdown only, no image) — that one exists for `.note` because a `PageTextProcessor` can still enrich the OCR/recognized text without an image attachment. `.spd` has no text at all, so a markdown-only export would have nothing to write.

Also refactors `renderAtelierCompositeDataUrl()` out to be exported from `atelierView.ts` (previously private there) so these new commands reuse the same open-and-flatten logic that the view (#137) and embed (#139) already use, instead of duplicating it.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` — all 95 existing tests still pass
- [x] `npm run lint` — no new warnings/errors
- [x] Verified the PNG→PDF path (`embedPng`/`addPage`/`drawImage`) against `supernote-typescript/tests/input/real-device.spd` outside the plugin — produces a valid single-page PDF sized correctly from the composite image
- [x] Not yet manually verified inside a running Obsidian vault (no automated Electron/GUI harness for this repo yet, same as #137/#139)