### PR TITLE
Add layer on/off toggle to the .spd viewer

### DIFF
--- a/src/atelierView.ts
+++ b/src/atelierView.ts
@@ -1,5 +1,5 @@
 import { App, Component, FileView, TFile } from 'obsidian';
-import { SupernoteAtelier } from 'supernote-typescript';
+import { SupernoteAtelier, IAtelierSurfaceName } from 'supernote-typescript';
 import { encodeDataURL } from 'image-js';
 // esbuild's "binary" loader (see esbuild.config.mjs) embeds the wasm file as
 // a base64 string and decodes it to a Uint8Array at load time, so sql.js
@@ -10,13 +10,13 @@ import sqlWasmBinary from 'sql.js/dist/sql-wasm.wasm';
 
 export const VIEW_TYPE_SUPERNOTE_ATELIER = "supernote-atelier-view";
 
-// Opens a `.spd` file (Supernote Atelier app) and flattens every layer into
-// one composite image via SupernoteAtelier.toCompositeImage()
-// (supernote-typescript#33), pre-encoded as a data URL for an <img> src.
-// Shared by SupernoteAtelierView, SupernoteAtelierEmbed, and VaultWriter's
-// .spd export commands (see main.ts). Returns null if the file has no drawn
-// content anywhere (an empty canvas).
-export async function renderAtelierCompositeDataUrl(app: App, file: TFile): Promise<string | null> {
+// Opens a `.spd` file (Supernote Atelier app) via SupernoteAtelier.open()
+// (supernote-typescript#33). Shared by every entry point below — parsing the
+// sqlite database is the expensive part, so SupernoteAtelierView's layer
+// toggle (which needs to re-composite on every checkbox click) does this
+// once per file load and reuses the parsed SupernoteAtelier, rather than
+// re-parsing on every toggle.
+async function openAtelierFile(app: App, file: TFile): Promise<SupernoteAtelier> {
 	const buffer = await app.vault.readBinary(file);
 	// Uint8Array.buffer is typed ArrayBufferLike (could be a SharedArrayBuffer
 	// view) but sql.js's wasmBinary wants a plain ArrayBuffer; slice() always
@@ -25,9 +25,42 @@ export async function renderAtelierCompositeDataUrl(app: App, file: TFile): Prom
 		sqlWasmBinary.byteOffset,
 		sqlWasmBinary.byteOffset + sqlWasmBinary.byteLength,
 	) as ArrayBuffer;
-	const spd = await SupernoteAtelier.open(new Uint8Array(buffer), { wasmBinary });
-	const image = await spd.toCompositeImage();
+	return SupernoteAtelier.open(new Uint8Array(buffer), { wasmBinary });
+}
+
+// Flattens (a subset of) a parsed .spd file's layers via
+// SupernoteAtelier.toCompositeImage() (supernote-typescript#37 for the
+// `visibleSurfaces` filter), pre-encoded as a data URL for an <img> src.
+// `visibleSurfaces` omitted composites every layer; returns null if nothing
+// ends up visible (an empty canvas, or every layer toggled off).
+async function compositeDataUrl(spd: SupernoteAtelier, visibleSurfaces?: Iterable<IAtelierSurfaceName>): Promise<string | null> {
+	const image = await spd.toCompositeImage(visibleSurfaces);
 	return image ? encodeDataURL(image) : null;
+}
+
+// Opens a `.spd` file and flattens every layer in one step. Used by
+// SupernoteAtelierEmbed and VaultWriter's .spd export commands (see
+// main.ts), neither of which need repeated re-composites the way
+// SupernoteAtelierView's layer toggle does.
+export async function renderAtelierCompositeDataUrl(app: App, file: TFile): Promise<string | null> {
+	const spd = await openAtelierFile(app, file);
+	return compositeDataUrl(spd);
+}
+
+// A layer entry to show in the toggle UI. Backed by SupernoteAtelier.layers
+// (id + name, best-effort decoded from `ls`) when available; falls back to
+// the raw surface table names (e.g. "surface_1") when `ls` didn't decode, so
+// the toggle still works, just with less friendly labels.
+interface AtelierLayerOption {
+	surfaceName: IAtelierSurfaceName;
+	label: string;
+}
+
+function atelierLayerOptions(spd: SupernoteAtelier): AtelierLayerOption[] {
+	if (spd.layers && spd.layers.length > 0) {
+		return spd.layers.map((layer) => ({ surfaceName: `surface_${layer.id}`, label: layer.name }));
+	}
+	return Object.keys(spd.surfaces).map((surfaceName) => ({ surfaceName, label: surfaceName }));
 }
 
 function renderAtelierError(container: HTMLElement, err: unknown): void {
@@ -40,12 +73,18 @@ function renderAtelierError(container: HTMLElement, err: unknown): void {
 
 // Viewer for `.spd` files (Supernote Atelier app). Deliberately minimal
 // compared to SupernoteView (the `.note` viewer): `.spd` has no page
-// concept, just layered tiles on one canvas, so this just shows the
-// flattened composite as a single image. No zoom/find/thumbnail toolbar, no
-// layer on/off toggle, no vault-writing commands yet — see
-// https://github.com/philips/supernote-obsidian-plugin/issues/138.
+// concept, just layered tiles on one canvas. Shows the flattened composite
+// as a single image, with a checkbox per layer to show/hide it (skipped
+// entirely for a single-layer file — nothing to toggle). No zoom/find
+// toolbar yet — see https://github.com/philips/supernote-obsidian-plugin/issues/138.
 export class SupernoteAtelierView extends FileView {
 	declare file: TFile;
+
+	// Guards against a stale re-composite: if the file is reloaded (or the
+	// view closed) while a toggle's re-render is still in flight, its result
+	// is discarded instead of overwriting the newer load's image.
+	private loadRequestId = 0;
+	private imageEl: HTMLImageElement | null = null;
 
 	getViewType() {
 		return VIEW_TYPE_SUPERNOTE_ATELIER;
@@ -60,23 +99,83 @@ export class SupernoteAtelierView extends FileView {
 	}
 
 	async onLoadFile(file: TFile): Promise<void> {
+		const requestId = ++this.loadRequestId;
 		const container = this.contentEl;
 		container.empty();
 		container.addClass('supernote-atelier-view-content');
+		this.imageEl = null;
 
+		let spd: SupernoteAtelier;
+		try {
+			spd = await openAtelierFile(this.app, file);
+		} catch (err) {
+			if (requestId === this.loadRequestId) renderAtelierError(container, err);
+			return;
+		}
+		if (requestId !== this.loadRequestId) return;
+
+		const layers = atelierLayerOptions(spd);
+		// Every layer starts visible, keyed by surface name so toggling
+		// doesn't depend on layers[]/surfaces staying in a stable order.
+		const visible = new Set(layers.map((l) => l.surfaceName));
+
+		if (layers.length > 1) {
+			this.buildLayerToggle(container, layers, visible, () => { void this.updateImage(spd, visible, requestId); });
+		}
+
+		this.imageEl = container.createEl('img', { cls: 'supernote-atelier-image' });
+		await this.updateImage(spd, visible, requestId);
+	}
+
+	private buildLayerToggle(
+		container: HTMLElement,
+		layers: AtelierLayerOption[],
+		visible: Set<IAtelierSurfaceName>,
+		onChange: () => void,
+	): void {
+		const panel = container.createDiv({ cls: 'supernote-atelier-layers' });
+		panel.createSpan({ cls: 'supernote-atelier-layers-label', text: 'Layers' });
+		for (const layer of layers) {
+			const item = panel.createEl('label', { cls: 'supernote-atelier-layer-item' });
+			const checkbox = item.createEl('input', { attr: { type: 'checkbox' } });
+			checkbox.checked = true;
+			item.createSpan({ text: layer.label });
+			checkbox.addEventListener('change', () => {
+				if (checkbox.checked) {
+					visible.add(layer.surfaceName);
+				} else {
+					visible.delete(layer.surfaceName);
+				}
+				onChange();
+			});
+		}
+	}
+
+	// Re-composites just the visible surfaces and swaps the <img> src.
+	// Reused for both the initial render and every toggle click, so a toggle
+	// mid-render can't leave the image out of sync with the checkboxes.
+	private async updateImage(spd: SupernoteAtelier, visible: Set<IAtelierSurfaceName>, requestId: number): Promise<void> {
 		let dataUrl: string | null;
 		try {
-			dataUrl = await renderAtelierCompositeDataUrl(this.app, file);
+			dataUrl = await compositeDataUrl(spd, visible);
 		} catch (err) {
-			renderAtelierError(container, err);
+			if (requestId === this.loadRequestId) renderAtelierError(this.contentEl, err);
 			return;
 		}
+		if (requestId !== this.loadRequestId || !this.imageEl) return;
 
 		if (dataUrl === null) {
-			container.createDiv({ cls: 'supernote-atelier-empty', text: 'This .spd file has no drawn content.' });
+			this.imageEl.hide();
+			this.contentEl.querySelector('.supernote-atelier-empty')?.remove();
+			this.contentEl.createDiv({
+				cls: 'supernote-atelier-empty',
+				text: visible.size === 0 ? 'No layers selected.' : 'This .spd file has no drawn content.',
+			});
 			return;
 		}
-		container.createEl('img', { cls: 'supernote-atelier-image', attr: { src: dataUrl } });
+		this.contentEl.querySelector('.supernote-atelier-empty')?.remove();
+		this.imageEl.show();
+		this.imageEl.src = dataUrl;
 	}
 }
 

--- a/styles.css
+++ b/styles.css
@@ -316,6 +316,30 @@ div.supernote-canvas-wrap canvas {
     max-width: 100%;
 }
 
+.supernote-atelier-layers {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1em;
+    margin-bottom: 1em;
+    padding: 0.5em 0.8em;
+    background: var(--background-secondary);
+    border-radius: var(--radius-s);
+}
+
+.supernote-atelier-layers-label {
+    color: var(--text-muted);
+    font-size: var(--font-smaller);
+    font-weight: var(--font-semibold);
+}
+
+.supernote-atelier-layer-item {
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
+    cursor: pointer;
+}
+
 .supernote-atelier-empty {
     color: var(--text-muted);
     padding: 1em;


### PR DESCRIPTION
## Summary

Next slice of #138, on top of philips/supernote-typescript#37 (merged, released as v0.5.3): a per-layer show/hide toggle in `SupernoteAtelierView`.

- Bumps the `supernote-typescript` submodule to `v0.5.3`, which adds an optional `visibleSurfaces` filter to `SupernoteAtelier.toCompositeImage()`.
- `SupernoteAtelierView` now opens the `.spd` file once (`openAtelierFile`) and keeps the parsed `SupernoteAtelier` around, instead of the open-and-flatten-everything helper it used before. A checkbox per layer toggles that layer's surface in/out of a `Set`, and each toggle re-composites (`compositeDataUrl`) just the currently-checked surfaces — no re-parsing the sqlite database per click.
- Layer labels come from `SupernoteAtelier.layers` (decoded from the `ls` config) when available; falls back to raw `surface_N` table names otherwise, same graceful-degradation the parser itself already does.
- The toggle panel is skipped entirely for single-layer files — nothing to toggle, mirroring how `SupernoteEmbed` already skips its page-nav toolbar for a single-page `.note`.
- `SupernoteAtelierEmbed` and the `.spd` export commands (#140) are unaffected — they don't need toggle state, so they keep using `renderAtelierCompositeDataUrl()` (now refactored to share `openAtelierFile`/`compositeDataUrl` internally with the view instead of duplicating the wasm-loading boilerplate).

Still open on #138 after this: viewport/zoom, device attach/upload.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` — all 95 existing tests still pass
- [x] `npm run lint` — no new warnings/errors
- [x] Verified `toCompositeImage(visibleSurfaces)` against `supernote-typescript/tests/input/real-device.spd` outside the plugin (same path the toggle uses): hiding the "Reference Layer" surface leaves only the two sketch layers on a transparent background, and an empty visible set returns `null` — visually inspected the output
- [x] Not yet manually verified inside a running Obsidian vault (no automated Electron/GUI harness for this repo yet, same as prior `.spd` PRs)