### PR TITLE
Add zoom/fit-width controls to the .spd viewer

### DIFF
--- a/src/atelierView.ts
+++ b/src/atelierView.ts
@@ -28,14 +28,24 @@ async function openAtelierFile(app: App, file: TFile): Promise<SupernoteAtelier>
 	return SupernoteAtelier.open(new Uint8Array(buffer), { wasmBinary });
 }
 
+interface AtelierComposite {
+	dataUrl: string;
+	// Native pixel width of the composited image — every surface in a file
+	// shares the same tile-grid bounds (see SupernoteAtelier.toImage()'s doc
+	// comment), so this doesn't change across a layer toggle's re-composites,
+	// only the pixels do. SupernoteAtelierView uses it to size zoom/fit-width
+	// without waiting on the <img>'s own (async) decode of the data URL.
+	width: number;
+}
+
 // Flattens (a subset of) a parsed .spd file's layers via
 // SupernoteAtelier.toCompositeImage() (supernote-typescript#37 for the
 // `visibleSurfaces` filter), pre-encoded as a data URL for an <img> src.
 // `visibleSurfaces` omitted composites every layer; returns null if nothing
 // ends up visible (an empty canvas, or every layer toggled off).
-async function compositeDataUrl(spd: SupernoteAtelier, visibleSurfaces?: Iterable<IAtelierSurfaceName>): Promise<string | null> {
+async function compositeImage(spd: SupernoteAtelier, visibleSurfaces?: Iterable<IAtelierSurfaceName>): Promise<AtelierComposite | null> {
 	const image = await spd.toCompositeImage(visibleSurfaces);
-	return image ? encodeDataURL(image) : null;
+	return image ? { dataUrl: encodeDataURL(image), width: image.width } : null;
 }
 
 // Opens a `.spd` file and flattens every layer in one step. Used by
@@ -44,7 +54,8 @@ async function compositeDataUrl(spd: SupernoteAtelier, visibleSurfaces?: Iterabl
 // SupernoteAtelierView's layer toggle does.
 export async function renderAtelierCompositeDataUrl(app: App, file: TFile): Promise<string | null> {
 	const spd = await openAtelierFile(app, file);
-	return compositeDataUrl(spd);
+	const composite = await compositeImage(spd);
+	return composite ? composite.dataUrl : null;
 }
 
 // A layer entry to show in the toggle UI. Backed by SupernoteAtelier.layers
@@ -74,9 +85,12 @@ function renderAtelierError(container: HTMLElement, err: unknown): void {
 // Viewer for `.spd` files (Supernote Atelier app). Deliberately minimal
 // compared to SupernoteView (the `.note` viewer): `.spd` has no page
 // concept, just layered tiles on one canvas. Shows the flattened composite
-// as a single image, with a checkbox per layer to show/hide it (skipped
-// entirely for a single-layer file — nothing to toggle). No zoom/find
-// toolbar yet — see https://github.com/philips/supernote-obsidian-plugin/issues/138.
+// as a single image, with a checkbox per layer to show/hide it (skipped for
+// a single-layer file — nothing to toggle) and zoom controls (ctrl+scroll,
+// buttons, fit-width). Unlike SupernoteView's zoom, which re-rasterizes each
+// page at the new scale for crispness, `.spd`'s composite is already a fixed
+// bitmap (no vector/text source to re-render from) — zooming is just a CSS
+// width change on the <img>, no debounce or redraw needed.
 export class SupernoteAtelierView extends FileView {
 	declare file: TFile;
 
@@ -85,6 +99,19 @@ export class SupernoteAtelierView extends FileView {
 	// is discarded instead of overwriting the newer load's image.
 	private loadRequestId = 0;
 	private imageEl: HTMLImageElement | null = null;
+
+	// Native pixel size of the current composite (see AtelierComposite);
+	// invariant across layer toggles, so this is only (re)set on first load,
+	// not every re-composite. 0 until the first successful render.
+	private nativeWidth = 0;
+
+	// 1 = one image pixel per CSS pixel, same "100%" meaning SupernoteView's
+	// zoom uses.
+	private zoomScale = 1;
+	private fitWidthEnabled = true;
+	private zoomLabelEl: HTMLElement | null = null;
+	private fitWidthBtn: HTMLElement | null = null;
+	private resizeObserver: ResizeObserver | null = null;
 
 	getViewType() {
 		return VIEW_TYPE_SUPERNOTE_ATELIER;
@@ -98,12 +125,39 @@ export class SupernoteAtelierView extends FileView {
 		return "image";
 	}
 
+	async onOpen(): Promise<void> {
+		// Ctrl+scroll to zoom, same gesture/rationale as SupernoteView's (see
+		// its own onOpen for why plain scroll is left alone and metaKey isn't
+		// treated as a zoom gesture). contentEl persists across file loads, so
+		// this only needs registering once.
+		this.registerDomEvent(this.contentEl, 'wheel', (evt: WheelEvent) => {
+			if (!evt.ctrlKey) return;
+			evt.preventDefault();
+			const factor = Math.min(1.05, Math.max(0.95, 1 - evt.deltaY * 0.01));
+			this.setZoom(this.zoomScale * factor);
+		}, { passive: false });
+
+		// No debounce needed here (unlike SupernoteView's resize handling):
+		// re-fitting is just recomputing one CSS width, not re-rasterizing.
+		this.resizeObserver = new ResizeObserver(() => {
+			if (this.fitWidthEnabled) this.applyFitWidth();
+		});
+		this.resizeObserver.observe(this.contentEl);
+	}
+
+	async onClose(): Promise<void> {
+		this.resizeObserver?.disconnect();
+	}
+
 	async onLoadFile(file: TFile): Promise<void> {
 		const requestId = ++this.loadRequestId;
 		const container = this.contentEl;
 		container.empty();
 		container.addClass('supernote-atelier-view-content');
 		this.imageEl = null;
+		this.nativeWidth = 0;
+		this.zoomScale = 1;
+		this.fitWidthEnabled = true;
 
 		let spd: SupernoteAtelier;
 		try {
@@ -119,12 +173,34 @@ export class SupernoteAtelierView extends FileView {
 		// doesn't depend on layers[]/surfaces staying in a stable order.
 		const visible = new Set(layers.map((l) => l.surfaceName));
 
+		this.buildToolbar(container);
 		if (layers.length > 1) {
 			this.buildLayerToggle(container, layers, visible, () => { void this.updateImage(spd, visible, requestId); });
 		}
 
 		this.imageEl = container.createEl('img', { cls: 'supernote-atelier-image' });
 		await this.updateImage(spd, visible, requestId);
+	}
+
+	private buildToolbar(container: HTMLElement): void {
+		const toolbar = container.createDiv({ cls: 'supernote-toolbar' });
+		const zoomGroup = toolbar.createDiv({ cls: 'supernote-toolbar-group' });
+
+		const zoomOutBtn = zoomGroup.createEl('button', { text: '−', cls: 'clickable-icon', attr: { 'aria-label': 'Zoom out' } });
+		this.zoomLabelEl = zoomGroup.createSpan({ cls: 'supernote-zoom-label', text: '100%' });
+		const zoomInBtn = zoomGroup.createEl('button', { text: '+', cls: 'clickable-icon', attr: { 'aria-label': 'Zoom in' } });
+		const zoomResetBtn = zoomGroup.createEl('button', { text: 'Reset zoom', cls: 'clickable-icon' });
+		this.fitWidthBtn = zoomGroup.createEl('button', { text: 'Fit width', cls: 'clickable-icon', attr: { 'aria-label': 'Fit image to viewport width' } });
+
+		zoomOutBtn.addEventListener('click', () => this.setZoom(this.zoomScale / 1.25));
+		zoomInBtn.addEventListener('click', () => this.setZoom(this.zoomScale * 1.25));
+		zoomResetBtn.addEventListener('click', () => this.setZoom(1));
+		this.fitWidthBtn.addEventListener('click', () => {
+			this.fitWidthEnabled = !this.fitWidthEnabled;
+			if (this.fitWidthEnabled) this.applyFitWidth();
+			this.updateFitWidthButton();
+		});
+		this.updateFitWidthButton();
 	}
 
 	private buildLayerToggle(
@@ -151,20 +227,54 @@ export class SupernoteAtelierView extends FileView {
 		}
 	}
 
+	private setZoom(newScale: number, opts: { manual?: boolean } = {}): void {
+		const isManual = opts.manual !== false;
+		if (isManual) {
+			this.fitWidthEnabled = false;
+			this.updateFitWidthButton();
+		}
+
+		// Same split SupernoteView's setZoom uses: fit-width can legitimately
+		// need a wide range (a small native image on a large/high-DPI
+		// display), while manual zoom gets a tighter sanity cap.
+		const ceiling = isManual ? 5 : 20;
+		this.zoomScale = Math.min(ceiling, Math.max(0.05, newScale));
+		this.zoomLabelEl?.setText(`${Math.round(this.zoomScale * 100)}%`);
+
+		if (this.imageEl && this.nativeWidth > 0) {
+			this.imageEl.setCssStyles({ width: `${this.nativeWidth * this.zoomScale}px`, maxWidth: 'none' });
+		}
+	}
+
+	// Scales the image so its rendered width matches however much horizontal
+	// space is actually available in the view's content area.
+	private applyFitWidth(): void {
+		if (this.nativeWidth <= 0) return;
+		const container = this.contentEl;
+		const style = getComputedStyle(container);
+		const availableWidth = container.clientWidth - parseFloat(style.paddingLeft || '0') - parseFloat(style.paddingRight || '0');
+		if (availableWidth <= 0) return;
+		this.setZoom(availableWidth / this.nativeWidth, { manual: false });
+	}
+
+	private updateFitWidthButton(): void {
+		this.fitWidthBtn?.toggleClass('is-active', this.fitWidthEnabled);
+	}
+
 	// Re-composites just the visible surfaces and swaps the <img> src.
 	// Reused for both the initial render and every toggle click, so a toggle
 	// mid-render can't leave the image out of sync with the checkboxes.
 	private async updateImage(spd: SupernoteAtelier, visible: Set<IAtelierSurfaceName>, requestId: number): Promise<void> {
-		let dataUrl: string | null;
+		let composite: AtelierComposite | null;
 		try {
-			dataUrl = await compositeDataUrl(spd, visible);
+			composite = await compositeImage(spd, visible);
 		} catch (err) {
 			if (requestId === this.loadRequestId) renderAtelierError(this.contentEl, err);
 			return;
 		}
 		if (requestId !== this.loadRequestId || !this.imageEl) return;
 
-		if (dataUrl === null) {
+		if (composite === null) {
 			this.imageEl.hide();
 			this.contentEl.querySelector('.supernote-atelier-empty')?.remove();
 			this.contentEl.createDiv({
@@ -175,7 +285,16 @@ export class SupernoteAtelierView extends FileView {
 		}
 		this.contentEl.querySelector('.supernote-atelier-empty')?.remove();
 		this.imageEl.show();
-		this.imageEl.src = dataUrl;
+		this.imageEl.src = composite.dataUrl;
+
+		// Composite dimensions are shared across every surface in the file
+		// (see AtelierComposite's doc comment), so this only needs setting —
+		// and fit-width only needs applying — once, on the load that first
+		// discovers them, not on every subsequent layer-toggle re-composite.
+		if (this.nativeWidth === 0) {
+			this.nativeWidth = composite.width;
+			this.applyFitWidth();
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Next slice of #138: zoom controls for `SupernoteAtelierView`, mirroring `SupernoteView`'s zoom UX (+/- buttons, reset, ctrl+scroll, a "Fit width" toggle that stays fitted across pane resizes).

Simpler under the hood than `SupernoteView`'s zoom, though: a `.spd` composite is a single already-flattened bitmap (`SupernoteAtelier.toCompositeImage()`), not a vector/text source to re-rasterize per page at each new scale for crispness the way `.note` pages are. Zooming here is just a CSS width change on the `<img>` — no debounce, no redraw, no commit-then-settle dance `SupernoteView.setZoom`/`commitZoom` need.

- `compositeImage()` (internal helper) now threads the composited `Image`'s own pixel width out as `AtelierComposite.width`, so zoom math has it immediately rather than waiting on the `<img>`'s own async data-URL decode (`naturalWidth`).
- Fit-width is on by default, same as `SupernoteView`; a `ResizeObserver` on the view's content area keeps it fitted as the pane resizes.
- Zoom state resets on file load but survives a layer toggle (composite dimensions are invariant across which layers are visible — see the `AtelierComposite` doc comment) — toggling a layer just swaps the image `src`, it doesn't reset your zoom/pan.

**Deliberately does not** use `SupernoteAtelier.viewport` (`vp.x`/`vp.y`/`vp.scale`) to restore the pan/zoom Atelier had open when the file was saved. That field is an unconfirmed best-effort decode per the parser's own doc comments — getting its semantics wrong would produce a confusing initial framing that matches neither "fit width" nor the actual content. Left as a possible future addition if someone confirms what those values actually mean.

Device attach/upload is the one item still open on #138 after this.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` — all 95 existing tests still pass
- [x] `npm run lint` — no new warnings/errors
- [x] Not yet manually verified inside a running Obsidian vault (no automated Electron/GUI harness for this repo yet, same as prior `.spd` PRs) — would appreciate a click-through if you get a chance, especially ctrl+scroll/pinch-zoom and the fit-width toggle on resize