### PR TITLE
Include .spd files in device sync and "import edited today"

### DIFF
--- a/src/FileListModal.ts
+++ b/src/FileListModal.ts
@@ -43,12 +43,14 @@ export async function fetchSupernoteDirectory(ip: string, path: string): Promise
     return data.fileList.sort(compareByDirectoryThenNameThenDate);
 }
 
+const SYNCABLE_EXTENSION_PATTERN = /\.(note|spd)$/i;
+
 // Recursively walks the whole device tree starting at `path`, collecting
-// every `.note` file found. Shared by ImportTodayModal (which further
+// every `.note`/`.spd` file found. Shared by ImportTodayModal (which further
 // filters by date) and the device auto-sync engine (which filters by the
 // configured path patterns) — both need the same "list everything once"
 // traversal, just with different downstream filtering.
-export async function scanDeviceNoteTree(ip: string, path = '/', visited: Set<string> = new Set()): Promise<SupernoteFile[]> {
+export async function scanDeviceSupernoteTree(ip: string, path = '/', visited: Set<string> = new Set()): Promise<SupernoteFile[]> {
     if (visited.has(path)) return [];
     visited.add(path);
 
@@ -57,8 +59,8 @@ export async function scanDeviceNoteTree(ip: string, path = '/', visited: Set<st
 
     for (const entry of entries) {
         if (entry.isDirectory) {
-            results.push(...await scanDeviceNoteTree(ip, entry.uri, visited));
-        } else if (entry.name.toLowerCase().endsWith('.note')) {
+            results.push(...await scanDeviceSupernoteTree(ip, entry.uri, visited));
+        } else if (SYNCABLE_EXTENSION_PATTERN.test(entry.name)) {
             results.push(entry);
         }
     }

--- a/src/ImportTodayModal.ts
+++ b/src/ImportTodayModal.ts
@@ -1,6 +1,6 @@
 import { App, Modal, Notice, Editor } from 'obsidian';
 import SupernotePlugin from './main';
-import { SupernoteFile, scanDeviceNoteTree } from './FileListModal';
+import { SupernoteFile, scanDeviceSupernoteTree } from './FileListModal';
 import { fetchFromDevice, DEVICE_TRANSFER_TIMEOUT_MS } from './deviceFetch';
 import { parseDeviceDate, isSameLocalDay, todayLocalMidnight, formatDateInputValue, parseDateInputValue } from './deviceDate';
 import { ImportFormat, IMPORT_FORMAT_LABELS } from './settings';
@@ -38,7 +38,7 @@ export class ImportTodayModal extends Modal {
         // modal, instead of it applying to every CTA button in Obsidian (see
         // issue #74 — an unscoped rule shifted button text down app-wide).
         contentEl.addClass('supernote-import-modal');
-        contentEl.createEl('h2', { text: 'Import supernote pages' });
+        contentEl.createEl('h2', { text: 'Import supernote pages and drawings' });
         const status = contentEl.createEl('p', { text: 'Scanning device for notes…' });
 
         try {
@@ -137,11 +137,12 @@ export class ImportTodayModal extends Modal {
         }
     }
 
-    // Walks the whole device tree once and records every .note file's parsed
-    // date, so switching the date picker only needs to re-filter in memory
-    // instead of re-fetching the device's directory tree over HTTP each time.
+    // Walks the whole device tree once and records every .note/.spd file's
+    // parsed date, so switching the date picker only needs to re-filter in
+    // memory instead of re-fetching the device's directory tree over HTTP
+    // each time.
     private async scanAllNotes(): Promise<ScannedNote[]> {
-        const files = await scanDeviceNoteTree(this.plugin.settings.directConnectIP);
+        const files = await scanDeviceSupernoteTree(this.plugin.settings.directConnectIP);
         const results: ScannedNote[] = [];
         for (const file of files) {
             const modified = parseDeviceDate(file.date);

--- a/src/atelierView.ts
+++ b/src/atelierView.ts
@@ -11,13 +11,10 @@ import sqlWasmBinary from 'sql.js/dist/sql-wasm.wasm';
 export const VIEW_TYPE_SUPERNOTE_ATELIER = "supernote-atelier-view";
 
 // Opens a `.spd` file (Supernote Atelier app) via SupernoteAtelier.open()
-// (supernote-typescript#33). Shared by every entry point below — parsing the
-// sqlite database is the expensive part, so SupernoteAtelierView's layer
-// toggle (which needs to re-composite on every checkbox click) does this
-// once per file load and reuses the parsed SupernoteAtelier, rather than
-// re-parsing on every toggle.
-async function openAtelierFile(app: App, file: TFile): Promise<SupernoteAtelier> {
-	const buffer = await app.vault.readBinary(file);
+// (supernote-typescript#33), from raw bytes — a device fetch not yet
+// written into the vault (see renderAtelierCompositeFromBuffer), as well as
+// openAtelierFile below (an already-in-vault TFile).
+async function openAtelierBuffer(buffer: Uint8Array): Promise<SupernoteAtelier> {
 	// Uint8Array.buffer is typed ArrayBufferLike (could be a SharedArrayBuffer
 	// view) but sql.js's wasmBinary wants a plain ArrayBuffer; slice() always
 	// returns one sized to exactly this array's bytes.
@@ -25,7 +22,18 @@ async function openAtelierFile(app: App, file: TFile): Promise<SupernoteAtelier>
 		sqlWasmBinary.byteOffset,
 		sqlWasmBinary.byteOffset + sqlWasmBinary.byteLength,
 	) as ArrayBuffer;
-	return SupernoteAtelier.open(new Uint8Array(buffer), { wasmBinary });
+	return SupernoteAtelier.open(buffer, { wasmBinary });
+}
+
+// Opens a `.spd` file already in the vault. Shared by SupernoteAtelierView,
+// SupernoteAtelierEmbed, and VaultWriter's .spd export commands — parsing
+// the sqlite database is the expensive part, so SupernoteAtelierView's
+// layer toggle (which needs to re-composite on every checkbox click) does
+// this once per file load and reuses the parsed SupernoteAtelier, rather
+// than re-parsing on every toggle.
+async function openAtelierFile(app: App, file: TFile): Promise<SupernoteAtelier> {
+	const buffer = await app.vault.readBinary(file);
+	return openAtelierBuffer(new Uint8Array(buffer));
 }
 
 interface AtelierComposite {
@@ -48,12 +56,22 @@ async function compositeImage(spd: SupernoteAtelier, visibleSurfaces?: Iterable<
 	return image ? { dataUrl: encodeDataURL(image), width: image.width } : null;
 }
 
-// Opens a `.spd` file and flattens every layer in one step. Used by
-// SupernoteAtelierEmbed and VaultWriter's .spd export commands (see
-// main.ts), neither of which need repeated re-composites the way
+// Opens a `.spd` file already in the vault and flattens every layer in one
+// step. Used by SupernoteAtelierEmbed and VaultWriter's .spd export
+// commands, neither of which need repeated re-composites the way
 // SupernoteAtelierView's layer toggle does.
 export async function renderAtelierCompositeDataUrl(app: App, file: TFile): Promise<string | null> {
 	const spd = await openAtelierFile(app, file);
+	const composite = await compositeImage(spd);
+	return composite ? composite.dataUrl : null;
+}
+
+// Same as renderAtelierCompositeDataUrl, but from raw bytes rather than a
+// vault TFile — used by VaultWriter.buildInsertableContent's .spd import
+// path, where the file has just been fetched from a device and isn't (yet,
+// or ever, depending on the chosen import format) written into the vault.
+export async function renderAtelierCompositeFromBuffer(buffer: Uint8Array): Promise<string | null> {
+	const spd = await openAtelierBuffer(buffer);
 	const composite = await compositeImage(spd);
 	return composite ? composite.dataUrl : null;
 }

--- a/src/deviceSync.ts
+++ b/src/deviceSync.ts
@@ -1,7 +1,7 @@
-// Pure planning/decision logic for mirroring .note files from a Supernote
-// device (over "Browse and Access") into the vault, unmodified — see issue
-// #119. Sync only ever copies the raw .note file; it never converts it to
-// markdown/images/PDF (that's a separate, one-off "import" flow — see
+// Pure planning/decision logic for mirroring .note/.spd files from a
+// Supernote device (over "Browse and Access") into the vault, unmodified —
+// see issue #119. Sync only ever copies the raw file; it never converts it
+// to markdown/images/PDF (that's a separate, one-off "import" flow — see
 // ImportTodayModal/buildInsertableContent — which doesn't have to deal with
 // re-syncing or overwrite conflicts the way something that runs repeatedly
 // does). Deliberately has no dependency on Obsidian's API: everything here

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ import { replaceTextWithCustomDictionary } from './customDictionary';
 import { runDeviceSync, appendSyncLogEntry } from './syncEngine';
 import { formatSyncFailureLogEntry } from './deviceSync';
 import { parseLinkRect, bucketLinksByPage } from './linkOverlay';
-import { SupernoteAtelierEmbed, SupernoteAtelierView, VIEW_TYPE_SUPERNOTE_ATELIER, renderAtelierCompositeDataUrl } from './atelierView';
+import { SupernoteAtelierEmbed, SupernoteAtelierView, VIEW_TYPE_SUPERNOTE_ATELIER, renderAtelierCompositeDataUrl, renderAtelierCompositeFromBuffer } from './atelierView';
 import { PDFDocument } from 'pdf-lib';
 
 function generateTimestamp(): string {
@@ -79,6 +79,25 @@ async function assemblePdfFromImages(sn: SupernoteX, images: string[]): Promise<
         await addPdfPage(ctx, sn.pages[i], pngBytes);
     }
     return ctx.pdfDoc.save();
+}
+
+// Wraps a single already-rasterized PNG (as a data URL) in a one-page PDF,
+// at the same 300dpi-assumed-source-density sizing convention `.note`'s PDF
+// export uses (createPdfContext/addPdfPage above). Used for `.spd`, which
+// has no recognition/OCR text to lay an invisible text layer under the way
+// addPdfPage does for `.note` pages, so this builds directly with pdf-lib
+// instead. Shared by VaultWriter.exportAtelierToPDF and its
+// buildInsertableContent .spd import path.
+async function buildSinglePagePdf(pngDataUrl: string): Promise<Uint8Array> {
+    const pdfDoc = await PDFDocument.create();
+    const pngImage = await pdfDoc.embedPng(dataUrlToBuffer(pngDataUrl));
+    const dpi = 300;
+    const pointsPerPixel = 72 / dpi;
+    const widthPts = pngImage.width * pointsPerPixel;
+    const heightPts = pngImage.height * pointsPerPixel;
+    const pdfPage = pdfDoc.addPage([widthPts, heightPts]);
+    pdfPage.drawImage(pngImage, { x: 0, y: 0, width: widthPts, height: heightPts });
+    return pdfDoc.save();
 }
 
 // Builds a PDF with only the invisible recognized-text layer, no page images
@@ -371,11 +390,16 @@ class VaultWriter {
 	}
 
 	/**
-	 * Converts a Supernote .note file (fetched from a device, not yet in the
-	 * vault) into the requested format and returns markdown for inserting it
-	 * inline into another note, rather than creating a new .md file for it.
+	 * Converts a Supernote .note or .spd file (fetched from a device, not yet
+	 * in the vault) into the requested format and returns markdown for
+	 * inserting it inline into another note, rather than creating a new .md
+	 * file for it.
 	 */
 	async buildInsertableContent(deviceFileName: string, noteBuffer: ArrayBuffer, targetPath: string, format: ImportFormat): Promise<string> {
+		if (/\.spd$/i.test(deviceFileName)) {
+			return this.buildInsertableAtelierContent(deviceFileName, noteBuffer, targetPath, format);
+		}
+
 		const basename = deviceFileName.replace(/\.note$/i, '');
 
 		// These two formats save the raw .note file itself into the vault and
@@ -402,6 +426,41 @@ class VaultWriter {
 		const rasterized = await this.rasterizePages(sn);
 		const imgs = await this.writeImageFiles(basename, rasterized);
 		return this.renderPagesMarkdown(basename, sn, imgs, targetPath, format, deviceFileName, rasterized);
+	}
+
+	// `.spd` equivalent of buildInsertableContent above. `.spd` has no pages
+	// and no recognized/OCR text (see rasterizeAtelier's doc comment below),
+	// so 'images' and 'images-text' both reduce to the same single-image
+	// output — there's no per-page text for the latter to add that the
+	// former doesn't already have.
+	private async buildInsertableAtelierContent(deviceFileName: string, buffer: ArrayBuffer, targetPath: string, format: ImportFormat): Promise<string> {
+		const basename = deviceFileName.replace(/\.spd$/i, '');
+
+		if (format === 'note-link' || format === 'embed') {
+			const filename = await this.app.fileManager.getAvailablePathForAttachment(deviceFileName);
+			const tfile = await this.app.vault.createBinary(filename, buffer);
+			const link = this.app.fileManager.generateMarkdownLink(tfile, targetPath);
+			return `${format === 'embed' ? '!' : ''}${link}\n`;
+		}
+
+		const dataUrl = await renderAtelierCompositeFromBuffer(new Uint8Array(buffer));
+		if (dataUrl === null) {
+			throw new Error(`"${deviceFileName}" has no drawn content to import.`);
+		}
+
+		if (format === 'pdf') {
+			const pdfBytes = await buildSinglePagePdf(dataUrl);
+			const filename = await this.app.fileManager.getAvailablePathForAttachment(`${basename}.pdf`);
+			const tfile = await this.app.vault.createBinary(filename, toArrayBuffer(pdfBytes));
+			const link = this.app.fileManager.generateMarkdownLink(tfile, targetPath);
+			return `${link}\n`;
+		}
+
+		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${basename}.png`);
+		const tfile = await this.app.vault.createBinary(filename, dataUrlToBuffer(dataUrl));
+		const alt = this.settings.invertColorsWhenDark ? 'supernote-invert-dark' : '';
+		const link = generateMarkdownImageEmbed(this.app, tfile, targetPath, alt);
+		return `## ${basename}\n\n${link}\n`;
 	}
 
 	// Shared page-by-page markdown body (heading + optional recognized text +
@@ -465,22 +524,7 @@ class VaultWriter {
 
 	async exportAtelierToPDF(file: TFile) {
 		const dataUrl = await this.rasterizeAtelier(file);
-
-		// A single full-page image, same sizing convention
-		// createPdfContext/addPdfPage use for `.note` pages (see pdf.ts in
-		// supernote-typescript): 300dpi assumed source density, converted to
-		// PDF points (72/inch). `.spd` has no recognition/OCR text to lay an
-		// invisible text layer under, so this builds the PDF directly with
-		// pdf-lib rather than going through that `.note`-specific machinery.
-		const pdfDoc = await PDFDocument.create();
-		const pngImage = await pdfDoc.embedPng(dataUrlToBuffer(dataUrl));
-		const dpi = 300;
-		const pointsPerPixel = 72 / dpi;
-		const widthPts = pngImage.width * pointsPerPixel;
-		const heightPts = pngImage.height * pointsPerPixel;
-		const pdfPage = pdfDoc.addPage([widthPts, heightPts]);
-		pdfPage.drawImage(pngImage, { x: 0, y: 0, width: widthPts, height: heightPts });
-		const pdfBytes = await pdfDoc.save();
+		const pdfBytes = await buildSinglePagePdf(dataUrl);
 
 		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}.pdf`);
 		await this.app.vault.createBinary(filename, toArrayBuffer(pdfBytes));
@@ -1990,7 +2034,7 @@ export default class SupernotePlugin extends Plugin {
 
 		this.addCommand({
 			id: 'import-todays-pages',
-			name: "Import notes edited today",
+			name: "Import notes and drawings edited today",
 			editorCallback: (editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
 				if (this.settings.directConnectIP.length === 0) {
 					new DirectConnectErrorModal(this.app, this.settings, new Error("IP is unset")).open();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -17,11 +17,11 @@ export const FILE_BROWSER_SORT_LABELS: Record<FileBrowserSortOrder, string> = {
 export type ImportFormat = 'note-link' | 'embed' | 'images' | 'pdf' | 'images-text';
 
 export const IMPORT_FORMAT_LABELS: Record<ImportFormat, string> = {
-    'note-link': 'Notes (save .note)',
-    'embed': 'Embedded note (save .note file, embed it)',
+    'note-link': 'Original file (save .note/.spd, link to it)',
+    'embed': 'Embedded original file (save .note/.spd file, embed it)',
     'images': 'Images only',
     'pdf': 'PDF',
-    'images-text': 'Images and text',
+    'images-text': 'Images and text (text only available for .note)',
 };
 
 // Obsidian's declarative settings API (1.13+): PluginSettingTab.getSettingDefinitions().

--- a/src/syncEngine.ts
+++ b/src/syncEngine.ts
@@ -1,6 +1,6 @@
 import { App, TFile } from 'obsidian';
 import { SupernotePluginSettings } from './settings';
-import { scanDeviceNoteTree } from './FileListModal';
+import { scanDeviceSupernoteTree } from './FileListModal';
 import { fetchFromDevice, DEVICE_TRANSFER_TIMEOUT_MS } from './deviceFetch';
 import {
     DeviceNoteListing,
@@ -95,8 +95,8 @@ async function currentHash(app: App, vaultPath: string): Promise<string | null> 
 // manifest. Deliberately thin — all the actual decision-making lives in
 // deviceSync.ts and is unit tested there; this just wires those pure
 // decisions up to real device fetches and vault writes. Sync only ever
-// copies the raw .note file byte-for-byte — no rendering, no format choice —
-// see deviceSync.ts's top-of-file comment for why.
+// copies the raw .note/.spd file byte-for-byte — no rendering, no format
+// choice — see deviceSync.ts's top-of-file comment for why.
 export async function runDeviceSync(
     app: App,
     settings: SupernotePluginSettings,
@@ -107,7 +107,7 @@ export async function runDeviceSync(
         throw new Error('Supernote IP is unset');
     }
 
-    const deviceFiles = await scanDeviceNoteTree(ip);
+    const deviceFiles = await scanDeviceSupernoteTree(ip);
     const listings: DeviceNoteListing[] = deviceFiles.map((f) => ({ uri: f.uri, date: f.date, size: f.size }));
     const patterns = parsePathFilters(settings.syncPathFiltersRaw);
     const plan = planSync(listings, settings.noteSyncState, patterns);


### PR DESCRIPTION
## Summary

Last two items on #138.

**Attach/upload to device** turns out to need no code changes: `DownloadListModal`/`UploadListModal` already list/download/upload whatever file is clicked or active, with no extension filtering anywhere in that path. `.spd` files can already be attached from or uploaded to a device today — confirmed by reading through `FileListModal.ts` end to end, the only `.note`-specific filtering in that file was in `scanDeviceNoteTree` (see below), which those two modals don't use.

**Device sync + "import edited today"** did need changes, since both walk the device tree through `scanDeviceNoteTree`, which hardcoded a `.note`-only filter:

- Renamed to `scanDeviceSupernoteTree` and now matches `.note` **or** `.spd`.
- **Device sync** (`runDeviceSync`) needed nothing else — it already only ever byte-copies whatever the scan hands it, with zero format-specific logic downstream (confirmed via `deviceSync.ts`'s pure planning logic and `syncEngine.ts`'s raw-fetch-and-write loop).
- **"Import notes edited today"** (`ImportTodayModal` → `VaultWriter.buildInsertableContent`) does interpret file content per format, so `buildInsertableContent` now branches on `.spd` and dispatches to a new `buildInsertableAtelierContent`:
  - Reuses a new `renderAtelierCompositeFromBuffer()` (same as the existing `renderAtelierCompositeDataUrl()`, but from a raw device-fetched buffer instead of a vault `TFile` — the file isn't necessarily in the vault yet at this point).
  - Reuses a new `buildSinglePagePdf()` helper, factored out of `exportAtelierToPDF` so the pdf-lib page-sizing math isn't duplicated between the existing export command and this new import path.
  - `.spd` has no pages and no recognized/OCR text, so `'images'` and `'images-text'` produce the same single-image output for it — there's no per-page text for `'images-text'` to add that `'images'` doesn't already have.
- `IMPORT_FORMAT_LABELS`' wording no longer implies `.note`-only (`"Notes (save .note)"` → `"Original file (save .note/.spd, link to it)"`, etc.), and flags that the text half of "Images and text" is `.note`-only.
- Renamed the `import-todays-pages` command's **display name** (not its `id`, to preserve existing hotkey bindings) to "Import notes and drawings edited today", per the issue's own suggested wording. Also updated the modal's own heading text.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` — all 95 existing tests still pass (none of them covered `scanDeviceNoteTree`/sync's file-tree scanning directly — it's pure HTTP/device-facing code with no existing unit test seam — so this relies on the build+lint+manual-reasoning route already used for the other `.spd` PRs)
- [x] `npm run lint` — no new warnings/errors
- [x] Verified the buffer-based import path (`renderAtelierCompositeFromBuffer` → `buildSinglePagePdf`) end-to-end outside the plugin against `supernote-typescript/tests/input/real-device.spd`, simulating a raw device fetch (not a vault file) — produces byte-identical output to the already-verified vault-file path from prior `.spd` PRs
- [x] Not yet manually verified inside a running Obsidian vault against a real device (no automated Electron/GUI harness for this repo yet, same as prior `.spd` PRs)