### PR TITLE
Expose keywords/links/pageId/orientation/recognitionStatus to OCR plugins

### DIFF
--- a/ocr-plugins.md
+++ b/ocr-plugins.md
@@ -98,6 +98,11 @@ with:
 | `text` | `string` | This page's text so far: the device's own recognized text, if any, already run through any earlier-registered processors. Empty string if none |
 | `imageMimeType` | `string` | MIME type of what `readImage()` resolves to. Currently always `"image/png"` — read it rather than assuming, in case that changes |
 | `readImage()` | `() => Promise<ArrayBuffer>` | This page's rasterized image bytes. Raw bytes, not a vault `TFile` — this runs whether or not the export actually wants images saved into the vault, so there may be no `TFile` backing it at all |
+| `keywords` | `string[]` | This page's starred keywords, exactly as the device's own recognition read them. Raw OCR'd text, deduplicated — not sanitized into Obsidian tag form; that's a choice for your processor to make. Most starred keywords never appear as literal text elsewhere on the page, so this is the only way to see them at all |
+| `links` | `ILink[]` (from `supernote-typescript`) | This page's own internal links (Supernote's link feature). Same-file page anchors are already resolved (`ILink.text` gets `#Page N` appended). Cross-file anchors are not — `ILink.LINKFILE` is the base64-encoded absolute device path of the target `.note` file if you want to resolve that yourself |
+| `pageId` | `string` | This page's own `PAGEID`, if any (empty string otherwise) — the identifier other notes' links resolve against |
+| `orientation` | `string` | This page's orientation, exactly as recorded in the `.note` file |
+| `recognitionStatus` | `RecognitionStatuses` (from `supernote-typescript`) | Whether the device's own handwriting recognition ran on this page, and whether it completed. Distinguishes "never ran" and "ran, found nothing" from `text` alone, which conflates both with "ran and found nothing" |
 
 Pages are processed one at a time, in order — `pageNumber` reliably starts
 at 1 and counts up for a given run, with no concurrent calls to interleave.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { installAtPolyfill } from './polyfills';
 import { App, Modal, Notice, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, Component, loadPdfJs, Scope, SearchComponent, setIcon, Platform } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS, ImportFormat } from './settings';
-import { SupernoteX, ILink, fetchMirrorFrame, createPdfContext, addPdfPage, addTextOnlyPdfPage } from 'supernote-typescript';
+import { SupernoteX, ILink, RecognitionStatuses, fetchMirrorFrame, createPdfContext, addPdfPage, addTextOnlyPdfPage } from 'supernote-typescript';
 import { encode } from 'image-js';
 import { DownloadListModal, UploadListModal } from './FileListModal';
 import { ImportTodayModal } from './ImportTodayModal';
@@ -263,6 +263,61 @@ export interface PageTextProcessorContext {
 	 *  actually wants image files saved into the vault, so there may be no
 	 *  TFile backing it at all. */
 	readImage(): Promise<ArrayBuffer>;
+	/** This page's starred keywords, as Supernote's own handwriting
+	 *  recognition read them (`IKeyword.KEYWORD`) — raw OCR'd text, in
+	 *  encounter order, deduplicated. Not sanitized into Obsidian tag form;
+	 *  that's a choice for whichever processor consumes this. Most starred
+	 *  keywords never appear as literal text elsewhere on the page, so this
+	 *  is the only way an external processor can see them at all. */
+	keywords: string[];
+	/** This page's own internal links (Supernote's link feature). Same-file
+	 *  page anchors are already resolved (`ILink.text` gets `#Page N`
+	 *  appended). Cross-file anchors are not — `ILink.LINKFILE` is the
+	 *  base64-encoded absolute device path of the target `.note` file, for a
+	 *  processor that wants to resolve that itself. */
+	links: ILink[];
+	/** This page's own PAGEID, if any — the identifier other notes' links
+	 *  resolve against (empty string if the page has none). */
+	pageId: string;
+	/** This page's orientation, exactly as recorded in the `.note` file. */
+	orientation: string;
+	/** Whether the device's own handwriting recognition ran on this page,
+	 *  and whether it completed — distinguishes "recognition never ran"
+	 *  and "ran, found nothing" from `text` alone, which conflates both with
+	 *  "recognition ran and found nothing". */
+	recognitionStatus: RecognitionStatuses;
+}
+
+// This page's starred keywords (IKeyword.KEYWORD), deduplicated. sn.keywords'
+// Record keys encode the 1-indexed page as their first 4 characters — the
+// same convention _parseLinks documents for sn.links (see collectPageLinks
+// below), and more reliable than IKeyword.KEYWORDPAGE, which can be '0'
+// (invalid).
+function collectPageKeywords(sn: SupernoteX, pageIndex: number): string[] {
+	const seen = new Set<string>();
+	const result: string[] = [];
+	for (const [key, entries] of Object.entries(sn.keywords)) {
+		if (parseInt(key.slice(0, 4)) - 1 !== pageIndex) continue;
+		for (const entry of entries) {
+			const text = entry.KEYWORD.trim();
+			if (text.length === 0 || seen.has(text)) continue;
+			seen.add(text);
+			result.push(text);
+		}
+	}
+	return result;
+}
+
+// This page's own links. See supernote-typescript's _parseLinks doc comment
+// for why sn.links' Record keys (not ILink.OBJPAGE) are the reliable way to
+// find which page a link is drawn on.
+function collectPageLinks(sn: SupernoteX, pageIndex: number): ILink[] {
+	const result: ILink[] = [];
+	for (const [key, entries] of Object.entries(sn.links)) {
+		if (parseInt(key.slice(0, 4)) - 1 !== pageIndex) continue;
+		result.push(...entries);
+	}
+	return result;
 }
 
 // Return the page's new text (replacing `ctx.text` entirely — a processor
@@ -287,19 +342,28 @@ class VaultWriter {
 	// writing that image out as a vault attachment — callers rasterize on
 	// demand (see rasterizePages()) whenever processors are registered, even
 	// for a markdown-only export that wouldn't otherwise touch images at all.
-	private async applyPageTextProcessors(sourceName: string, pageIndex: number, totalPages: number, text: string, imageDataUrl: string | undefined): Promise<string> {
+	private async applyPageTextProcessors(sourceName: string, pageIndex: number, sn: SupernoteX, text: string, imageDataUrl: string | undefined): Promise<string> {
 		if (!imageDataUrl || this.processors.size === 0) return text;
+
+		const page = sn.pages[pageIndex];
+		const keywords = collectPageKeywords(sn, pageIndex);
+		const links = collectPageLinks(sn, pageIndex);
 
 		let result = text;
 		for (const processor of this.processors) {
 			try {
 				const out = await processor({
 					pageNumber: pageIndex + 1,
-					totalPages,
+					totalPages: sn.pages.length,
 					sourceName,
 					text: result,
 					imageMimeType: dataUrlMimeType(imageDataUrl),
 					readImage: async () => dataUrlToBuffer(imageDataUrl),
+					keywords,
+					links,
+					pageId: page.PAGEID ?? '',
+					orientation: page.ORIENTATION,
+					recognitionStatus: page.RECOGNSTATUS,
 				});
 				if (out !== null && out !== undefined) result = out;
 			} catch (err) {
@@ -338,7 +402,7 @@ class VaultWriter {
 			let pageText = sn.pages[i].text !== undefined && sn.pages[i].text.length > 0
 				? processSupernoteText(sn.pages[i].text, this.settings)
 				: '';
-			pageText = await this.applyPageTextProcessors(file.name, i, sn.pages.length, pageText, images?.[i]);
+			pageText = await this.applyPageTextProcessors(file.name, i, sn, pageText, images?.[i]);
 			if (pageText.length > 0) {
 				content += `${pageText}\n`;
 			}
@@ -473,7 +537,7 @@ class VaultWriter {
 				let pageText = sn.pages[i].text !== undefined && sn.pages[i].text.length > 0
 					? processSupernoteText(sn.pages[i].text, this.settings)
 					: '';
-				pageText = await this.applyPageTextProcessors(sourceName, i, sn.pages.length, pageText, rasterized[i]);
+				pageText = await this.applyPageTextProcessors(sourceName, i, sn, pageText, rasterized[i]);
 				if (pageText.length > 0) {
 					content += `${pageText}\n`;
 				}


### PR DESCRIPTION
## Summary

Implements the field additions discussed in #145 (a follow-up from #144's [prototype](https://github.com/philips/supernote-obsidian-ocr-keywords), which found the `registerPageTextProcessor` hook couldn't reproduce PR #122/#123's native keyword-star/link handling from outside the plugin).

Extends `PageTextProcessorContext` with:

- `keywords: string[]` - this page's starred keywords, raw OCR'd text, deduplicated
- `links: ILink[]` - this page's own internal links, same-file anchors already resolved
- `pageId: string` - this page's own `PAGEID`
- `orientation: string` - this page's orientation as recorded in the `.note` file
- `recognitionStatus: RecognitionStatuses` - whether recognition ran/completed on this page, distinguishing that from `text` being merely empty

`keywords`/`links` are grouped per page using the same "first 4 characters of the `sn.keywords`/`sn.links` Record key = 1-indexed page" convention `supernote-typescript`'s `_parseLinks` already documents (more reliable than `IKeyword.KEYWORDPAGE`, which can be `'0'`/invalid).

**Titles were considered and dropped from this pass** - `ITitle` has no decoded text (only `TITLERECT` + a bitmap), so producing title text would need correlating that rectangle against `page.recognitionElements`' word-level boxes, which is new logic, not just wiring through an existing field. Left for a follow-up once that's designed.

**Stacked on [supernote-typescript#38](https://github.com/philips/supernote-typescript/pull/38)**, which exports `RecognitionStatuses` from that library's index (needed so `recognitionStatus` can be typed as the real enum rather than a bare string) - this PR's submodule pointer currently points at that branch, not `main`. Rebase the pointer once #38 merges.

## Test plan
- [x] `npm run build` (both submodule and plugin) - clean
- [x] `npx tsc --noEmit` - clean
- [x] `npx eslint src/main.ts` - 0 errors
- [x] `npx vitest run` - 95 passed
- [x] Manually verified `collectPageKeywords`/`collectPageLinks` against a real device-created fixture (`supernote-typescript/tests/input/nomad-3.26.40-link-tag-3p.note`) - keywords landed on the correct page (3), links resolved to the correct target pages (2), `pageId`/`orientation`/`recognitionStatus` all populated as expected
- [ ] Manual test in Obsidian: a companion plugin registering a processor and logging `ctx.keywords`/`ctx.links`/`ctx.pageId`/`ctx.orientation`/`ctx.recognitionStatus` against a real note with starred keywords and internal links