### PR TITLE
Add stage-by-stage logging to the search text-layer pipeline (#147 diagnostics)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -113,8 +113,15 @@ async function buildSinglePagePdf(pngDataUrl: string): Promise<Uint8Array> {
 async function assembleTextOnlyPdf(sn: SupernoteX): Promise<Uint8Array> {
     const ctx = await createPdfContext();
     for (let i = 0; i < sn.pages.length; i++) {
+        // Per-page, not just before/after the whole loop: if this ever hangs
+        // or crashes partway through (see issue #147 - a hard crash with no
+        // catchable JS error, so the only trace of it is whatever was last
+        // logged), the last page number logged narrows it down to one page's
+        // recognition data rather than "somewhere in this note".
+        console.debug(`Supernote: text-only PDF — page ${i + 1}/${sn.pages.length}`);
         await addTextOnlyPdfPage(ctx, sn.pages[i], sn.pageWidth, sn.pageHeight);
     }
+    console.debug(`Supernote: text-only PDF — saving (${sn.pages.length} page(s))`);
     return ctx.pdfDoc.save();
 }
 
@@ -1043,9 +1050,20 @@ export class SupernoteView extends FileView {
 		// assemblePdfFromImages(), since this PDF is only ever handed to
 		// pdf.js for getTextContent()/getViewport(), never rendered/shown.
 		this.pdfDocPromise = (async () => {
+			// Logged stage-by-stage (see issue #147): a hard native crash
+			// here has no catchable JS error to report — ensureTextLayer()'s
+			// own try/catch only fires for an ordinary thrown exception, and
+			// wouldn't run at all if nothing ever scrolled a page into view.
+			// The last of these lines to print is the closest thing to a
+			// stack trace such a crash leaves behind.
+			console.debug('Supernote: search text layer — building text-only PDF…');
 			const pdfBytes = await assembleTextOnlyPdf(sn);
+			console.debug(`Supernote: search text layer — text-only PDF built (${pdfBytes.byteLength} bytes), loading pdf.js…`);
 			this.pdfjsLib = await loadPdfJs() as PdfJsLib;
-			return this.pdfjsLib.getDocument({ data: pdfBytes }).promise;
+			console.debug('Supernote: search text layer — pdf.js loaded, parsing PDF…');
+			const pdfDoc = await this.pdfjsLib.getDocument({ data: pdfBytes }).promise;
+			console.debug('Supernote: search text layer — ready');
+			return pdfDoc;
 		})();
 	}
 
@@ -1126,6 +1144,10 @@ export class SupernoteView extends FileView {
 		state.textLayerLoaded = true; // set eagerly: no double-trigger race
 
 		try {
+			// See issue #147: if this ever crashes hard (no catchable JS
+			// error), the last of these lines to print is the closest thing
+			// to a stack trace it leaves behind.
+			console.debug(`Supernote: text layer — page ${state.pageNumber} awaiting PDF…`);
 			const pdfDoc = await this.pdfDocPromise;
 			if (!pdfDoc) return;
 
@@ -1134,8 +1156,10 @@ export class SupernoteView extends FileView {
 			}
 			const pdfPage = state.pdfPage;
 
+			console.debug(`Supernote: text layer — page ${state.pageNumber} building…`);
 			const viewport = pdfPage.getViewport({ scale: this.zoomScale });
 			await this.buildTextLayerForState(pdfPage, state, viewport);
+			console.debug(`Supernote: text layer — page ${state.pageNumber} ready`);
 		} catch (error) {
 			console.error(`Failed to build text layer for page ${state.pageNumber}:`, error);
 		}


### PR DESCRIPTION
## Summary

Diagnostic-only change for #147 (crash/"boot loop" opening a specific `.note` file on iOS). Not a fix - we don't have a confirmed root cause yet, and this is intended to get one.

What we know so far: the reporter's note is only 8 pages; the render-completion log (`main.ts:1027`, after parsing/rasterization/`ImageBitmap` decode/canvas draw for all pages succeed) is the last thing that ever printed - even with Safari's Web Inspector attached live to the device. That rules out parsing/rasterization/canvas rendering as the cause for this report, and points at whatever runs immediately after: the fire-and-forget pipeline that builds a text-only PDF (`assembleTextOnlyPdf`/`pdf-lib`) purely so pdf.js can provide a search/select text layer, plus each visible page's own text-layer build in `ensureTextLayer()`.

The concerning part: `ensureTextLayer()` already wraps its work in try/catch and logs `Failed to build text layer for page N: ...` on any ordinary thrown exception - and that log never appeared either, with the inspector attached. Whatever's happening is severe enough to leave no catchable JS error and no further console output at all - consistent with a hard native/WASM-level crash or an unresponsive-script watchdog kill, not a normal bug we could just try/catch our way out of blind.

## Changes
Adds `console.debug` checkpoints stage-by-stage:
- `assembleTextOnlyPdf`: per-page, plus before saving
- The `pdfDocPromise` IIFE in `onLoadFile()`: before/after building the PDF, loading pdf.js, and parsing it
- `ensureTextLayer()`: before awaiting the PDF and before/after building each page's own text layer

Whichever line prints last next time narrows this from "somewhere in a ~6-stage pipeline with zero visibility" down to one specific stage, or one specific page's recognition data - actionable next-step info instead of another log line identical to what we already have.

## Test plan
- [x] `npx tsc --noEmit` - clean
- [x] `npx eslint src/main.ts` - 0 errors
- [x] `npx vitest run` - 95 passed
- [x] `npm run build` - clean
- [ ] Reporter to reproduce with this build and share whichever `console.debug` line prints last