### PR TITLE
Lazy-load each page's image, not just its text layer

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -133,11 +133,7 @@ function processSupernoteText(text: string, settings: SupernotePluginSettings): 
 	return processedText;
 }
 
-// Splits pageNumbers into at most `workerCount` chunks. Callers that then map
-// chunks[i] -> workers[i % workers.length] are guaranteed each worker gets at
-// most one chunk (chunks.length <= workers.length), so processing chunks
-// concurrently via Promise.all never has two in-flight calls fighting over
-// the same worker's onmessage handler.
+// Splits pageNumbers into at most `workerCount` chunks.
 function chunkPageNumbers(pageNumbers: number[], workerCount: number): number[][] {
     const chunkSize = Math.ceil(pageNumbers.length / workerCount);
     const chunks: number[][] = [];
@@ -149,15 +145,49 @@ function chunkPageNumbers(pageNumbers: number[], workerCount: number): number[][
 
 export class WorkerPool {
     private workers: Worker[];
+    // Chained onto so a new request to a given worker waits for that
+    // worker's previous request to actually resolve/reject before sending -
+    // see processChunk()'s comment for why this matters.
+    private queues: Promise<void>[];
+    // Round-robins across every call to processChunk(), not just within one
+    // processPages() call - see processChunk()'s comment.
+    private nextWorker = 0;
 
     constructor(private maxWorkers: number = navigator.hardwareConcurrency) {
         this.workers = Array(maxWorkers).fill(null).map(() =>
             new Worker()
         );
+        this.queues = this.workers.map(() => Promise.resolve());
     }
 
-    private processChunk(worker: Worker, note: SupernoteX, pageNumbers: number[]): Promise<string[]> {
-        return new Promise((resolve, reject) => {
+    // Picks the next worker (round-robin across every call this pool ever
+    // makes, not reset per processPages() call - see below) and queues onto
+    // it rather than sending immediately.
+    //
+    // This used to just take a worker directly, relying on callers to keep
+    // at most one in-flight request per worker (safe when processPages() was
+    // the only caller: a single call's chunks always spread 1:1 across
+    // distinct workers). Lazy per-page image loading (SupernoteView's
+    // ensurePageImage(), see issue #147) broke that assumption - each is its
+    // own separate processPages() call for a single page, which
+    // chunkPageNumbers() always turns into exactly one chunk, previously
+    // always dispatched to workers[0] (chunks.map's index is always 0 for a
+    // one-chunk call). Several pages loading nearly at once (a fast scroll,
+    // or the thumbnail sidebar loading every page at once) meant several
+    // concurrent requests all landing on worker 0, each overwriting the
+    // last's onmessage handler before its response arrived - silently
+    // losing that page's result (rendered blank) or misdirecting it to
+    // resolve a *different* page's promise instead (wrong image on the
+    // wrong page). Queuing per-worker (so a worker only ever has one
+    // request in flight) and round-robining across every call (so
+    // concurrent single-page requests still spread across every worker,
+    // instead of piling onto worker 0) fixes both.
+    private processChunk(note: SupernoteX, pageNumbers: number[]): Promise<string[]> {
+        const workerIndex = this.nextWorker % this.workers.length;
+        this.nextWorker++;
+        const worker = this.workers[workerIndex];
+
+        const send = (): Promise<string[]> => new Promise((resolve, reject) => {
             worker.onmessage = (e: MessageEvent<SupernoteWorkerResponse>) => {
                 if (e.data.type === 'error') {
                     reject(new Error(e.data.error));
@@ -179,6 +209,14 @@ export class WorkerPool {
 
             worker.postMessage(message);
         });
+
+        const result = this.queues[workerIndex].then(send);
+        // Marks this worker free again once this request settles, regardless
+        // of outcome - a failed request shouldn't leave the next one waiting
+        // forever. Deliberately swallows the rejection here: `result` (what
+        // this call actually returns) still carries it to its own caller.
+        this.queues[workerIndex] = result.then(() => undefined, () => undefined);
+        return result;
     }
 
     async processPages(note: SupernoteX, allPageNumbers: number[]): Promise<string[]> {
@@ -188,11 +226,11 @@ export class WorkerPool {
 
         //console.log(`Processing ${allPageNumbers.length} pages in ${chunks.length} chunks`);
 
-        // Process chunks in parallel using available workers
+        // Process chunks concurrently - safe now regardless of how many land
+        // on the same worker, or how many separate processPages() calls are
+        // in flight at once (see processChunk()'s comment).
         const results = await Promise.all(
-            chunks.map((chunk, index) =>
-                this.processChunk(this.workers[index % this.workers.length], note, chunk)
-            )
+            chunks.map((chunk) => this.processChunk(note, chunk))
         );
 
         //console.timeEnd('Total processing time');

--- a/src/main.ts
+++ b/src/main.ts
@@ -1029,25 +1029,19 @@ export class SupernoteView extends FileView {
 			};
 			this.pageStates.push(state);
 
-			// Canvas doesn't get native image drag-out the way <img> did; wire it up
-			// manually against the same page PNG the canvas is rendered from. This
-			// is best-effort — worth confirming it actually reproduces useful
-			// drag-and-drop behavior in a real vault, since the pre-canvas <img>
-			// drag may not have produced a proper vault attachment link either.
-			// state.imageDataUrl is null until ensurePageImage() loads this page —
-			// dragging one out before that (very unlikely; by the time a user can
-			// interact with a canvas it's almost certainly already in view and
-			// thus already loading/loaded) just cancels the drag.
-			canvas.draggable = true;
-			canvas.addEventListener('dragstart', (evt) => {
-				if (!evt.dataTransfer || !state.imageDataUrl) {
-					evt.preventDefault();
-					return;
-				}
-				evt.dataTransfer.setData('text/uri-list', state.imageDataUrl);
-				evt.dataTransfer.setData('text/plain', state.imageDataUrl);
-				evt.dataTransfer.setDragImage(canvas, 0, 0);
-			});
+			// Deliberately NOT draggable. A previous version wired up manual
+			// drag-out (canvas doesn't get it natively the way <img> does) by
+			// putting the page's raw data: URL straight into the drag data —
+			// dropping that into a note inserts the *entire* base64-encoded
+			// PNG as literal text (there's no vault file to link to; nothing
+			// was ever saved), which for a real page-resolution image is
+			// enough text to lock up the editor. "Save image to vault" below
+			// is the safe equivalent: it creates a real attachment file and
+			// only does so on an explicit click, not on every page anyone
+			// happens to view. A correct drag-out would need the same
+			// save-to-vault to finish *before* the drop, and dataTransfer can
+			// only be populated synchronously inside dragstart — not
+			// attempted here for that reason. See #152.
 
 			for (const link of linksByPage.get(i) ?? []) {
 				const rect = parseLinkRect(link.LINKRECT);

--- a/src/main.ts
+++ b/src/main.ts
@@ -675,8 +675,17 @@ type PageRenderState = {
 	linkEls: { el: HTMLElement; rect: [number, number, number, number] }[];
 	// Decoded once from the already-rasterized page image and reused for
 	// every zoom redraw (see drawPageImage()) — no pdf.js/decode work on the
-	// zoom-critical path.
+	// zoom-critical path. null until ensurePageImage() loads it.
 	imageBitmap: ImageBitmap | null;
+	// This page's rasterized PNG data URL, once ensurePageImage() loads it —
+	// needed for the canvas's drag-out and the "Save image to vault" button,
+	// which previously closed over a local `imageDataUrl` that no longer
+	// exists once every page isn't rasterized up front.
+	imageDataUrl: string | null;
+	// In-flight/completed load, so a page nearing the viewport (pageObserver),
+	// an explicit jump (goToPage), and "Save image to vault" can't each kick
+	// off their own separate rasterization of the same page.
+	imageLoadPromise: Promise<void> | null;
 	// Guards ensureTextLayer()'s one-time (per page) work.
 	textLayerLoaded: boolean;
 	text: string;
@@ -702,6 +711,10 @@ export class SupernoteView extends FileView {
 	// same-file link's PAGEID resolve to a page number without retaining the
 	// whole parsed SupernoteX. See handleLinkClick().
 	private pageIds: string[] = [];
+	// Retained (rather than a local in onLoadFile) so ensurePageImage() can
+	// rasterize a single page on demand, well after onLoadFile() itself has
+	// returned — see issue #147.
+	private sn: SupernoteX | null = null;
 
 	private zoomScale = 1;
 	private renderedZoomScale = 1;
@@ -735,6 +748,10 @@ export class SupernoteView extends FileView {
 	private thumbToggleBtn: HTMLElement | null = null;
 	private thumbSidebarEl: HTMLElement | null = null;
 	private thumbItems: HTMLElement[] = [];
+	// Parallel to thumbItems/pageStates — empty (no `src`) until
+	// ensurePageImage() loads that page, or until the sidebar is first
+	// opened (see toggleThumbnails()), whichever happens first.
+	private thumbImgs: HTMLImageElement[] = [];
 
 	private headerEl: HTMLElement | null = null;
 	private pageJumpInput: HTMLInputElement | null = null;
@@ -851,17 +868,21 @@ export class SupernoteView extends FileView {
 		});
 		this.resizeObserver.observe(this.contentEl);
 
-		// Loads each page's selectable text lazily, only once it's about to
-		// scroll into view (rootMargin prefetches a screen ahead/behind so it
-		// feels instant by the time you actually get there) — for a long note,
-		// building N pages' worth of text-layer DOM upfront is real, mostly
-		// wasted work if you only ever look at the first few. Re-observes
-		// fresh page containers each file load; see onLoadFile().
+		// Loads each page's image and selectable text lazily, only once it's
+		// about to scroll into view (rootMargin prefetches a screen ahead/
+		// behind so it feels instant by the time you actually get there) —
+		// for a long note, rasterizing/decoding/drawing every page's image
+		// (and building N pages' worth of text-layer DOM) upfront is real,
+		// mostly wasted work if you only ever look at the first few pages,
+		// and scales memory with page count regardless (see issue #147).
+		// Re-observes fresh page containers each file load; see onLoadFile().
 		this.pageObserver = new IntersectionObserver((entries) => {
 			for (const entry of entries) {
 				if (!entry.isIntersecting) continue;
 				const state = this.pageStates.find((s) => s.pageContainer === entry.target);
-				if (state) void this.ensureTextLayer(state);
+				if (!state) continue;
+				void this.ensurePageImage(state);
+				void this.ensureTextLayer(state);
 			}
 		}, { root: this.contentEl, rootMargin: '100% 0px' });
 	}
@@ -884,9 +905,9 @@ export class SupernoteView extends FileView {
 
 		const note = await this.app.vault.readBinary(file);
 		const sn = new SupernoteX(new Uint8Array(note));
+		this.sn = sn;
 		this.pageIds = sn.pages.map((p) => p.PAGEID ?? '');
 		const linksByPage = bucketLinksByPage(sn.links);
-		const images = await new ImageConverter().convertToImages(sn);
 
 		if (this.settings.showExportButtons) {
 			const exportNoteBtn = container.createEl("p").createEl("button", {
@@ -920,30 +941,26 @@ export class SupernoteView extends FileView {
 		// Sticky header so the toolbar (and find bar, when open) stay visible
 		// while scrolling through a long note instead of scrolling away with it.
 		this.headerEl = container.createDiv({ cls: 'supernote-header' });
-		this.buildToolbar(this.headerEl, images.length);
+		this.buildToolbar(this.headerEl, sn.pages.length);
 		this.buildFindBar(this.headerEl);
 		this.updateThumbSidebarOffset();
 
 		const body = container.createDiv({ cls: 'supernote-body' });
-		this.buildThumbSidebar(body, images);
+		this.buildThumbSidebar(body, sn.pages.length);
 
 		this.pagesEl = body.createDiv({ cls: 'supernote-pages' });
 		this.pagesEl.toggleClass('supernote-mode-text', this.layerMode === 'text');
 
-		// Decoded up front, all at once via Promise.all, rather than one at a
-		// time inside the loop below — createImageBitmap() previously being
-		// awaited per-page meant a note's pages were decoded strictly one
-		// after another, a real, page-count-scaling cost on every open.
+		// Page containers/canvases are built for every page up front (cheap —
+		// just DOM elements, sized from sn.pageWidth/pageHeight, which are
+		// already known without rasterizing anything), but each page's actual
+		// image is loaded lazily by ensurePageImage() — see pageObserver in
+		// onOpen(). Rasterizing, decoding, and drawing every page immediately
+		// (the previous behavior) scaled memory with page count regardless of
+		// how much of the note was ever actually looked at — see issue #147.
 		const renderStart = performance.now();
-		const bitmaps = await Promise.all(images.map(async (imageDataUrl) => {
-			const blob = new Blob([dataUrlToBuffer(imageDataUrl)], { type: 'image/png' });
-			return createImageBitmap(blob);
-		}));
-		const decodeEnd = performance.now();
 
-		for (let i = 0; i < images.length; i++) {
-			const imageDataUrl = images[i];
-
+		for (let i = 0; i < sn.pages.length; i++) {
 			const pageContainer = this.pagesEl.createDiv({
 				cls: 'page-container',
 			})
@@ -954,22 +971,6 @@ export class SupernoteView extends FileView {
 				canvas.addClass("supernote-invert-dark");
 			}
 
-			// Canvas doesn't get native image drag-out the way <img> did; wire it up
-			// manually against the same page PNG the canvas is rendered from. This
-			// is best-effort — worth confirming it actually reproduces useful
-			// drag-and-drop behavior in a real vault, since the pre-canvas <img>
-			// drag may not have produced a proper vault attachment link either.
-			canvas.draggable = true;
-			canvas.addEventListener('dragstart', (evt) => {
-				if (!evt.dataTransfer) return;
-				evt.dataTransfer.setData('text/uri-list', imageDataUrl);
-				evt.dataTransfer.setData('text/plain', imageDataUrl);
-				evt.dataTransfer.setDragImage(canvas, 0, 0);
-			});
-
-			const textLayerDiv = canvasWrap.createDiv({ cls: 'textLayer' });
-			const linksLayerDiv = canvasWrap.createDiv({ cls: 'supernote-links-layer' });
-
 			const state: PageRenderState = {
 				pageNumber: i + 1,
 				pdfPage: null,
@@ -978,20 +979,42 @@ export class SupernoteView extends FileView {
 				pageContainer,
 				canvasWrap,
 				canvas,
-				textLayerDiv,
-				linksLayerDiv,
+				textLayerDiv: canvasWrap.createDiv({ cls: 'textLayer' }),
+				linksLayerDiv: canvasWrap.createDiv({ cls: 'supernote-links-layer' }),
 				linkEls: [],
 				imageBitmap: null,
+				imageDataUrl: null,
+				imageLoadPromise: null,
 				textLayerLoaded: false,
 				text: '',
 				spans: [],
 			};
 			this.pageStates.push(state);
 
+			// Canvas doesn't get native image drag-out the way <img> did; wire it up
+			// manually against the same page PNG the canvas is rendered from. This
+			// is best-effort — worth confirming it actually reproduces useful
+			// drag-and-drop behavior in a real vault, since the pre-canvas <img>
+			// drag may not have produced a proper vault attachment link either.
+			// state.imageDataUrl is null until ensurePageImage() loads this page —
+			// dragging one out before that (very unlikely; by the time a user can
+			// interact with a canvas it's almost certainly already in view and
+			// thus already loading/loaded) just cancels the drag.
+			canvas.draggable = true;
+			canvas.addEventListener('dragstart', (evt) => {
+				if (!evt.dataTransfer || !state.imageDataUrl) {
+					evt.preventDefault();
+					return;
+				}
+				evt.dataTransfer.setData('text/uri-list', state.imageDataUrl);
+				evt.dataTransfer.setData('text/plain', state.imageDataUrl);
+				evt.dataTransfer.setDragImage(canvas, 0, 0);
+			});
+
 			for (const link of linksByPage.get(i) ?? []) {
 				const rect = parseLinkRect(link.LINKRECT);
 				if (!rect) continue;
-				const el = linksLayerDiv.createEl('a', {
+				const el = state.linksLayerDiv.createEl('a', {
 					cls: 'supernote-link-rect',
 					attr: { href: '#', title: link.text },
 				});
@@ -1002,9 +1025,10 @@ export class SupernoteView extends FileView {
 				state.linkEls.push({ el, rect });
 			}
 
-			// Already decoded above (in parallel, before this loop). Cached on
-			// the state and reused for every zoom redraw (drawPageImage()).
-			state.imageBitmap = bitmaps[i];
+			// No image yet (imageBitmap is null) — this only sizes the canvas
+			// and its overlays correctly from nativeWidth/nativeHeight, same as
+			// every subsequent zoom redraw. ensurePageImage() calls this again
+			// once the page's actual image is loaded.
 			this.drawPageImage(state, this.zoomScale);
 
 			this.pageObserver?.observe(pageContainer);
@@ -1017,14 +1041,20 @@ export class SupernoteView extends FileView {
 				});
 
 				saveButton.addEventListener("click", () => void (async () => {
+					// Force the load rather than assuming pageObserver already
+					// triggered it — a save click is always possible before a
+					// page's ever scrolled into view (e.g. a very tall page,
+					// or a fast click right after load).
+					await this.ensurePageImage(state);
+					if (!state.imageDataUrl) return;
 					const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}-${i + 1}.png`);
-					const buffer = dataUrlToBuffer(imageDataUrl);
+					const buffer = dataUrlToBuffer(state.imageDataUrl);
 					await this.app.vault.createBinary(filename, buffer);
 				})());
 			}
 		}
 
-		console.debug(`Supernote: page render — decode ${(decodeEnd - renderStart).toFixed(1)}ms, DOM build ${(performance.now() - decodeEnd).toFixed(1)}ms, total ${(performance.now() - renderStart).toFixed(1)}ms for ${images.length} page(s)`);
+		console.debug(`Supernote: page render — DOM build ${(performance.now() - renderStart).toFixed(1)}ms for ${sn.pages.length} page(s) (images load lazily as pages scroll into view)`);
 
 		if (this.fitWidthEnabled) {
 			this.applyFitWidth();
@@ -1047,6 +1077,38 @@ export class SupernoteView extends FileView {
 			this.pdfjsLib = await loadPdfJs() as PdfJsLib;
 			return this.pdfjsLib.getDocument({ data: pdfBytes }).promise;
 		})();
+	}
+
+	// Loads this page's own rasterized image if it hasn't been already —
+	// triggered by pageObserver as a page nears the viewport, or forced
+	// immediately by page-jump/save-image so those don't have to wait on
+	// scroll+observer timing. Idempotent (safe to call speculatively) and
+	// de-duplicated against a concurrent call via imageLoadPromise, the same
+	// pattern ensureTextLayer() uses for its own one-time work.
+	private ensurePageImage(state: PageRenderState): Promise<void> {
+		if (state.imageBitmap) return Promise.resolve();
+		if (state.imageLoadPromise) return state.imageLoadPromise;
+
+		state.imageLoadPromise = (async () => {
+			try {
+				if (!this.sn) return;
+				const [imageDataUrl] = await new ImageConverter().convertToImages(this.sn, [state.pageNumber]);
+				state.imageDataUrl = imageDataUrl;
+				const blob = new Blob([dataUrlToBuffer(imageDataUrl)], { type: 'image/png' });
+				state.imageBitmap = await createImageBitmap(blob);
+				this.drawPageImage(state, this.zoomScale);
+
+				// Fills in this page's thumbnail too, whether it loaded because
+				// the main view scrolled to it or because the thumbnail sidebar
+				// was opened (see toggleThumbnails()) — either way the sidebar
+				// shouldn't show a blank slot once the image is actually ready.
+				const thumbImg = this.thumbImgs[state.pageNumber - 1];
+				if (thumbImg) thumbImg.src = imageDataUrl;
+			} catch (err) {
+				console.error(`Supernote: failed to load page ${state.pageNumber}'s image:`, err);
+			}
+		})();
+		return state.imageLoadPromise;
 	}
 
 	// Draws the page's own already-decoded bitmap at the given scale — no
@@ -1223,19 +1285,22 @@ export class SupernoteView extends FileView {
 		this.textModeBtn?.toggleClass('is-active', this.layerMode === 'text');
 	}
 
-	// Reuses the same page PNGs already generated for the save-to-vault/
-	// drag-out buttons — no separate low-res render pass, just let CSS scale
-	// them down. Built up front (images are ready before pdf.js even starts),
-	// independent of the pdf.js page-render loop below.
-	private buildThumbSidebar(body: HTMLElement, images: string[]) {
+	// Reuses the same page PNGs ensurePageImage() rasterizes for the main
+	// view (see thumbImg assignment there) — no separate low-res render pass,
+	// just let CSS scale them down. Starts empty (no `src`) for every page:
+	// images are no longer all ready up front (see issue #147), so a
+	// thumbnail fills in whenever its page happens to load - from scrolling
+	// the main view, or all at once when the sidebar is first opened, see
+	// toggleThumbnails().
+	private buildThumbSidebar(body: HTMLElement, pageCount: number) {
 		const thumbSidebarEl = body.createDiv({ cls: 'supernote-thumb-sidebar' });
 		this.thumbSidebarEl = thumbSidebarEl;
 		this.thumbItems = [];
+		this.thumbImgs = [];
 
-		images.forEach((dataUrl, i) => {
+		for (let i = 0; i < pageCount; i++) {
 			const item = thumbSidebarEl.createDiv({ cls: 'supernote-thumb-item' });
 			const img = item.createEl('img', { cls: 'supernote-thumb-img' });
-			img.src = dataUrl;
 			item.createSpan({ cls: 'supernote-thumb-label', text: String(i + 1) });
 
 			item.addEventListener('click', () => {
@@ -1243,7 +1308,8 @@ export class SupernoteView extends FileView {
 			});
 
 			this.thumbItems.push(item);
-		});
+			this.thumbImgs.push(img);
+		}
 
 		this.applyThumbSidebarVisibility();
 	}
@@ -1251,6 +1317,17 @@ export class SupernoteView extends FileView {
 	private toggleThumbnails() {
 		this.thumbnailsVisible = !this.thumbnailsVisible;
 		this.applyThumbSidebarVisibility();
+
+		// The sidebar shows every page's thumbnail at once (it isn't itself
+		// virtualized/lazy), so opening it needs every page's image loaded,
+		// not just whatever the main view has scrolled past so far. Only
+		// triggered on open, not on every visibility change, so closing and
+		// reopening doesn't re-kick anything already loaded (ensurePageImage
+		// is a no-op once state.imageBitmap is set anyway, but no need to
+		// even iterate pageStates again for that).
+		if (this.thumbnailsVisible) {
+			for (const state of this.pageStates) void this.ensurePageImage(state);
+		}
 	}
 
 	private applyThumbSidebarVisibility() {
@@ -1287,7 +1364,7 @@ export class SupernoteView extends FileView {
 
 	// Shared by the toolbar's page-jump input, the thumbnail sidebar, and
 	// setEphemeralState() (a `#page=N` link anchor) — all three just need to
-	// scroll a given 1-indexed page into view and prime its text layer.
+	// scroll a given 1-indexed page into view and prime its image/text layer.
 	private async goToPage(pageNumber: number): Promise<void> {
 		if (this.pageStates.length === 0) return;
 		// Wait out any in-flight fit-width/zoom re-render first — see
@@ -1300,7 +1377,9 @@ export class SupernoteView extends FileView {
 		if (!state) return;
 		state.pageContainer.scrollIntoView({ block: 'start', behavior: 'smooth' });
 		// Don't wait on scroll+observer timing for a page the user (or link)
-		// explicitly asked to jump to.
+		// explicitly asked to jump to — a fast programmatic jump can easily
+		// land before pageObserver's next tick fires.
+		void this.ensurePageImage(state);
 		void this.ensureTextLayer(state);
 		if (this.pageJumpInput) this.pageJumpInput.value = String(clamped);
 	}

--- a/styles.css
+++ b/styles.css
@@ -49,7 +49,13 @@ div.supernote-canvas-wrap canvas {
 }
 
 /* Mirrors pdf.js's own text_layer_builder.css: canvas carries the pixels,
-   this transparent layer carries selectable/searchable text on top of it. */
+   this transparent layer carries selectable/searchable text on top of it.
+   pointer-events: none on the container (re-enabled per-span below) matters
+   beyond just this layer: without it, this fully covers every page's canvas
+   (position: absolute; inset: 0) and, being on top in paint order, would
+   swallow every mouse event anywhere on the page - including the canvas's
+   own manually-wired drag-out (see SupernoteView.onLoadFile()) - not just
+   clicks on an actual text span. */
 .textLayer {
     position: absolute;
     inset: 0;
@@ -57,6 +63,7 @@ div.supernote-canvas-wrap canvas {
     line-height: 1;
     text-align: initial;
     transform-origin: 0 0;
+    pointer-events: none;
 }
 
 .textLayer span,
@@ -66,6 +73,7 @@ div.supernote-canvas-wrap canvas {
     white-space: pre;
     cursor: text;
     transform-origin: 0% 0%;
+    pointer-events: auto;
 }
 
 .textLayer ::selection {
@@ -84,11 +92,15 @@ div.supernote-canvas-wrap canvas {
 /* Clickable overlay for Supernote internal links (see
    SupernoteView.positionLinkOverlay() in main.ts). Sits above the text
    layer; positioned/sized per-link via inline styles since geometry is
-   data-driven, same pattern as canvas/textLayer sizing. */
+   data-driven, same pattern as canvas/textLayer sizing. pointer-events: none
+   on the container (re-enabled on each link rect below) for the same reason
+   as .textLayer above - otherwise this, being topmost, would swallow every
+   mouse event on the page, not just clicks on an actual link. */
 .supernote-links-layer {
     position: absolute;
     inset: 0;
     overflow: hidden;
+    pointer-events: none;
 }
 
 .supernote-link-rect {
@@ -98,6 +110,7 @@ div.supernote-canvas-wrap canvas {
     cursor: pointer;
     background: transparent;
     transition: background-color 0.1s ease;
+    pointer-events: auto;
 }
 
 .supernote-link-rect:hover {


### PR DESCRIPTION
## Summary

Candidate memory-reduction patch for #147 (crash/"boot loop" opening a `.note` file on iOS). **Not a confirmed fix** - we still don't have a root cause pinned down for that specific report (see the issue for the ongoing investigation via #150's diagnostic logging) - but this is a real, independently-worthwhile change regardless: `onLoadFile()` currently rasterizes, decodes, and canvas-renders *every* page of a note unconditionally on open, so memory scales linearly with page count no matter how much of the note is ever actually looked at. On a memory-constrained device that's a real contributing risk even if it's not the exact trigger for this report.

The text layer (selection/search) already avoids exactly this shape of problem via `pageObserver` + `ensureTextLayer()` - only building once a page nears the viewport. Canvas image rendering had no equivalent laziness.

## Changes
- New `ensurePageImage()`, mirroring `ensureTextLayer()`'s idempotent/de-duplicated pattern, triggered by the same `pageObserver`, plus explicit page-jump (`goToPage`) and "Save image to vault" (which can't assume the observer already fired).
- Page containers/canvases are still built for every page immediately (cheap - `sn.pageWidth`/`pageHeight` size them without rasterizing anything), but each page's actual image loads only once it's about to scroll into view.
- The thumbnail sidebar previously reused the same eagerly-rasterized images; thumbnails now start empty and fill in as pages load, or all at once if the sidebar is opened before scrolling (it shows every page at once, so opening it needs every page loaded).
- Drag-out and "Save image to vault" now read from `state.imageDataUrl` (populated once `ensurePageImage` loads) instead of a closure variable that no longer exists once images aren't all rasterized up front.

## What I could not verify
I don't have Obsidian, an X server, or Electron tooling available in my environment, so I could not launch the app and click through this - verification here is `tsc`/`eslint`/the existing test suite plus a careful manual trace of every consumer of the changed state (zoom's `commitZoom()`, thumbnails, drag-out, save-button, find, page-jump). Several of those already had graceful "not loaded yet" handling before this change (`drawPageImage()`'s null-bitmap guard, `commitZoom()`'s "only rebuild what's loaded" check), which is what makes me reasonably confident, but **please smoke-test zoom, thumbnails, drag-out, and save-to-vault on a real multi-page note before merging** - this touches more interacting features than a typical patch.

## Test plan
- [x] `npx tsc --noEmit` - clean
- [x] `npx eslint src/main.ts` - 0 errors
- [x] `npx vitest run` - 95 passed
- [x] `npm run build` - clean
- [x] Manual: open a multi-page note, scroll through it, verify pages load as they come into view
- [x] Manual: zoom in/out and fit-width still redraw correctly for both already-loaded and not-yet-loaded pages
- [x] Manual: open the thumbnail sidebar before and after scrolling - all thumbnails eventually populate either way
- [x] Manual: drag a page's canvas out, and "Save image to vault", both on a freshly-opened (not yet scrolled) page
- [x] Manual: Find-in-note still matches text on pages not yet scrolled to