### PR TITLE
Reduce mobile padding around note pages

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -854,7 +854,19 @@ export class SupernoteView extends FileView {
 		// ancestor's padding directly avoids combining sticky with a negative
 		// margin at all; .supernote-header's own (positive, sticky-safe)
 		// padding-top puts a little breathing room back.
-		this.contentEl.setCssStyles({ paddingTop: '0' });
+		//
+		// On mobile (issue #148 - reported on an iPhone 13 mini, but likely
+		// any small screen), that same ancestor padding on the left/right/
+		// bottom sides is real, wasted width on a screen already tight for
+		// legibility of handwritten content - left alone on desktop, where a
+		// window is normally wide enough that it isn't a meaningful loss.
+		// div.page-container's own margin gets the equivalent reduction in
+		// styles.css, scoped to body.is-mobile the same way.
+		this.contentEl.setCssStyles(
+			Platform.isMobile
+				? { paddingTop: '0', paddingLeft: '0.25em', paddingRight: '0.25em', paddingBottom: '0.25em' }
+				: { paddingTop: '0' },
+		);
 
 		this.scope?.register(['Mod'], 'f', (evt) => {
 			evt.preventDefault();

--- a/styles.css
+++ b/styles.css
@@ -37,6 +37,15 @@ div.page-container {
     margin: 1.2em;
 }
 
+/* Issue #148: 1.2em of margin on every side of every page is real, wasted
+   width on a small screen already tight for legibility of handwritten
+   content - a phone doesn't have the spare width a desktop window does.
+   Left alone elsewhere; SupernoteView.onOpen() reduces its own ancestor
+   .view-content padding the same way, scoped the same way. */
+body.is-mobile div.page-container {
+    margin: 0.3em;
+}
+
 div.supernote-canvas-wrap {
     position: relative;
     display: inline-block;


### PR DESCRIPTION
## Summary

Fixes #148 - on an iPhone 13 mini (and likely any small screen), the padding/margin around note pages eats a meaningful chunk of an already-tight width:

- `SupernoteView.onOpen()` already zeroes the ancestor `.view-content`'s top padding (for the sticky toolbar - see existing comment there); left/right/bottom padding was untouched.
- `div.page-container` has a flat `1.2em` margin on every side.

Both add up to real, wasted horizontal space on a phone screen, where every pixel matters for legibility of handwritten content - much less noticeable on a desktop window, which usually has width to spare.

## Changes
- `src/main.ts`: `Platform.isMobile` now also zeroes (well, reduces to `0.25em`) the content view's left/right/bottom padding, not just top.
- `styles.css`: `body.is-mobile div.page-container` reduces the `1.2em` margin to `0.3em`.

Scoped to mobile only rather than changing desktop's spacing, since the report is specific to small screens. `applyFitWidth()` already reads the container's margin from its live computed style at runtime, so it automatically picks up the reduced mobile value - no changes needed there.

## Test plan
- [x] `npx tsc --noEmit` - clean
- [x] `npx eslint src/main.ts` - 0 errors
- [x] `npx vitest run` - 95 passed
- [x] `npm run build` - clean
- [x] Manual: open a note on a phone (or Obsidian's mobile emulator) and confirm noticeably more of the page is visible/legible, with fit-width still filling the available space correctly
- [x] Manual: confirm desktop appearance is unchanged