### PR TITLE
Evict scrolled-away pages' images instead of only loading lazily

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -720,17 +720,27 @@ type PageRenderState = {
 	linkEls: { el: HTMLElement; rect: [number, number, number, number] }[];
 	// Decoded once from the already-rasterized page image and reused for
 	// every zoom redraw (see drawPageImage()) — no pdf.js/decode work on the
-	// zoom-critical path. null until ensurePageImage() loads it.
+	// zoom-critical path. null until ensurePageImage() loads it, and again
+	// after evictPageImage() frees it.
 	imageBitmap: ImageBitmap | null;
 	// This page's rasterized PNG data URL, once ensurePageImage() loads it —
-	// needed for the canvas's drag-out and the "Save image to vault" button,
-	// which previously closed over a local `imageDataUrl` that no longer
-	// exists once every page isn't rasterized up front.
+	// needed for the "Save image to vault" button and to fill in this page's
+	// thumbnail (see ensurePageImage()). null again after evictPageImage().
 	imageDataUrl: string | null;
-	// In-flight/completed load, so a page nearing the viewport (pageObserver),
-	// an explicit jump (goToPage), and "Save image to vault" can't each kick
-	// off their own separate rasterization of the same page.
+	// In-flight/completed load, so a page nearing the viewport (pageObserver
+	// or thumbObserver), an explicit jump (goToPage), and "Save image to
+	// vault" can't each kick off their own separate rasterization of the
+	// same page. Reset to null by evictPageImage() so a later reload isn't
+	// mistaken for one already in flight/done.
 	imageLoadPromise: Promise<void> | null;
+	// Whether this page is currently within pageObserver's margin (main
+	// view) or its thumbnail item is within thumbObserver's margin (sidebar)
+	// - see updatePageLoadState(). A page is only evicted once both are
+	// false, so scrolling just one of the two views (either reproduces
+	// issue #154's crash on its own) doesn't evict a page the other still
+	// wants shown.
+	visibleInMainView: boolean;
+	visibleInThumbnail: boolean;
 	// Guards ensureTextLayer()'s one-time (per page) work.
 	textLayerLoaded: boolean;
 	text: string;
@@ -784,6 +794,13 @@ export class SupernoteView extends FileView {
 	// actually loaded — see ensureTextLayer()/pageObserver.
 	private pdfDocPromise: Promise<PdfJsDocument> | null = null;
 	private pageObserver: IntersectionObserver | null = null;
+	// Scoped to the thumbnail sidebar's own scroll container, not contentEl -
+	// re-created per file load in buildThumbSidebar() (thumbSidebarEl itself
+	// is a fresh element each load, and root can't be changed after an
+	// IntersectionObserver is constructed). See PageRenderState.
+	// visibleInThumbnail/updatePageLoadState() for why this exists alongside
+	// pageObserver rather than reusing it.
+	private thumbObserver: IntersectionObserver | null = null;
 
 	private layerMode: 'image' | 'text' = 'image';
 	private imageModeBtn: HTMLElement | null = null;
@@ -933,28 +950,41 @@ export class SupernoteView extends FileView {
 		// mostly wasted work if you only ever look at the first few pages,
 		// and scales memory with page count regardless (see issue #147).
 		// Also evicts a page's image once it scrolls back *out* of that same
-		// margin (see evictPageImage()) - loading lazily instead of upfront
-		// bounds memory by "how many pages are near the viewport right now"
-		// rather than "how many have been scrolled past so far", which for a
-		// long enough document (100 pages, see issue #154) still grows
-		// without bound as you keep scrolling even though each individual
-		// page loads lazily. Text layers are left alone here - much lighter
-		// (a string + some span elements, not a decoded bitmap/canvas
-		// backing store) and losing search state/highlights on scroll-past
-		// would be a worse trade for a small saving.
+		// margin (see evictPageImage()/updatePageLoadState()) - loading
+		// lazily instead of upfront bounds memory by "how many pages are
+		// near the viewport right now" rather than "how many have been
+		// scrolled past so far", which for a long enough document (100
+		// pages, see issue #154) still grows without bound as you keep
+		// scrolling even though each individual page loads lazily. Text
+		// layers are left alone for eviction - much lighter (a string + some
+		// span elements, not a decoded bitmap/canvas backing store) and
+		// losing search state/highlights on scroll-past would be a worse
+		// trade for a small saving.
 		// Re-observes fresh page containers each file load; see onLoadFile().
 		this.pageObserver = new IntersectionObserver((entries) => {
 			for (const entry of entries) {
 				const state = this.pageStates.find((s) => s.pageContainer === entry.target);
 				if (!state) continue;
-				if (entry.isIntersecting) {
-					void this.ensurePageImage(state);
-					void this.ensureTextLayer(state);
-				} else {
-					this.evictPageImage(state);
-				}
+				state.visibleInMainView = entry.isIntersecting;
+				if (entry.isIntersecting) void this.ensureTextLayer(state);
+				this.updatePageLoadState(state);
 			}
 		}, { root: this.contentEl, rootMargin: '100% 0px' });
+	}
+
+	// Shared by pageObserver (main view) and thumbObserver (sidebar): a page
+	// loads if either view currently wants it shown, and only evicts once
+	// neither does. The thumbnail sidebar scrolls independently of the main
+	// view - a page can be near the viewport in one and far from it in the
+	// other - so either alone could reproduce issue #154's crash (it says
+	// so explicitly: "the user can also reproduce the crash by scrolling
+	// thumbnails only") if eviction only checked one of the two.
+	private updatePageLoadState(state: PageRenderState): void {
+		if (state.visibleInMainView || state.visibleInThumbnail) {
+			void this.ensurePageImage(state);
+		} else {
+			this.evictPageImage(state);
+		}
 	}
 
 	async onLoadFile(file: TFile): Promise<void> {
@@ -963,6 +993,7 @@ export class SupernoteView extends FileView {
 
 		window.clearTimeout(this.zoomDebounceTimer);
 		this.pageObserver?.disconnect();
+		this.thumbObserver?.disconnect();
 		this.pageStates = [];
 		this.zoomScale = 1;
 		this.renderedZoomScale = 1;
@@ -1055,6 +1086,8 @@ export class SupernoteView extends FileView {
 				imageBitmap: null,
 				imageDataUrl: null,
 				imageLoadPromise: null,
+				visibleInMainView: false,
+				visibleInThumbnail: false,
 				textLayerLoaded: false,
 				text: '',
 				spans: [],
@@ -1234,15 +1267,16 @@ export class SupernoteView extends FileView {
 		state.canvas.getContext("2d")?.drawImage(state.imageBitmap, 0, 0, bitmapWidth, bitmapHeight);
 	}
 
-	// Frees a page's decoded image once it's scrolled back out of
-	// pageObserver's margin (see onOpen()) - lazy *loading* alone still lets
-	// memory grow without bound on a long enough document as you keep
-	// scrolling, since nothing ever released an earlier page's bitmap/
-	// canvas backing store once loaded (see issue #154). Safe to call
-	// speculatively: a no-op if nothing's actually loaded (most pages, most
-	// of the time - pageObserver also reports initial non-intersection for
-	// every page outside the viewport at file-open time, before anything
-	// has loaded at all).
+	// Frees a page's decoded image once neither the main view nor the
+	// thumbnail sidebar wants it shown anymore (see updatePageLoadState()).
+	// Lazy *loading* alone still lets memory grow without bound on a long
+	// enough document as either view is scrolled, since nothing ever
+	// released an earlier page's bitmap/canvas backing store once loaded
+	// (see issue #154 - reproducible by scrolling the main view alone, or
+	// the thumbnail sidebar alone). Safe to call speculatively: a no-op if
+	// nothing's actually loaded (most pages, most of the time - both
+	// observers also report initial non-intersection for anything outside
+	// their own viewport at file-open time, before anything has loaded).
 	private evictPageImage(state: PageRenderState): void {
 		if (!state.imageBitmap) return;
 
@@ -1263,6 +1297,14 @@ export class SupernoteView extends FileView {
 		// that correctly and it doesn't need to change) - only this.
 		state.canvas.width = 1;
 		state.canvas.height = 1;
+
+		// The thumbnail <img> decodes and caches its own copy independent of
+		// the canvas/imageBitmap above - clearing its `src` releases that
+		// too. Only reached when neither view wants this page shown (see
+		// updatePageLoadState()), so this can't clear a thumbnail the
+		// sidebar still has visible.
+		const thumbImg = this.thumbImgs[state.pageNumber - 1];
+		if (thumbImg) thumbImg.src = '';
 	}
 
 	// Repositions each link's clickable region to the page's current CSS
@@ -1424,6 +1466,29 @@ export class SupernoteView extends FileView {
 		this.thumbItems = [];
 		this.thumbImgs = [];
 
+		// Scoped to this sidebar's own scroll container (it scrolls
+		// independently of the main view - see CSS `overflow-y: auto` on
+		// .supernote-thumb-sidebar), not contentEl. A fresh observer every
+		// file load: thumbSidebarEl above is itself a brand new element each
+		// time, and an IntersectionObserver's root can't be changed after
+		// construction, so the one from any previous file load (disconnected
+		// in onLoadFile()) can't just be reused here. While the sidebar is
+		// hidden (display: none, see applyThumbSidebarVisibility()) every
+		// item reports non-intersecting - it has no layout box to intersect
+		// with - so nothing loads until it's actually shown; opening it then
+		// only loads whichever thumbnails are actually scrolled into view in
+		// it, the same as the main view's own pageObserver.
+		this.thumbObserver = new IntersectionObserver((entries) => {
+			for (const entry of entries) {
+				const index = this.thumbItems.indexOf(entry.target as HTMLElement);
+				if (index === -1) continue;
+				const state = this.pageStates[index];
+				if (!state) continue;
+				state.visibleInThumbnail = entry.isIntersecting;
+				this.updatePageLoadState(state);
+			}
+		}, { root: thumbSidebarEl, rootMargin: '100% 0px' });
+
 		for (let i = 0; i < pageCount; i++) {
 			const item = thumbSidebarEl.createDiv({ cls: 'supernote-thumb-item' });
 			const img = item.createEl('img', { cls: 'supernote-thumb-img' });
@@ -1435,6 +1500,7 @@ export class SupernoteView extends FileView {
 
 			this.thumbItems.push(item);
 			this.thumbImgs.push(img);
+			this.thumbObserver.observe(item);
 		}
 
 		this.applyThumbSidebarVisibility();
@@ -1443,17 +1509,6 @@ export class SupernoteView extends FileView {
 	private toggleThumbnails() {
 		this.thumbnailsVisible = !this.thumbnailsVisible;
 		this.applyThumbSidebarVisibility();
-
-		// The sidebar shows every page's thumbnail at once (it isn't itself
-		// virtualized/lazy), so opening it needs every page's image loaded,
-		// not just whatever the main view has scrolled past so far. Only
-		// triggered on open, not on every visibility change, so closing and
-		// reopening doesn't re-kick anything already loaded (ensurePageImage
-		// is a no-op once state.imageBitmap is set anyway, but no need to
-		// even iterate pageStates again for that).
-		if (this.thumbnailsVisible) {
-			for (const state of this.pageStates) void this.ensurePageImage(state);
-		}
 	}
 
 	private applyThumbSidebarVisibility() {
@@ -1504,7 +1559,13 @@ export class SupernoteView extends FileView {
 		state.pageContainer.scrollIntoView({ block: 'start', behavior: 'smooth' });
 		// Don't wait on scroll+observer timing for a page the user (or link)
 		// explicitly asked to jump to — a fast programmatic jump can easily
-		// land before pageObserver's next tick fires.
+		// land before pageObserver's next tick fires. Marking it visible
+		// directly (rather than just calling ensurePageImage()) also closes
+		// off a narrow race with evictPageImage(): a stray non-intersecting
+		// callback firing for this page while the scroll is still settling
+		// would otherwise see visibleInMainView still false and could evict
+		// the very page we just asked to load.
+		state.visibleInMainView = true;
 		void this.ensurePageImage(state);
 		void this.ensureTextLayer(state);
 		if (this.pageJumpInput) this.pageJumpInput.value = String(clamped);
@@ -1829,6 +1890,7 @@ export class SupernoteView extends FileView {
 		window.clearTimeout(this.fitWidthDebounceTimer);
 		this.resizeObserver?.disconnect();
 		this.pageObserver?.disconnect();
+		this.thumbObserver?.disconnect();
 	}
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -932,14 +932,27 @@ export class SupernoteView extends FileView {
 		// (and building N pages' worth of text-layer DOM) upfront is real,
 		// mostly wasted work if you only ever look at the first few pages,
 		// and scales memory with page count regardless (see issue #147).
+		// Also evicts a page's image once it scrolls back *out* of that same
+		// margin (see evictPageImage()) - loading lazily instead of upfront
+		// bounds memory by "how many pages are near the viewport right now"
+		// rather than "how many have been scrolled past so far", which for a
+		// long enough document (100 pages, see issue #154) still grows
+		// without bound as you keep scrolling even though each individual
+		// page loads lazily. Text layers are left alone here - much lighter
+		// (a string + some span elements, not a decoded bitmap/canvas
+		// backing store) and losing search state/highlights on scroll-past
+		// would be a worse trade for a small saving.
 		// Re-observes fresh page containers each file load; see onLoadFile().
 		this.pageObserver = new IntersectionObserver((entries) => {
 			for (const entry of entries) {
-				if (!entry.isIntersecting) continue;
 				const state = this.pageStates.find((s) => s.pageContainer === entry.target);
 				if (!state) continue;
-				void this.ensurePageImage(state);
-				void this.ensureTextLayer(state);
+				if (entry.isIntersecting) {
+					void this.ensurePageImage(state);
+					void this.ensureTextLayer(state);
+				} else {
+					this.evictPageImage(state);
+				}
 			}
 		}, { root: this.contentEl, rootMargin: '100% 0px' });
 	}
@@ -1181,30 +1194,75 @@ export class SupernoteView extends FileView {
 		const width = Math.max(1, Math.round(state.nativeWidth * scale));
 		const height = Math.max(1, Math.round(state.nativeHeight * scale));
 
-		// The canvas's backing store (width/height attributes) previously
-		// matched its CSS display size 1:1, so on a high-DPR mobile screen the
-		// browser had to upscale it to cover the physical pixels — the "chunky
-		// artifacts" that make handwritten strokes hard to read. Rendering the
-		// backing store at devicePixelRatio and leaving the CSS size alone
-		// (via explicit style, since an unstyled <canvas> otherwise takes its
-		// size from its width/height attributes) fixes that; capped at 3 so an
-		// extreme DPR display doesn't blow up canvas memory for no visible
-		// benefit.
-		const dpr = Math.min(window.devicePixelRatio || 1, 3);
-		const bitmapWidth = Math.max(1, Math.round(width * dpr));
-		const bitmapHeight = Math.max(1, Math.round(height * dpr));
-
-		state.canvas.width = bitmapWidth;
-		state.canvas.height = bitmapHeight;
+		// CSS (layout) size always tracks the current zoom, for every page,
+		// regardless of whether its image is actually loaded right now.
+		// commitZoom() calls this unconditionally for every page on every
+		// zoom change - scroll position, thumbnail click-to-jump, and
+		// page-anchor links all depend on every page's box being the right
+		// height even for pages that aren't currently loaded (never viewed
+		// yet, or evicted after scrolling away - see evictPageImage()).
 		state.canvas.setCssStyles({ width: `${width}px`, height: `${height}px` });
 		state.canvasWrap.setCssStyles({ width: `${width}px`, height: `${height}px` });
 		state.textLayerDiv.setCssStyles({ width: `${width}px`, height: `${height}px` });
 		state.linksLayerDiv.setCssStyles({ width: `${width}px`, height: `${height}px` });
 		this.positionLinkOverlay(state, width, height);
 
-		if (state.imageBitmap) {
-			state.canvas.getContext("2d")?.drawImage(state.imageBitmap, 0, 0, bitmapWidth, bitmapHeight);
-		}
+		// The backing store (actual pixel buffer - the expensive part) only
+		// needs to match this size when there's a real image to draw into
+		// it. Previously resized unconditionally here, which meant
+		// commitZoom()'s loop over every page reallocated a full-size
+		// backing store for every page in the document on every zoom
+		// change, including pages nowhere near the viewport - undoing lazy
+		// loading's whole memory benefit for a long document the moment you
+		// touched zoom at all (see issue #154). A page with no imageBitmap
+		// keeps whatever backing store size it already has (a fresh
+		// <canvas>'s browser default, or evictPageImage()'s 1x1 shrink) -
+		// the browser just stretches/blurs that placeholder to fill the CSS
+		// box above, fine since such a page is off-screen by definition.
+		if (!state.imageBitmap) return;
+
+		// Rendering the backing store at devicePixelRatio and leaving the
+		// CSS size alone (set above) fixes the "chunky artifacts" a 1:1
+		// backing store gets upscaled into on a high-DPR mobile screen;
+		// capped at 3 so an extreme DPR display doesn't blow up canvas
+		// memory for no visible benefit.
+		const dpr = Math.min(window.devicePixelRatio || 1, 3);
+		const bitmapWidth = Math.max(1, Math.round(width * dpr));
+		const bitmapHeight = Math.max(1, Math.round(height * dpr));
+		state.canvas.width = bitmapWidth;
+		state.canvas.height = bitmapHeight;
+		state.canvas.getContext("2d")?.drawImage(state.imageBitmap, 0, 0, bitmapWidth, bitmapHeight);
+	}
+
+	// Frees a page's decoded image once it's scrolled back out of
+	// pageObserver's margin (see onOpen()) - lazy *loading* alone still lets
+	// memory grow without bound on a long enough document as you keep
+	// scrolling, since nothing ever released an earlier page's bitmap/
+	// canvas backing store once loaded (see issue #154). Safe to call
+	// speculatively: a no-op if nothing's actually loaded (most pages, most
+	// of the time - pageObserver also reports initial non-intersection for
+	// every page outside the viewport at file-open time, before anything
+	// has loaded at all).
+	private evictPageImage(state: PageRenderState): void {
+		if (!state.imageBitmap) return;
+
+		// Releases the decoded bitmap's memory explicitly rather than
+		// waiting on GC to notice it's unreachable.
+		state.imageBitmap.close();
+		state.imageBitmap = null;
+		state.imageDataUrl = null;
+		// Lets a later re-entry actually reload instead of reusing this
+		// already-settled (but now stale) promise - ensurePageImage()'s
+		// imageBitmap check alone isn't enough once it's null again.
+		state.imageLoadPromise = null;
+
+		// The backing store doesn't shrink on its own just because nothing
+		// points at an ImageBitmap for it anymore - a canvas keeps its full
+		// pixel buffer resident until its width/height actually change.
+		// Deliberately doesn't touch CSS size (drawPageImage() already set
+		// that correctly and it doesn't need to change) - only this.
+		state.canvas.width = 1;
+		state.canvas.height = 1;
 	}
 
 	// Repositions each link's clickable region to the page's current CSS


### PR DESCRIPTION
## Summary

Fixes #154 - a 100-page note still crashed on an iPhone 13 mini around page 14-20, even after #151's lazy loading. That fix only bounds *when* a page's image loads (on scroll-near, not upfront) - it never releases anything, so memory still grows monotonically with how many pages you've scrolled past, not how many are actually near the viewport. On a long enough document, that's still unbounded.

**Update**: also fixes the same crash reproduced by scrolling the thumbnail sidebar alone (reported separately) - see "Thumbnail sidebar" below.

## Changes

- New `evictPageImage()`, called from the same `pageObserver` that already triggers lazy loading: once a page's container leaves the `rootMargin`-extended viewport, its `ImageBitmap` is explicitly `.close()`'d and its canvas backing store shrunk to 1x1. Scrolling back re-triggers `ensurePageImage()` exactly as if the page had never loaded (both `imageBitmap` and `imageLoadPromise` reset to `null`).
- Fixed a related gap this exposed in `drawPageImage()`: it resized every page's canvas backing store unconditionally. `commitZoom()` calls it for *every* page on *every* zoom change - so touching zoom on a long document would reallocate a full-size backing store for every page regardless of load state, undoing the lazy-loading memory benefit immediately. Split so CSS (layout) size still always updates for every page (scroll position / page-anchor links depend on correct page heights even for unloaded pages), but the backing store itself only resizes when there's an actual image to draw.
- Text layers (search/selection) are deliberately left alone - much lighter than a decoded bitmap/canvas, and losing search highlights on scroll-past would be a worse trade for a small memory saving.

## Thumbnail sidebar

The sidebar scrolls independently of the main view, so it could reproduce the same crash on its own (`toggleThumbnails()` used to eagerly load every page's image the moment it opened at all, regardless of how many thumbnails were actually visible). Added a second `IntersectionObserver` (`thumbObserver`), scoped to the sidebar's own scroll container, that lazily loads/evicts thumbnails the same way. Since a page can be near the viewport in one of the two views while far from it in the other, `PageRenderState` now tracks `visibleInMainView`/`visibleInThumbnail` separately, and eviction only fires once *both* are false - so scrolling just one view doesn't evict a page the other still has visible. `evictPageImage()` also now clears the thumbnail `<img>`'s own `src`, since it decodes/caches its own copy independent of the main canvas.

## What I could not verify

Same caveat as #151: no Obsidian/Electron/X server available in my environment, so this is verified by `tsc`/`eslint`/the existing test suite and a careful manual trace (zoom via `commitZoom`, initial layout sizing, `goToPage`, thumbnails), not by actually scrolling a 100-page note on a real device. **Please verify on the actual reported scenario** (a 100-page note, iPhone 13 mini or similar - both scrolling the main view and scrolling the thumbnail sidebar) before considering this closed - that's the one thing I can't substitute for here.

## Test plan
- [x] `npx tsc --noEmit` - clean
- [x] `npx eslint src/main.ts` - 0 errors
- [x] `npx vitest run` - 95 passed
- [x] `npm run build` - clean
- [ ] Manual: scroll through a 100+ page note on a memory-constrained device past page 20 without a crash
- [ ] Manual: open the thumbnail sidebar on the same long note and scroll through *it* without a crash
- [ ] Manual: zoom in/out on a long document after scrolling partway through - no crash, and pages already scrolled past still redraw correctly if scrolled back to
- [ ] Manual: page-anchor link / thumbnail click-to-jump / page-jump input still land on the correct page even deep into a long, partially-scrolled document
