### PR TITLE
Remove thumbnail sidebar's rootMargin prefetch — still crashed opening it

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1477,7 +1477,21 @@ export class SupernoteView extends FileView {
 		// item reports non-intersecting - it has no layout box to intersect
 		// with - so nothing loads until it's actually shown; opening it then
 		// only loads whichever thumbnails are actually scrolled into view in
-		// it, the same as the main view's own pageObserver.
+		// it.
+		//
+		// No rootMargin prefetch buffer here, unlike pageObserver's '100%
+		// 0px' - confirmed by testing (issue #154): opening the sidebar at
+		// all still crashed even after this observer existed, because a
+		// percentage margin is relative to the *root's own* size, and a
+		// thumbnail item (~150-250px, image + label) is much smaller than a
+		// main-view page (often near-full-viewport). The same 100% margin
+		// that only ever brings 1-2 main-view pages into range at once fits
+		// several times that many thumbnails into an equivalent pixel
+		// margin - each still triggering a full, real-page-resolution
+		// rasterization (ensurePageImage() has no separate cheap/low-res
+		// path), just to fill in a 140px-wide image. A thumbnail popping in
+		// slightly after it's actually scrolled to is an acceptable trade-off
+		// for a navigation aid, unlike the main reading view.
 		this.thumbObserver = new IntersectionObserver((entries) => {
 			for (const entry of entries) {
 				const index = this.thumbItems.indexOf(entry.target as HTMLElement);
@@ -1487,7 +1501,7 @@ export class SupernoteView extends FileView {
 				state.visibleInThumbnail = entry.isIntersecting;
 				this.updatePageLoadState(state);
 			}
-		}, { root: thumbSidebarEl, rootMargin: '100% 0px' });
+		}, { root: thumbSidebarEl });
 
 		for (let i = 0; i < pageCount; i++) {
 			const item = thumbSidebarEl.createDiv({ cls: 'supernote-thumb-item' });


### PR DESCRIPTION
## Summary

Follow-up to #155 (merged). The reporter confirmed main-view scrolling on the 100-page note no longer crashes, but opening the thumbnail sidebar at all still did, even with #155's lazy-load/evict cycle for thumbnails.

**Root cause**: `rootMargin` percentages are relative to the *root element's own size*, not the viewport. `thumbObserver`'s root is the sidebar, sized around each ~150-250px thumbnail item (image + label). `pageObserver`'s root (the main content area) is sized around each often-near-full-viewport page. The same `'100% 0px'` margin that only ever brings 1-2 main-view pages into range at once fits several times that many thumbnails into an equivalent pixel margin - each still triggering a full, real-page-resolution rasterization (`ensurePageImage()` has no separate cheap/low-res path for thumbnail-only loads, just to fill in a 140px-wide image). Opening the sidebar on a long document meant a burst of many simultaneous full rasterizations, not the 1-2 at a time the main view actually needed.

## Change

Removed `rootMargin` entirely for `thumbObserver` (defaults to `0px`) - a thumbnail popping in slightly after it's actually scrolled to is an acceptable trade-off for a navigation aid, unlike the main reading view, which keeps its own prefetch margin unchanged.

## What I could not verify

Same caveat as #151/#155: no Obsidian/Electron/X server available in my environment. Verified via `tsc`/`eslint`/the test suite and reasoning about `IntersectionObserver`'s `rootMargin` percentage semantics, not by actually opening the thumbnail sidebar on the reported 100-page note. **Please verify on that document** before considering #154 closed.

## Test plan
- [x] `npx tsc --noEmit` - clean
- [x] `npx eslint src/main.ts` - 0 errors
- [x] `npx vitest run` - 95 passed
- [x] `npm run build` - clean
- [ ] Manual: open the thumbnail sidebar on the 100-page note without a crash
- [ ] Manual: scroll the thumbnail sidebar itself without a crash
- [ ] Manual: thumbnails still populate (with a brief, acceptable delay) as they're scrolled to