### PR TITLE
Reserve thumbnail box size upfront to stop layout-shift pop/reflow

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1047,7 +1047,7 @@ export class SupernoteView extends FileView {
 		this.updateThumbSidebarOffset();
 
 		const body = container.createDiv({ cls: 'supernote-body' });
-		this.buildThumbSidebar(body, sn.pages.length);
+		this.buildThumbSidebar(body, sn.pages.length, sn.pageWidth, sn.pageHeight);
 
 		this.pagesEl = body.createDiv({ cls: 'supernote-pages' });
 		this.pagesEl.toggleClass('supernote-mode-text', this.layerMode === 'text');
@@ -1460,7 +1460,7 @@ export class SupernoteView extends FileView {
 	// thumbnail fills in whenever its page happens to load - from scrolling
 	// the main view, or all at once when the sidebar is first opened, see
 	// toggleThumbnails().
-	private buildThumbSidebar(body: HTMLElement, pageCount: number) {
+	private buildThumbSidebar(body: HTMLElement, pageCount: number, pageWidth: number, pageHeight: number) {
 		const thumbSidebarEl = body.createDiv({ cls: 'supernote-thumb-sidebar' });
 		this.thumbSidebarEl = thumbSidebarEl;
 		this.thumbItems = [];
@@ -1506,6 +1506,20 @@ export class SupernoteView extends FileView {
 		for (let i = 0; i < pageCount; i++) {
 			const item = thumbSidebarEl.createDiv({ cls: 'supernote-thumb-item' });
 			const img = item.createEl('img', { cls: 'supernote-thumb-img' });
+			// Reserves this thumbnail's correct box size (width is already
+			// fixed at 100% of the item via CSS; aspect-ratio derives the
+			// height from that) before ensurePageImage() ever sets `src` -
+			// an <img> with no src/dimensions otherwise collapses to ~0
+			// height, so it "pops" to full size right as it loads. That's
+			// not just visual: every pop shifts every later thumbnail's
+			// position, which reflows the whole sidebar and can re-trigger
+			// thumbObserver for a large swath of items at once - plausibly
+			// why scrolling the sidebar for a while still crashed (issue
+			// #154) even after loads were bounded to whatever's actually
+			// visible. A stable layout from the start means each item's
+			// intersection only ever changes because of an actual scroll,
+			// not a layout shift caused by a sibling loading in.
+			img.style.aspectRatio = `${pageWidth} / ${pageHeight}`;
 			item.createSpan({ cls: 'supernote-thumb-label', text: String(i + 1) });
 
 			item.addEventListener('click', () => {


### PR DESCRIPTION
## Summary

Addresses both issues reported after #156 (merged): thumbnails visibly "pop" once their image loads, and scrolling the thumbnail sidebar for a while (~50 pages) still crashed.

I think these are the same underlying bug. A thumbnail's \`<img>\` has no \`src\`/dimensions until \`ensurePageImage()\` loads it, so it collapses to ~0 height in the meantime - that's the visible "pop," but it's not just cosmetic: every pop shifts every later thumbnail's position, reflowing the whole sidebar. A reflow that moves many items at once can re-trigger \`thumbObserver\` across a large swath of them, even though nothing was actually scrolled - turning a scroll through a long sidebar into a cascade of extra load/evict churn well beyond whatever's actually visible at any moment, which #156's zero-\`rootMargin\` fix alone doesn't bound (it only limits how many are *visible* at once, not how often the whole list reflows).

## Change

Sets each thumbnail's \`aspect-ratio\` from the note's own \`pageWidth\`/\`pageHeight\` (uniform across all pages - already used for \`nativeWidth\`/\`nativeHeight\` elsewhere) before any image data exists. Width is already fixed at 100% of the item via CSS, so \`aspect-ratio\` derives the correct height immediately - the box is right from the start, nothing to pop, and an item's intersection state can now only change because of an actual scroll, not a sibling loading in and shifting everything below it.

## What I could not verify

Same caveat as the last few PRs on this issue: no Obsidian/Electron/X server in my environment. This is my best-reasoned fix connecting both symptoms, but I can't confirm the crash is actually gone at ~50 pages of thumbnail scrolling without a real device. **Please retest that specific scenario** - if it still crashes after this, the cause is something else and worth a fresh look rather than assuming this was it.

## Test plan
- [x] `npx tsc --noEmit` - clean
- [x] `npx eslint src/main.ts` - 0 errors
- [x] `npx vitest run` - 95 passed
- [x] `npm run build` - clean
- [ ] Manual: thumbnails no longer visibly pop/resize as they load
- [ ] Manual: scroll the thumbnail sidebar through 50+ pages without a crash