### PR TITLE
Debounce thumbnail loading so a fast scroll skips transient flybys

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -741,6 +741,9 @@ type PageRenderState = {
 	// wants shown.
 	visibleInMainView: boolean;
 	visibleInThumbnail: boolean;
+	// Debounces thumbObserver's load trigger (not eviction) - see its doc
+	// comment in buildThumbSidebar().
+	thumbLoadDebounceTimer: number | undefined;
 	// Guards ensureTextLayer()'s one-time (per page) work.
 	textLayerLoaded: boolean;
 	text: string;
@@ -994,6 +997,11 @@ export class SupernoteView extends FileView {
 		window.clearTimeout(this.zoomDebounceTimer);
 		this.pageObserver?.disconnect();
 		this.thumbObserver?.disconnect();
+		// Disconnecting the observer stops new callbacks, but doesn't cancel
+		// timers already scheduled by earlier ones - without this, one could
+		// still fire after the file switch and redundantly load a page from
+		// a note the user has already navigated away from.
+		for (const state of this.pageStates) window.clearTimeout(state.thumbLoadDebounceTimer);
 		this.pageStates = [];
 		this.zoomScale = 1;
 		this.renderedZoomScale = 1;
@@ -1088,6 +1096,7 @@ export class SupernoteView extends FileView {
 				imageLoadPromise: null,
 				visibleInMainView: false,
 				visibleInThumbnail: false,
+				thumbLoadDebounceTimer: undefined,
 				textLayerLoaded: false,
 				text: '',
 				spans: [],
@@ -1492,6 +1501,19 @@ export class SupernoteView extends FileView {
 		// path), just to fill in a 140px-wide image. A thumbnail popping in
 		// slightly after it's actually scrolled to is an acceptable trade-off
 		// for a navigation aid, unlike the main reading view.
+		// Loading itself (not eviction) is also debounced ~200ms - confirmed
+		// by testing (issue #154): even bounded to "only what's visible" and
+		// with the pop/reflow fixed, scrolling the sidebar *quickly* through
+		// many pages still crashed, while scrolling slowly was fine. A fast
+		// scroll flings most thumbnails past the viewport well within that
+		// window - each one is still a full, real-page-resolution
+		// rasterization (no separate cheap/low-res path for thumbnails), so
+		// a rapid flyby was triggering (then almost immediately evicting)
+		// dozens of them in quick succession. Debouncing means a thumbnail
+		// that's only ever transiently intersecting during a fast scroll
+		// never triggers a load at all - only ones the user actually lingers
+		// near for a moment do. Eviction isn't debounced: freeing memory
+		// promptly has no downside.
 		this.thumbObserver = new IntersectionObserver((entries) => {
 			for (const entry of entries) {
 				const index = this.thumbItems.indexOf(entry.target as HTMLElement);
@@ -1499,7 +1521,17 @@ export class SupernoteView extends FileView {
 				const state = this.pageStates[index];
 				if (!state) continue;
 				state.visibleInThumbnail = entry.isIntersecting;
-				this.updatePageLoadState(state);
+				window.clearTimeout(state.thumbLoadDebounceTimer);
+				if (entry.isIntersecting) {
+					state.thumbLoadDebounceTimer = window.setTimeout(() => {
+						// Re-checks rather than assuming still true - the
+						// timer firing doesn't mean nothing happened since
+						// it was scheduled.
+						if (state.visibleInThumbnail) this.updatePageLoadState(state);
+					}, 200);
+				} else {
+					this.updatePageLoadState(state);
+				}
 			}
 		}, { root: thumbSidebarEl });
 
@@ -1919,6 +1951,7 @@ export class SupernoteView extends FileView {
 		this.resizeObserver?.disconnect();
 		this.pageObserver?.disconnect();
 		this.thumbObserver?.disconnect();
+		for (const state of this.pageStates) window.clearTimeout(state.thumbLoadDebounceTimer);
 	}
 }
 


### PR DESCRIPTION
## Summary

Addresses the "scrolling quickly still crashes" half of the 3.0.2-beta.17 test report on #154 (scrolling slowly was already fine after #158's pop/reflow fix).

A fast scroll through the thumbnail sidebar flings most thumbnails past the viewport within a couple hundred milliseconds. Every one of those still triggered a full, real-page-resolution rasterization (there's no separate cheap/low-res path for thumbnails) the instant it became intersecting, then got evicted again almost as fast once it left - meaning a quick flick through a long sidebar fired off dozens of full rasterizations back-to-back in rapid succession, which #156's "only load what's visible" fix didn't prevent (each one genuinely *was* visible, if only for a moment).

## Change

Debounces the load trigger ~200ms per thumbnail: it only actually rasterizes if it's still intersecting once its timer fires, so a thumbnail that was only ever transiently in view during a fast scroll never triggers a load at all - only ones the user actually lingers near for a moment do. Eviction is deliberately **not** debounced - freeing memory promptly on scroll-away has no downside.

Also clears any pending per-page timers in `onLoadFile()`'s reset and `onClose()` - disconnecting the observer stops new callbacks but not timers an earlier one already scheduled, which could otherwise fire after a file switch and redundantly load a page from a note the user's already navigated away from.

## Downscaling thumbnails (raised in the issue, not done here)

The reporter also asked about actually downscaling thumbnail resolution instead of/alongside debouncing. That would be the more complete fix - thumbnails don't need full page resolution at all - but the rasterization pipeline (`toImage`/`extractPageRenderData` in the `supernote-typescript` submodule) has no scale/resolution parameter today; adding one is a bigger change than this PR, touching a different repo. Debouncing was the faster, lower-risk fix to try first for the specific "fast scroll" symptom - happy to look into downscaling separately if this isn't enough on its own.

## What I could not verify

Same caveat as the last several PRs here: no Obsidian/Electron/X server in my environment. Verified via `tsc`/`eslint`/tests and reasoning about the debounce's effect on IntersectionObserver's fast-scroll callback pattern, not by actually fast-scrolling the reported sidebar on a real device.

## Test plan
- [x] `npx tsc --noEmit` - clean
- [x] `npx eslint src/main.ts` - 0 errors
- [x] `npx vitest run` - 95 passed
- [x] `npm run build` - clean
- [ ] Manual: scroll the thumbnail sidebar quickly through 50+ pages without a crash
- [ ] Manual: thumbnails you actually pause near still populate within ~200ms