### PR TITLE
Pack toolbar buttons individually so they wrap tighter on narrow screens

### DIFF
--- a/src/atelierView.ts
+++ b/src/atelierView.ts
@@ -209,7 +209,8 @@ export class SupernoteAtelierView extends FileView {
 		const zoomInBtn = zoomGroup.createEl('button', { text: '+', cls: 'clickable-icon', attr: { 'aria-label': 'Zoom in' } });
 		const zoomResetBtn = zoomGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Reset zoom' } });
 		setIcon(zoomResetBtn, 'rotate-ccw');
-		this.fitWidthBtn = zoomGroup.createEl('button', { text: 'Fit width', cls: 'clickable-icon', attr: { 'aria-label': 'Fit image to viewport width' } });
+		this.fitWidthBtn = zoomGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Fit image to viewport width' } });
+		setIcon(this.fitWidthBtn, 'stretch-horizontal');
 
 		zoomOutBtn.addEventListener('click', () => this.setZoom(this.zoomScale / 1.25));
 		zoomInBtn.addEventListener('click', () => this.setZoom(this.zoomScale * 1.25));

--- a/src/atelierView.ts
+++ b/src/atelierView.ts
@@ -1,4 +1,4 @@
-import { App, Component, FileView, TFile } from 'obsidian';
+import { App, Component, FileView, TFile, setIcon } from 'obsidian';
 import { SupernoteAtelier, IAtelierSurfaceName } from 'supernote-typescript';
 import { encodeDataURL } from 'image-js';
 // esbuild's "binary" loader (see esbuild.config.mjs) embeds the wasm file as
@@ -207,7 +207,8 @@ export class SupernoteAtelierView extends FileView {
 		const zoomOutBtn = zoomGroup.createEl('button', { text: '−', cls: 'clickable-icon', attr: { 'aria-label': 'Zoom out' } });
 		this.zoomLabelEl = zoomGroup.createSpan({ cls: 'supernote-zoom-label', text: '100%' });
 		const zoomInBtn = zoomGroup.createEl('button', { text: '+', cls: 'clickable-icon', attr: { 'aria-label': 'Zoom in' } });
-		const zoomResetBtn = zoomGroup.createEl('button', { text: 'Reset zoom', cls: 'clickable-icon' });
+		const zoomResetBtn = zoomGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Reset zoom' } });
+		setIcon(zoomResetBtn, 'rotate-ccw');
 		this.fitWidthBtn = zoomGroup.createEl('button', { text: 'Fit width', cls: 'clickable-icon', attr: { 'aria-label': 'Fit image to viewport width' } });
 
 		zoomOutBtn.addEventListener('click', () => this.setZoom(this.zoomScale / 1.25));

--- a/src/main.ts
+++ b/src/main.ts
@@ -1386,7 +1386,8 @@ export class SupernoteView extends FileView {
 		const zoomOutBtn = zoomGroup.createEl('button', { text: '−', cls: 'clickable-icon', attr: { 'aria-label': 'Zoom out' } });
 		this.zoomLabelEl = zoomGroup.createSpan({ cls: 'supernote-zoom-label', text: '100%' });
 		const zoomInBtn = zoomGroup.createEl('button', { text: '+', cls: 'clickable-icon', attr: { 'aria-label': 'Zoom in' } });
-		const zoomResetBtn = zoomGroup.createEl('button', { text: 'Reset zoom', cls: 'clickable-icon' });
+		const zoomResetBtn = zoomGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Reset zoom' } });
+		setIcon(zoomResetBtn, 'rotate-ccw');
 		this.fitWidthBtn = zoomGroup.createEl('button', { text: 'Fit width', cls: 'clickable-icon', attr: { 'aria-label': 'Fit page to viewport width' } });
 
 		zoomOutBtn.addEventListener('click', () => this.setZoom(this.zoomScale / 1.25));

--- a/src/main.ts
+++ b/src/main.ts
@@ -1388,7 +1388,8 @@ export class SupernoteView extends FileView {
 		const zoomInBtn = zoomGroup.createEl('button', { text: '+', cls: 'clickable-icon', attr: { 'aria-label': 'Zoom in' } });
 		const zoomResetBtn = zoomGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Reset zoom' } });
 		setIcon(zoomResetBtn, 'rotate-ccw');
-		this.fitWidthBtn = zoomGroup.createEl('button', { text: 'Fit width', cls: 'clickable-icon', attr: { 'aria-label': 'Fit page to viewport width' } });
+		this.fitWidthBtn = zoomGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Fit page to viewport width' } });
+		setIcon(this.fitWidthBtn, 'stretch-horizontal');
 
 		zoomOutBtn.addEventListener('click', () => this.setZoom(this.zoomScale / 1.25));
 		zoomInBtn.addEventListener('click', () => this.setZoom(this.zoomScale * 1.25));
@@ -1403,8 +1404,10 @@ export class SupernoteView extends FileView {
 		this.updateFitWidthButton();
 
 		const layerGroup = toolbar.createDiv({ cls: 'supernote-toolbar-group' });
-		this.imageModeBtn = layerGroup.createEl('button', { text: 'Image', cls: 'clickable-icon', attr: { 'aria-label': 'Show page image' } });
-		this.textModeBtn = layerGroup.createEl('button', { text: 'Text', cls: 'clickable-icon', attr: { 'aria-label': 'Show recognized text' } });
+		this.imageModeBtn = layerGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Show page image' } });
+		setIcon(this.imageModeBtn, 'image');
+		this.textModeBtn = layerGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Show recognized text' } });
+		setIcon(this.textModeBtn, 'type');
 		this.imageModeBtn.addEventListener('click', () => this.setLayerMode('image'));
 		this.textModeBtn.addEventListener('click', () => this.setLayerMode('text'));
 		this.updateLayerModeButtons();

--- a/styles.css
+++ b/styles.css
@@ -139,14 +139,17 @@ div.supernote-canvas-wrap canvas {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 1em;
+    gap: 0.5em;
     margin: 0.5em 0;
 }
 
+/* display: contents lets each button wrap individually within
+   .supernote-toolbar's flex-wrap instead of the whole group wrapping as one
+   block - otherwise a single-button group (e.g. the thumbnail toggle) can
+   land alone on its own line while trailing space next to it goes unused
+   (see issue #157). */
 .supernote-toolbar-group {
-    display: flex;
-    align-items: center;
-    gap: 0.4em;
+    display: contents;
 }
 
 .supernote-zoom-label {


### PR DESCRIPTION
## Summary
Fixes #157 — the .note toolbar was taking up much more vertical space than Obsidian's built-in PDF toolbar, with the thumbnail toggle stranded alone on its own line.

- `.supernote-toolbar-group` was `display: flex`, so each group (thumbnail toggle, zoom controls, layer toggle, find, page jump) wrapped as an indivisible block. A single-button group like the thumbnail toggle would land alone on a line even with plenty of room next to it. Switching it to `display: contents` lets each button wrap individually within the parent toolbar's own flex-wrap, packing rows tighter.
- Reduced the toolbar's own gap from `1em` to `0.5em` to pack more per row.
- Swapped the "Reset zoom" text button for a compact icon button (`rotate-ccw`), matching the icon-only style already used for the thumbnail toggle and find button, and applied the same change in `atelierView.ts`'s toolbar for consistency (same CSS classes, same button).

## Test plan
- [x] `./scripts/build` (submodule init + build) succeeds
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 95 tests pass
- [x] `npx eslint src/main.ts src/atelierView.ts` — clean
- [ ] Manually verify in Obsidian mobile (or a narrow desktop window) that the toolbar now wraps to fewer lines and the thumbnail button no longer sits alone on its own row