### PR TITLE
Fix path traversal in device auto-sync (GHSA-3gx3-r874-5pp4)

### DIFF
--- a/src/FileListModal.ts
+++ b/src/FileListModal.ts
@@ -60,11 +60,22 @@ export async function scanDeviceSupernoteTree(ip: string, path = '/', visited: S
     for (const entry of entries) {
         if (entry.isDirectory) {
             results.push(...await scanDeviceSupernoteTree(ip, entry.uri, visited));
-        } else if (SYNCABLE_EXTENSION_PATTERN.test(entry.name)) {
+        } else if (SYNCABLE_EXTENSION_PATTERN.test(entry.name) && uriMatchesName(entry.uri, entry.name)) {
             results.push(entry);
         }
     }
     return results;
+}
+
+// Defense in depth against a device listing whose `name` and `uri` fields
+// disagree (e.g. a crafted `uri` carrying `../` traversal segments while
+// `name` still passes the syncable-extension filter): only trust entries
+// where `uri`'s own filename matches `name`, since every downstream
+// consumer of `uri` (deviceUriToVaultPath) assumes the two describe the
+// same file.
+function uriMatchesName(uri: string, name: string): boolean {
+    const segments = uri.split('/').filter((s) => s.length > 0);
+    return segments[segments.length - 1] === name;
 }
 
 function compareByDirectoryThenNameThenDate(a: SupernoteFile, b: SupernoteFile): number {

--- a/src/deviceSync.test.ts
+++ b/src/deviceSync.test.ts
@@ -246,6 +246,27 @@ describe('deviceUriToVaultPath (safety: deterministic, collision-free naming —
         const b = deviceUriToVaultPath('Sync', '/Work/x.note');
         expect(a).not.toBe(b);
     });
+
+    // Regression for GHSA-3gx3-r874-5pp4: a malicious/rogue device could send a
+    // `uri` containing `..` segments to escape the sync folder (and the vault
+    // entirely) on write, despite `name` alone passing the syncable-extension
+    // filter upstream.
+    it('strips ".." segments instead of letting them escape the sync folder', () => {
+        expect(deviceUriToVaultPath('Supernote sync', '/../../PWNED.txt')).toBe(
+            'Supernote sync/PWNED.txt',
+        );
+    });
+
+    it('strips "." and ".." segments anywhere in the path, not just at the start', () => {
+        expect(deviceUriToVaultPath('Sync', '/Diary/../../../etc/x.note')).toBe('Sync/Diary/etc/x.note');
+        expect(deviceUriToVaultPath('Sync', '/Diary/./x.note')).toBe('Sync/Diary/x.note');
+    });
+
+    it('never produces a resolved path outside the sync folder for any ".."-laden input', () => {
+        const path = deviceUriToVaultPath('Supernote sync', '/../../../../../../PWNED.txt');
+        expect(path.startsWith('Supernote sync/')).toBe(true);
+        expect(path).not.toContain('..');
+    });
 });
 
 describe('hashBytes', () => {

--- a/src/deviceSync.ts
+++ b/src/deviceSync.ts
@@ -153,7 +153,7 @@ const INVALID_FILENAME_CHARS = /[\\:*?"<>|]/g;
 export function deviceUriToVaultPath(syncFolder: string, deviceUri: string): string {
     const segments = deviceUri
         .split('/')
-        .filter((s) => s.length > 0)
+        .filter((s) => s.length > 0 && s !== '.' && s !== '..')
         .map((s) => s.replace(INVALID_FILENAME_CHARS, '_'));
 
     const cleanRoot = syncFolder.replace(/^\/+|\/+$/g, '');


### PR DESCRIPTION
## Summary
- Fixes GHSA-3gx3-r874-5pp4: `deviceUriToVaultPath()` sanitized invalid filename characters in a device listing's `uri` but never rejected `..` path segments, so a malicious/rogue Supernote device (or an on-LAN attacker impersonating the paired device's IP) could send a `uri` like `/../../PWNED.txt` in its directory listing and make `runDeviceSync()` create a new file outside the configured sync folder — including outside the vault entirely.
- Strips `.` and `..` segments in `deviceUriToVaultPath()` (`src/deviceSync.ts`), per the advisory's suggested remediation.
- Adds defense in depth in `scanDeviceSupernoteTree()` (`src/FileListModal.ts`): drop any listing entry whose `uri` and `name` disagree on the final filename, since `name` alone gates the `.note`/`.spd` extension filter while `uri` is what's actually used to build the write path.

## Test plan
- [x] `npx vitest run` — 98 tests pass, including new regression tests for `..`-laden `uri` values in `deviceSync.test.ts`
- [x] `npx tsc -noEmit -skipLibCheck` — clean
- [x] `npm run build` — succeeds, `main.js` produced