### PR TITLE
Fix #172: invert thumbnail colors in dark mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1894,6 +1894,9 @@ export class SupernoteView extends FileView {
 		for (let i = 0; i < pageCount; i++) {
 			const item = thumbSidebarEl.createDiv({ cls: 'supernote-thumb-item' });
 			const img = item.createEl('img', { cls: 'supernote-thumb-img' });
+			if (this.settings.invertColorsWhenDark) {
+				img.addClass("supernote-invert-dark");
+			}
 			// Reserves this thumbnail's correct box size (width is already
 			// fixed at 100% of the item via CSS; aspect-ratio derives the
 			// height from that) before ensurePageImage() ever sets `src` -


### PR DESCRIPTION
## Summary
- Thumbnails render as a separate `<img>` from the main page canvas and never got the `supernote-invert-dark` class the canvas gets, so with dark mode + "invert colors when dark" enabled, thumbnails stayed dark-on-dark while the main view correctly inverted to light strokes.
- Reuses the existing `.theme-dark img.supernote-invert-dark` CSS rule — no `styles.css` changes needed, just applying the class at thumbnail creation.

Closes #172.

## Test plan
- [x] `npm run build` (tsc typecheck + esbuild)
- [x] `npm run lint`
- [x] `npm test`
- [x] Manually verified in Obsidian: toggled dark mode with invert-colors-when-dark enabled, thumbnails now match the main view's inverted colors