### PR TITLE
Add scripts for headless Obsidian testing on Linux

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,15 +23,22 @@
   set everything up; it handles submodule init/update and both builds.
 - Tests: vitest (`npm test`), scoped to `src/**/*.test.ts` only — the
   submodule has its own separate test suite.
+- For UI/rendering changes, typecheck+lint+tests don't confirm the feature
+  actually renders correctly — `scripts/setup-obsidian-test-env` (one-time,
+  Fedora/RHEL) and `scripts/obsidian-headless` (start/stop/screenshot/click/
+  key) set up and drive a real Obsidian instance under Xvfb, so a change can
+  be screenshotted and visually confirmed even with no display attached.
 
 ### Common commands
 
 ```bash
-./scripts/build   # first-time setup: submodule + full build
-npm run dev       # esbuild watch mode
-npm run build     # tsc typecheck + production esbuild bundle (minified)
-npm run lint      # eslint .
-npm test          # vitest run
+./scripts/build                       # first-time setup: submodule + full build
+npm run dev                           # esbuild watch mode
+npm run build                         # tsc typecheck + production esbuild bundle (minified)
+npm run lint                          # eslint .
+npm test                              # vitest run
+./scripts/setup-obsidian-test-env     # one-time: set up a headless Obsidian test vault
+./scripts/obsidian-headless start     # launch it; screenshot/click/key/stop subcommands too
 ```
 
 ## Linting

--- a/scripts/obsidian-headless
+++ b/scripts/obsidian-headless
@@ -1,0 +1,109 @@
+#!/bin/sh
+# Runs the Obsidian instance set up by scripts/setup-obsidian-test-env under
+# a virtual (Xvfb) display, so it can be driven and screenshotted from a
+# terminal with no real display attached - useful for visually confirming a
+# rendering/UI change actually works, not just that it type-checks.
+#
+# Usage:
+#   scripts/obsidian-headless start                 # launch Xvfb + Obsidian
+#   scripts/obsidian-headless screenshot out.png     # capture the display
+#   scripts/obsidian-headless click <x> <y>          # click at coordinates
+#   scripts/obsidian-headless key <keysym>           # e.g. Escape, ctrl+o
+#   scripts/obsidian-headless status
+#   scripts/obsidian-headless stop                   # kill Obsidian + Xvfb
+#
+# There's no window manager running on the virtual display, so every window
+# (main window, settings dialog, ...) is unmanaged/unstacked - use
+# screenshots to find click targets rather than assuming focus-follows.
+set -e
+
+DISPLAY_NUM="${OBSIDIAN_HEADLESS_DISPLAY:-99}"
+RES="${OBSIDIAN_HEADLESS_RES:-1400x1000x24}"
+OBSIDIAN_DIR="${OBSIDIAN_INSTALL_DIR:-$HOME/opt/obsidian}"
+STATE_DIR="$HOME/.cache/obsidian-headless"
+mkdir -p "$STATE_DIR"
+XVFB_PID_FILE="$STATE_DIR/xvfb.pid"
+OBSIDIAN_PID_FILE="$STATE_DIR/obsidian.pid"
+
+is_running() {
+	# $1 = pid file
+	[ -f "$1" ] && kill -0 "$(cat "$1")" 2>/dev/null
+}
+
+cmd_start() {
+	if is_running "$XVFB_PID_FILE"; then
+		echo "Xvfb already running on :$DISPLAY_NUM (pid $(cat "$XVFB_PID_FILE"))"
+	else
+		Xvfb ":$DISPLAY_NUM" -screen 0 "$RES" -nolisten tcp >"$STATE_DIR/xvfb.log" 2>&1 &
+		echo $! > "$XVFB_PID_FILE"
+		sleep 1
+		echo "Started Xvfb on :$DISPLAY_NUM (pid $(cat "$XVFB_PID_FILE"))"
+	fi
+
+	if is_running "$OBSIDIAN_PID_FILE"; then
+		echo "Obsidian already running (pid $(cat "$OBSIDIAN_PID_FILE"))"
+		return
+	fi
+
+	if [ ! -x "$OBSIDIAN_DIR/obsidian" ]; then
+		echo "No Obsidian binary at $OBSIDIAN_DIR - run scripts/setup-obsidian-test-env first." >&2
+		exit 1
+	fi
+
+	# --no-sandbox: Electron's setuid sandbox helper needs privileges this
+	# container's user doesn't have; --disable-gpu avoids needing a real
+	# GPU/DRM device behind Xvfb.
+	(cd "$OBSIDIAN_DIR" && DISPLAY=":$DISPLAY_NUM" ./obsidian --no-sandbox --disable-gpu --disable-dev-shm-usage \
+		>"$STATE_DIR/obsidian.log" 2>&1 &
+		echo $! > "$OBSIDIAN_PID_FILE")
+	sleep 5
+	echo "Started Obsidian (pid $(cat "$OBSIDIAN_PID_FILE")); log at $STATE_DIR/obsidian.log"
+}
+
+cmd_stop() {
+	if is_running "$OBSIDIAN_PID_FILE"; then
+		pkill -P "$(cat "$OBSIDIAN_PID_FILE")" 2>/dev/null || true
+		kill "$(cat "$OBSIDIAN_PID_FILE")" 2>/dev/null || true
+	fi
+	rm -f "$OBSIDIAN_PID_FILE"
+	if is_running "$XVFB_PID_FILE"; then
+		kill "$(cat "$XVFB_PID_FILE")" 2>/dev/null || true
+	fi
+	rm -f "$XVFB_PID_FILE"
+	echo "Stopped."
+}
+
+cmd_status() {
+	if is_running "$XVFB_PID_FILE"; then echo "Xvfb: running (:$DISPLAY_NUM)"; else echo "Xvfb: stopped"; fi
+	if is_running "$OBSIDIAN_PID_FILE"; then echo "Obsidian: running"; else echo "Obsidian: stopped"; fi
+}
+
+cmd_screenshot() {
+	OUT="${1:?usage: obsidian-headless screenshot <output.png>}"
+	DISPLAY=":$DISPLAY_NUM" import -window root "$OUT"
+	echo "Saved $OUT"
+}
+
+cmd_click() {
+	X="${1:?usage: obsidian-headless click <x> <y>}"
+	Y="${2:?usage: obsidian-headless click <x> <y>}"
+	DISPLAY=":$DISPLAY_NUM" xdotool mousemove "$X" "$Y" click 1
+}
+
+cmd_key() {
+	KEYS="${1:?usage: obsidian-headless key <keysym-or-combo>}"
+	DISPLAY=":$DISPLAY_NUM" xdotool key "$KEYS"
+}
+
+case "$1" in
+	start) cmd_start ;;
+	stop) cmd_stop ;;
+	status) cmd_status ;;
+	screenshot) shift; cmd_screenshot "$@" ;;
+	click) shift; cmd_click "$@" ;;
+	key) shift; cmd_key "$@" ;;
+	*)
+		echo "Usage: $0 {start|stop|status|screenshot <out.png>|click <x> <y>|key <keys>}" >&2
+		exit 1
+		;;
+esac

--- a/scripts/setup-obsidian-test-env
+++ b/scripts/setup-obsidian-test-env
@@ -1,0 +1,122 @@
+#!/bin/sh
+# One-time setup for testing this plugin inside a real (headless) Obsidian
+# instance on Linux. Installs the system libraries Electron/Obsidian needs to
+# run under Xvfb, downloads Obsidian itself, and wires up a throwaway test
+# vault with this plugin symlinked in (so a rebuild of main.js/styles.css is
+# picked up on next launch without re-running this script).
+#
+# After this, use `scripts/obsidian-headless start` to actually launch it.
+#
+# Only tested on Fedora/RHEL (dnf). On a Debian/Ubuntu box, install the
+# equivalent -dev-less runtime libs via apt instead (nss, nspr, atk,
+# at-spi2-core, cups, libdrm2, libgbm1, libasound2, pango, cairo, libgtk-3-0,
+# the libx11/libxcomposite/libxdamage/libxfixes/libxrandr/libxtst family,
+# xvfb, dbus-x11, fonts-liberation) - the package names differ but the set of
+# shared libraries needed is the same.
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VAULT="${OBSIDIAN_TEST_VAULT:-$HOME/obsidian-test-vault}"
+OBSIDIAN_DIR="${OBSIDIAN_INSTALL_DIR:-$HOME/opt/obsidian}"
+
+if ! command -v dnf >/dev/null 2>&1; then
+	echo "This script's package install step targets dnf (Fedora/RHEL)." >&2
+	echo "See the comment at the top of this script for the Debian/Ubuntu equivalent." >&2
+	exit 1
+fi
+
+echo "==> Installing runtime libraries Obsidian's Electron needs to render under Xvfb"
+sudo dnf install -y \
+	alsa-lib at-spi2-atk at-spi2-core atk cairo cups-libs dbus-x11 gtk3 \
+	libXScrnSaver libXcomposite libXcursor libXdamage libXext libXfixes libXi \
+	libXrandr libXrender libXtst libdrm libxshmfence mesa-dri-drivers mesa-libgbm \
+	nspr nss pango xorg-x11-server-Xvfb xorg-x11-xauth xdotool \
+	liberation-sans-fonts liberation-mono-fonts ImageMagick
+
+if [ -x "$OBSIDIAN_DIR/obsidian" ] && [ "$1" != "--force" ]; then
+	echo "==> Obsidian already installed at $OBSIDIAN_DIR (pass --force to re-download)"
+else
+	case "$(uname -m)" in
+		aarch64|arm64) ASSET_ARCH="arm64" ;;
+		x86_64|amd64) ASSET_ARCH="x64" ;;
+		*) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+	esac
+
+	echo "==> Looking up latest Obsidian release for linux-$ASSET_ARCH"
+	if [ "$ASSET_ARCH" = "x64" ]; then
+		# The x64 tarball's name has no arch suffix at all (just
+		# obsidian-<version>.tar.gz), unlike arm64's
+		# obsidian-<version>-arm64.tar.gz - so this can't just grep
+		# for "x64", it has to grep for tar.gz and exclude arm64.
+		URL=$(curl -sL https://api.github.com/repos/obsidianmd/obsidian-releases/releases/latest \
+			| grep browser_download_url \
+			| grep '\.tar\.gz"' \
+			| grep -v arm64 \
+			| cut -d'"' -f4)
+	else
+		URL=$(curl -sL https://api.github.com/repos/obsidianmd/obsidian-releases/releases/latest \
+			| grep browser_download_url \
+			| grep -- "-${ASSET_ARCH}.tar.gz\"" \
+			| cut -d'"' -f4)
+	fi
+	if [ -z "$URL" ]; then
+		echo "Couldn't find a linux-$ASSET_ARCH tarball in the latest obsidian-releases release." >&2
+		exit 1
+	fi
+
+	echo "==> Downloading $URL"
+	TMP_TGZ="$(mktemp --suffix=.tar.gz)"
+	curl -sL "$URL" -o "$TMP_TGZ"
+
+	rm -rf "$OBSIDIAN_DIR"
+	mkdir -p "$OBSIDIAN_DIR"
+	tar xzf "$TMP_TGZ" -C "$OBSIDIAN_DIR" --strip-components=1
+	rm -f "$TMP_TGZ"
+fi
+
+echo "==> Setting up test vault at $VAULT"
+PLUGIN_DIR="$VAULT/.obsidian/plugins/supernote"
+mkdir -p "$PLUGIN_DIR"
+
+# Symlinked, not copied: a rebuild (npm run build / npm run dev) in the repo
+# is reflected the next time Obsidian (re)loads the plugin, no re-run of this
+# script needed.
+ln -sf "$REPO_ROOT/manifest.json" "$PLUGIN_DIR/manifest.json"
+ln -sf "$REPO_ROOT/main.js" "$PLUGIN_DIR/main.js"
+ln -sf "$REPO_ROOT/styles.css" "$PLUGIN_DIR/styles.css"
+
+if [ ! -f "$VAULT/.obsidian/community-plugins.json" ]; then
+	echo '["supernote"]' > "$VAULT/.obsidian/community-plugins.json"
+fi
+
+# Drop in a real .note file to open, if the repo has one checked in and the
+# vault doesn't have one of its own yet (leaves any already there alone, in
+# case a previous run's manual edits/exports should be kept).
+if ! find "$VAULT" -maxdepth 1 -iname '*.note' -print -quit | grep -q . ; then
+	SAMPLE_NOTE=$(find "$REPO_ROOT" -maxdepth 1 -iname '*.note' -print -quit)
+	if [ -n "$SAMPLE_NOTE" ]; then
+		cp "$SAMPLE_NOTE" "$VAULT/"
+	fi
+fi
+
+echo "==> Registering $VAULT with Obsidian and marking it open-on-launch"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/obsidian"
+mkdir -p "$CONFIG_DIR"
+OBSIDIAN_JSON="$CONFIG_DIR/obsidian.json"
+[ -f "$OBSIDIAN_JSON" ] || echo '{"vaults":{}}' > "$OBSIDIAN_JSON"
+
+VAULT_ID=$(python3 -c "import uuid; print(uuid.uuid4().hex[:16])")
+TS=$(date +%s%3N)
+jq --arg id "$VAULT_ID" --arg path "$VAULT" --argjson ts "$TS" '
+	.vaults = (.vaults // {}) |
+	((.vaults | to_entries | map(select(.value.path == $path)))[0].key) as $existing_id |
+	if $existing_id then
+		.vaults[$existing_id].ts = $ts | .vaults[$existing_id].open = true
+	else
+		.vaults[$id] = {path: $path, ts: $ts, open: true}
+	end
+' "$OBSIDIAN_JSON" > "$OBSIDIAN_JSON.tmp"
+mv "$OBSIDIAN_JSON.tmp" "$OBSIDIAN_JSON"
+
+echo
+echo "Done. Next: scripts/obsidian-headless start"


### PR DESCRIPTION
## Summary
- `scripts/setup-obsidian-test-env`: one-time setup — installs the runtime libraries Electron/Obsidian needs to render under Xvfb (dnf/Fedora), downloads the matching Obsidian Linux release for the host arch, and wires up a throwaway test vault with this plugin **symlinked** in (`manifest.json`/`main.js`/`styles.css`), so a rebuild is picked up on next launch without rerunning setup.
- `scripts/obsidian-headless`: drives it — `start`/`stop`/`status`/`screenshot <file>`/`click <x> <y>`/`key <keys>`, for taking screenshots of a real running Obsidian instance with no physical display attached.

This came out of manually verifying the #172 thumbnail dark-mode fix (PR #173) — there was no way to visually confirm a rendering change actually worked short of trusting typecheck/lint/tests, so this sets up a real Obsidian instance to screenshot instead. Verified working end-to-end (opened the bundled `Moonchild notes.note`, toggled dark mode, confirmed both main view and thumbnails render as expected).

Only tested on Fedora/RHEL (dnf) on aarch64; the script notes the Debian/Ubuntu package-name equivalents needed if adapted.

## Test plan
- [x] Ran `scripts/setup-obsidian-test-env` from a clean state (no prior install) — completes without error, plugin symlinked into test vault
- [x] Ran `scripts/obsidian-headless start` / `screenshot` / `stop` — Obsidian launches under Xvfb, screenshot captures the real rendered UI, clean shutdown