### PR TITLE
Show a Notice when exports finish

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"id": "supernote",
 	"name": "Supernote (Unofficial)",
 	"version": "2.9.1",
-	"minAppVersion": "1.7.2",
+	"minAppVersion": "1.8.7",
 	"description": "View Supernote notes, generate markdown from note and capture screen mirror.",
 	"author": "Brandon Philips",
 	"authorUrl": "https://ifup.org",

--- a/src/main.ts
+++ b/src/main.ts
@@ -594,11 +594,21 @@ class VaultWriter {
 		return new ImageConverter().convertToImages(sn);
 	}
 
+	// A 100-page PDF conversion (or similar) can take a while, so surface
+	// completion with a Notice instead of leaving the user to guess whether
+	// anything happened - clicking it jumps straight to the new file.
+	private notifyExportComplete(file: TFile) {
+		const notice = new Notice(`Created "${file.path}" - click to open`);
+		notice.noticeEl.addEventListener('click', () => {
+			void this.app.workspace.getLeaf(false).openFile(file);
+		});
+	}
+
 	// `images` (raw rasterized page data URLs, for processors) is independent
 	// of `imgs` (vault TFiles, for the embedded image links) — a markdown-only
 	// export passes `imgs: null` but can still pass `images` so registered
 	// processors run, even though no image attachment gets saved.
-	async writeMarkdownFile(file: TFile, sn: SupernoteX, imgs: TFile[] | null, images: string[] | null = null) {
+	async writeMarkdownFile(file: TFile, sn: SupernoteX, imgs: TFile[] | null, images: string[] | null = null): Promise<TFile> {
 		let content = '';
 
 		// Generate a non-conflicting filename - it has a bit of a race but that is OK
@@ -631,7 +641,7 @@ class VaultWriter {
 			}
 		}
 
-		await this.app.vault.create(filename, content);
+		return this.app.vault.create(filename, content);
 	}
 
 	// `images` is already-rasterized page data URLs (see rasterizePages()) —
@@ -655,7 +665,8 @@ class VaultWriter {
 		// processor still needs one to work with — rasterize only when
 		// there's actually a processor to hand it to.
 		const images = this.processors.size > 0 ? await this.rasterizePages(sn) : null;
-		await this.writeMarkdownFile(file, sn, null, images);
+		const mdFile = await this.writeMarkdownFile(file, sn, null, images);
+		this.notifyExportComplete(mdFile);
 	}
 
 	async attachNoteFiles(file: TFile) {
@@ -664,7 +675,8 @@ class VaultWriter {
 
 		const images = await this.rasterizePages(sn);
 		const imgs = await this.writeImageFiles(file.basename, images);
-		await this.writeMarkdownFile(file, sn, imgs, images);
+		const mdFile = await this.writeMarkdownFile(file, sn, imgs, images);
+		this.notifyExportComplete(mdFile);
 	}
 
 	/**
@@ -777,7 +789,8 @@ class VaultWriter {
 
 		// Generate filename and save
 		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}.pdf`);
-		await this.app.vault.createBinary(filename, toArrayBuffer(pdfBytes));
+		const pdfFile = await this.app.vault.createBinary(filename, toArrayBuffer(pdfBytes));
+		this.notifyExportComplete(pdfFile);
 	}
 
 	// `.spd` (Supernote Atelier) equivalents of the exports above. Unlike
@@ -794,7 +807,9 @@ class VaultWriter {
 	async attachAtelierImage(file: TFile): Promise<TFile> {
 		const dataUrl = await this.rasterizeAtelier(file);
 		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}.png`);
-		return this.app.vault.createBinary(filename, dataUrlToBuffer(dataUrl));
+		const pngFile = await this.app.vault.createBinary(filename, dataUrlToBuffer(dataUrl));
+		this.notifyExportComplete(pngFile);
+		return pngFile;
 	}
 
 	async exportAtelierToPDF(file: TFile) {
@@ -802,7 +817,8 @@ class VaultWriter {
 		const pdfBytes = await buildSinglePagePdf(dataUrl);
 
 		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}.pdf`);
-		await this.app.vault.createBinary(filename, toArrayBuffer(pdfBytes));
+		const pdfFile = await this.app.vault.createBinary(filename, toArrayBuffer(pdfBytes));
+		this.notifyExportComplete(pdfFile);
 	}
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -599,7 +599,7 @@ class VaultWriter {
 	// anything happened - clicking it jumps straight to the new file.
 	private notifyExportComplete(file: TFile) {
 		const notice = new Notice(`Created "${file.path}" - click to open`);
-		notice.noticeEl.addEventListener('click', () => {
+		notice.messageEl.addEventListener('click', () => {
 			void this.app.workspace.getLeaf(false).openFile(file);
 		});
 	}


### PR DESCRIPTION
## Summary
- Fixes #167: exports (PDF, markdown/image attachments, atelier PNG/PDF) now show a `Notice` when they finish, since long ones (e.g. a 100-page PDF conversion) previously gave no feedback once complete.
- The Notice is clickable — clicking it opens the newly created file in the current leaf.
- Applied consistently to every export/attach path in `VaultWriter`: `exportToPDF`, `exportAtelierToPDF`, `attachMarkdownFile`, `attachNoteFiles`, `attachAtelierImage`.
- Uses `Notice.messageEl` (not the deprecated `noticeEl`) as the click target. This requires Obsidian ≥1.8.7 (per `obsidianmd/no-unsupported-api` lint), so `minAppVersion` in `manifest.json` is bumped from `1.7.2` to `1.8.7`.

## Test plan
- [x] `npx tsc -noEmit` passes
- [x] `npm run build` succeeds
- [x] `npx eslint .` — no errors
- [x] `npm test` — 98/98 passing
- [x] Manual check in Obsidian: export a large note as PDF and confirm the Notice appears and clicking it opens the file