### PR TITLE
Fix #171: compact, reliably-selectable text mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -887,6 +887,14 @@ type PageRenderState = {
 	canvas: HTMLCanvasElement;
 	textLayerDiv: HTMLElement;
 	linksLayerDiv: HTMLElement;
+	// Compact/reflowed text mode's own display element - see
+	// ensureCompactText(). Independent of textLayerDiv above, which stays
+	// word-positioned (used for search-highlighting over the page image
+	// regardless of layerMode) rather than reflowed.
+	compactTextDiv: HTMLElement;
+	// Guards ensureCompactText()'s one-time (per page) work, same pattern as
+	// textLayerLoaded below.
+	compactTextLoaded: boolean;
 	// Rendered once at page-build time, in native (unscaled) page-pixel
 	// coordinates; repositioned to the current CSS pixel size on every
 	// drawPageImage() call (initial render + each zoom redraw) — see
@@ -1190,6 +1198,7 @@ export class SupernoteView extends FileView {
 						if (!state.visibleInMainView) return;
 						void this.ensurePageImage(state);
 						void this.ensureTextLayer(state);
+						this.ensureCompactText(state);
 					}, 150);
 				} else {
 					this.evictPageImage(state);
@@ -1303,6 +1312,15 @@ export class SupernoteView extends FileView {
 			if (this.settings.invertColorsWhenDark) {
 				canvas.addClass("supernote-invert-dark");
 			}
+			// Sibling of canvasWrap, not a child - unlike textLayerDiv (which
+			// mirrors canvasWrap's exact page-pixel dimensions to sit on top of
+			// it), this needs its own independent size: a reflowed column of
+			// text has no reason to match the page's aspect ratio. See
+			// ensureCompactText(). Text mode hides the whole of canvasWrap
+			// (see styles.css), linksLayerDiv included - internal note links
+			// have no clickable overlay here, only in image mode; there's no
+			// natural position to anchor one to once the text is reflowed.
+			const compactTextDiv = pageContainer.createDiv({ cls: 'supernote-compact-text' });
 
 			const state: PageRenderState = {
 				pageNumber: i + 1,
@@ -1314,6 +1332,8 @@ export class SupernoteView extends FileView {
 				canvas,
 				textLayerDiv: canvasWrap.createDiv({ cls: 'textLayer' }),
 				linksLayerDiv: canvasWrap.createDiv({ cls: 'supernote-links-layer' }),
+				compactTextDiv,
+				compactTextLoaded: false,
 				linkEls: [],
 				imageBitmap: null,
 				imageDataUrl: null,
@@ -1737,6 +1757,35 @@ export class SupernoteView extends FileView {
 		}
 	}
 
+	// Populates this page's compact/reflowed text view (see setLayerMode()'s
+	// 'text' mode) straight from the note's own recognized text - already
+	// reconstructed into reading-order lines/paragraphs by
+	// supernote-typescript's parsing (the same source markdown export uses;
+	// see exportToMarkdown()) - rather than pdf.js's word-positioned text
+	// layer (buildTextLayerForState()). That positioned layer is exactly
+	// what made the old text mode's selection unreliable (issue #171):
+	// dragging a selection across many individually-absolutely-positioned
+	// spans, arranged to match the original handwriting's x/y layout rather
+	// than a linear reading order, copies inconsistently and leaves large
+	// gaps for pages with sparse handwriting. A plain string in normal
+	// document flow has neither problem.
+	//
+	// Synchronous (no pdf.js/network/worker involved) but still gated behind
+	// a per-page loaded flag and called lazily (pageObserver, goToPage,
+	// setLayerMode('text')) rather than eagerly for every page at file-load
+	// time - consistent with how ensurePageImage()/ensureTextLayer() avoid
+	// doing all of a long note's pages' worth of work upfront (see
+	// onOpen()'s pageObserver comment).
+	private ensureCompactText(state: PageRenderState): void {
+		if (state.compactTextLoaded) return;
+		state.compactTextLoaded = true;
+
+		const rawText = this.sn?.pages[state.pageNumber - 1]?.text ?? '';
+		const hasText = rawText.length > 0;
+		state.compactTextDiv.toggleClass('supernote-compact-text-empty', !hasText);
+		state.compactTextDiv.setText(hasText ? processSupernoteText(rawText, this.settings) : 'No recognized text on this page.');
+	}
+
 	private buildToolbar(container: HTMLElement, pageCount: number) {
 		this.pageJumpInput = null;
 		const toolbar = container.createDiv({ cls: 'supernote-toolbar' });
@@ -1772,7 +1821,7 @@ export class SupernoteView extends FileView {
 		const layerGroup = toolbar.createDiv({ cls: 'supernote-toolbar-group' });
 		this.imageModeBtn = layerGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Show page image' } });
 		setIcon(this.imageModeBtn, 'image');
-		this.textModeBtn = layerGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Show recognized text' } });
+		this.textModeBtn = layerGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Show recognized text (compact)' } });
 		setIcon(this.textModeBtn, 'type');
 		this.imageModeBtn.addEventListener('click', () => this.setLayerMode('image'));
 		this.textModeBtn.addEventListener('click', () => this.setLayerMode('text'));
@@ -1816,6 +1865,19 @@ export class SupernoteView extends FileView {
 		this.layerMode = mode;
 		this.pagesEl?.toggleClass('supernote-mode-text', mode === 'text');
 		this.updateLayerModeButtons();
+
+		// Unlike ensurePageImage()/ensureTextLayer(), this is cheap enough
+		// (plain strings already held in memory as part of `this.sn`, no
+		// decode/network/worker involved) to just do for every page the
+		// moment the user actually asks for text mode, rather than waiting
+		// on each page to individually scroll into view first - so the
+		// whole note reads as compact text immediately, not page-by-page as
+		// you scroll.
+		if (mode === 'text') {
+			for (const state of this.pageStates) {
+				this.ensureCompactText(state);
+			}
+		}
 	}
 
 	private updateLayerModeButtons() {
@@ -1987,6 +2049,7 @@ export class SupernoteView extends FileView {
 		state.visibleInMainView = true;
 		void this.ensurePageImage(state);
 		void this.ensureTextLayer(state);
+		this.ensureCompactText(state);
 		if (this.pageJumpInput) this.pageJumpInput.value = String(clamped);
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1312,6 +1312,16 @@ export class SupernoteView extends FileView {
 			if (this.settings.invertColorsWhenDark) {
 				canvas.addClass("supernote-invert-dark");
 			}
+			// Text mode's own page number marker - in image mode, which page
+			// is which is obvious from the image itself (and the toolbar's
+			// page-jump box); in text mode, a long note is just a scrolling
+			// column of paragraphs with nothing else distinguishing one
+			// page's text from the next (issue #171's own follow-up report).
+			// Known immediately (just this loop's index), so unlike
+			// compactTextDiv's own content below, this needs no lazy
+			// population - it's created and filled in up front for every
+			// page, same as the thumbnail sidebar's own per-page labels.
+			pageContainer.createDiv({ cls: 'supernote-compact-text-label', text: `Page ${i + 1}` });
 			// Sibling of canvasWrap, not a child - unlike textLayerDiv (which
 			// mirrors canvasWrap's exact page-pixel dimensions to sit on top of
 			// it), this needs its own independent size: a reflowed column of

--- a/styles.css
+++ b/styles.css
@@ -220,7 +220,20 @@ div.supernote-canvas-wrap canvas {
     font-style: italic;
 }
 
-.supernote-mode-text .supernote-compact-text {
+/* Text mode's per-page marker (see the page-build loop in onLoadFile()) -
+   same muted/small treatment as .supernote-thumb-label and
+   .supernote-page-jump-total, so a long note's worth of stacked text blocks
+   in text mode still reads as distinct pages while scrolling. */
+.supernote-compact-text-label {
+    display: none;
+    margin: 0 0 0.3em;
+    color: var(--text-muted);
+    font-size: var(--font-smaller);
+    font-weight: var(--font-semibold);
+}
+
+.supernote-mode-text .supernote-compact-text,
+.supernote-mode-text .supernote-compact-text-label {
     display: block;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -184,6 +184,23 @@ div.supernote-canvas-wrap canvas {
     display: none;
 }
 
+/* div.page-container above is display: inline-block, which shrink-to-fits
+   its content's width - fine in image mode, where canvasWrap always carries
+   an explicit pixel width (see drawPageImage()) for it to shrink-to-fit
+   *to*, identically on every page (same source page dimensions). Text mode
+   has no such explicit width anywhere in the chain, so that same
+   shrink-to-fit instead sized each page's box to whatever its own longest
+   line happened to need, up to .supernote-compact-text's max-width below -
+   a short page got a narrow box, a long one a wide one. Switching to
+   display: block for text mode's page-container stretches it to
+   .supernote-pages' own (flex-determined, so already page-count- and
+   content-independent) full width instead, giving the child's `width: 100%`
+   below something concrete and *uniform across every page* to resolve
+   against. */
+.supernote-mode-text .page-container {
+    display: block;
+}
+
 /* Compact text mode - see SupernoteView.ensureCompactText(). Reflowed plain
    text in normal document flow (not positioned to match the original
    handwriting layout, unlike .textLayer above), so selection/copy behaves

--- a/styles.css
+++ b/styles.css
@@ -189,13 +189,24 @@ div.supernote-canvas-wrap canvas {
    handwriting layout, unlike .textLayer above), so selection/copy behaves
    like any other text and a sparse page doesn't leave a huge blank gap.
    Hidden outside text mode; sized independently of the page's own pixel
-   dimensions/aspect ratio, unlike canvasWrap/textLayer. */
+   dimensions/aspect ratio, unlike canvasWrap/textLayer.
+
+   user-select: text is not the default and has to be opted into explicitly
+   - Obsidian sets `body { user-select: none; }` and only opts specific
+   elements it controls back in (its editor, markdown preview, its own PDF
+   viewer's .textLayer via `.pdf-container .textLayer`, which - being scoped
+   to .pdf-container - doesn't reach this plugin's own same-named .textLayer
+   either). Without this, the text renders exactly as intended but a drag
+   across it does nothing - confirmed via issue #171's own follow-up. */
 .supernote-compact-text {
     display: none;
     box-sizing: border-box;
     width: 100%;
     max-width: 42em;
     padding: 1em 1.2em;
+    user-select: text;
+    -webkit-user-select: text;
+    cursor: text;
     white-space: pre-wrap;
     overflow-wrap: break-word;
     color: var(--text-normal);

--- a/styles.css
+++ b/styles.css
@@ -176,20 +176,41 @@ div.supernote-canvas-wrap canvas {
     color: var(--text-muted);
 }
 
-/* Text mode: hide the raster page, make the text layer's spans (otherwise
-   transparent, for overlaying selectable text on the image) actually
-   visible in roughly their original on-page layout. */
-.supernote-mode-text .supernote-canvas-wrap canvas {
+/* Text mode: hide the raster page (and its word-positioned, invisible
+   textLayer overlay - that one stays reserved for search-highlighting over
+   the image in image mode, see runFind()) in favor of .supernote-compact-text
+   below. */
+.supernote-mode-text .supernote-canvas-wrap {
     display: none;
 }
 
-.supernote-mode-text .textLayer {
+/* Compact text mode - see SupernoteView.ensureCompactText(). Reflowed plain
+   text in normal document flow (not positioned to match the original
+   handwriting layout, unlike .textLayer above), so selection/copy behaves
+   like any other text and a sparse page doesn't leave a huge blank gap.
+   Hidden outside text mode; sized independently of the page's own pixel
+   dimensions/aspect ratio, unlike canvasWrap/textLayer. */
+.supernote-compact-text {
+    display: none;
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 42em;
+    padding: 1em 1.2em;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    color: var(--text-normal);
     background: var(--background-primary);
     border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-s);
 }
 
-.supernote-mode-text .textLayer span {
-    color: var(--text-normal);
+.supernote-compact-text-empty {
+    color: var(--text-muted);
+    font-style: italic;
+}
+
+.supernote-mode-text .supernote-compact-text {
+    display: block;
 }
 
 .supernote-find-bar {


### PR DESCRIPTION
## Summary
Text mode used to show pdf.js's word-positioned text layer directly (built from a synthetic text-only PDF purely so pdf.js's `TextLayer` API could be reused) - each recognized word absolutely positioned to match the original handwriting's x/y layout. That's exactly what made selection unreliable: dragging across many individually-positioned spans copies inconsistently, and a page with sparse handwriting left a huge blank gap the full height of the page.

Text mode now shows the note's own recognized text - already reconstructed into reading-order lines/paragraphs by supernote-typescript's parsing (the same source markdown export already uses) - reflowed in normal document flow. Selection/copy works like any other text, and a page's box is only as tall as its actual text.

The word-positioned text layer is untouched and still used for search-highlighting over the page image in image mode (`runFind()`) - this only changes what text mode itself displays.

Closes #171.

## Test plan
- [x] `npm run build` (tsc typecheck + production esbuild bundle)
- [x] `npm run lint`
- [x] `npm test`
- [x] Manually verified end-to-end in a real Obsidian instance (`scripts/obsidian-headless`): opened a multi-page note, toggled text mode - text renders as clean flowing paragraphs instead of the old scattered positioned layout; toggled back to image mode without issue; confirmed readable contrast in both light and dark themes