### PR TITLE
Export current page as image

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1853,6 +1853,15 @@ export class SupernoteView extends FileView {
 		this.textModeBtn.addEventListener('click', () => this.setLayerMode('text'));
 		this.updateLayerModeButtons();
 
+		const exportGroup = toolbar.createDiv({ cls: 'supernote-toolbar-group' });
+		const exportPageBtn = exportGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Export current page as image' } });
+		setIcon(exportPageBtn, 'download');
+		exportPageBtn.addEventListener('click', () => {
+			this.exportCurrentPageAsImage().catch((err: unknown) => {
+				new ErrorModal(this.app, err instanceof Error ? err : new Error(String(err))).open();
+			});
+		});
+
 		// Mod+F (registered in onOpen) already toggles the find bar, but that
 		// hotkey has no mobile equivalent — without a button, search is
 		// unreachable on touch devices. Toolbar button covers both.
@@ -2077,6 +2086,32 @@ export class SupernoteView extends FileView {
 		void this.ensureTextLayer(state);
 		this.ensureCompactText(state);
 		if (this.pageJumpInput) this.pageJumpInput.value = String(clamped);
+	}
+
+	// Saves just the page currently shown in the toolbar's page indicator
+	// (kept up to date by updateCurrentPageIndicator()'s scrollspy) as a PNG
+	// attachment — the single-page equivalent of the per-page "Save image to
+	// vault" button, for when the user only wants the page they're looking
+	// at right now rather than the whole note. See issue #169. Exposed as a
+	// command (see 'export-current-page-as-image') and a toolbar button.
+	async exportCurrentPageAsImage(): Promise<void> {
+		if (this.pageStates.length === 0) return;
+		const requested = this.pageJumpInput ? Number(this.pageJumpInput.value) : 1;
+		const clamped = Math.min(this.pageStates.length, Math.max(1, Number.isFinite(requested) ? requested : 1));
+		const state = this.pageStates[clamped - 1];
+
+		// Same race as goToPage() above — force this page "visible" so
+		// ensurePageImage() doesn't discard the load if pageObserver hasn't
+		// caught up with the current scroll position yet.
+		state.visibleInMainView = true;
+		await this.ensurePageImage(state);
+		if (!state.imageDataUrl) {
+			throw new Error(`Page ${clamped} has no rendered image to export.`);
+		}
+
+		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${this.file.basename}-page-${clamped}.png`);
+		await this.app.vault.createBinary(filename, dataUrlToBuffer(state.imageDataUrl));
+		new Notice(`Saved page ${clamped} as ${filename}`);
 	}
 
 	// A clicked link region's target: same-file (jump in place via goToPage)
@@ -2883,6 +2918,21 @@ export default class SupernotePlugin extends Plugin {
 				}
 
 				return false;
+			},
+		});
+
+		this.addCommand({
+			id: 'export-current-page-as-image',
+			name: 'Export current page as PNG attachment',
+			checkCallback: (checking: boolean) => {
+				const view = this.app.workspace.getActiveViewOfType(SupernoteView);
+				if (!view) return false;
+				if (checking) return true;
+
+				view.exportCurrentPageAsImage().catch((err: unknown) => {
+					new ErrorModal(this.app, err instanceof Error ? err : new Error(String(err))).open();
+				});
+				return true;
 			},
 		});
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2112,20 +2112,11 @@ export class SupernoteView extends FileView {
 		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${this.file.basename}-page-${clamped}.png`);
 		const savedFile = await this.app.vault.createBinary(filename, dataUrlToBuffer(state.imageDataUrl));
 
-		// Clickable so the saved PNG is one click away instead of requiring a
-		// manual hunt through the file explorer for it.
-		const message = createFragment((frag) => {
-			frag.appendText(`Saved page ${clamped} as `);
-			frag.createEl('a', { text: filename, href: '#' });
-		});
-		const notice = new Notice(message, 8000);
-		// `messageEl` (its non-deprecated replacement) needs Obsidian 1.8.7;
-		// this plugin's minAppVersion is 1.7.2, and noticeEl works the same
-		// for this purpose since 0.9.7.
-		notice.noticeEl.addEventListener('click', (evt) => {
-			evt.preventDefault();
-			void this.app.workspace.getLeaf(true).openFile(savedFile);
-			notice.hide();
+		// Same "click to open" completion notice as VaultWriter's exports
+		// (see notifyExportComplete(), issue #167 / PR #175).
+		const notice = new Notice(`Created "${savedFile.path}" - click to open`);
+		notice.messageEl.addEventListener('click', () => {
+			void this.app.workspace.getLeaf(false).openFile(savedFile);
 		});
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2110,8 +2110,23 @@ export class SupernoteView extends FileView {
 		}
 
 		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${this.file.basename}-page-${clamped}.png`);
-		await this.app.vault.createBinary(filename, dataUrlToBuffer(state.imageDataUrl));
-		new Notice(`Saved page ${clamped} as ${filename}`);
+		const savedFile = await this.app.vault.createBinary(filename, dataUrlToBuffer(state.imageDataUrl));
+
+		// Clickable so the saved PNG is one click away instead of requiring a
+		// manual hunt through the file explorer for it.
+		const message = createFragment((frag) => {
+			frag.appendText(`Saved page ${clamped} as `);
+			frag.createEl('a', { text: filename, href: '#' });
+		});
+		const notice = new Notice(message, 8000);
+		// `messageEl` (its non-deprecated replacement) needs Obsidian 1.8.7;
+		// this plugin's minAppVersion is 1.7.2, and noticeEl works the same
+		// for this purpose since 0.9.7.
+		notice.noticeEl.addEventListener('click', (evt) => {
+			evt.preventDefault();
+			void this.app.workspace.getLeaf(true).openFile(savedFile);
+			notice.hide();
+		});
 	}
 
 	// A clicked link region's target: same-file (jump in place via goToPage)


### PR DESCRIPTION
## Summary
- Adds a toolbar button (download icon) and a command palette entry ("Export current page as PNG attachment") that saves just the page currently shown in the viewer as a PNG attachment.
- Reuses the existing per-page rasterization path (`ensurePageImage`) and the toolbar's existing page-indicator (`pageJumpInput`, kept live by the scrollspy in `updateCurrentPageIndicator`) to determine which page is "current", so it works whether or not the user has `showExportButtons` enabled.

Fixes #169.

## Test plan
- [x] `npm run build` (tsc typecheck + esbuild bundle)
- [x] `npm run lint`
- [x] `npm test` (98 tests passing)
- [x] Manual click-through in Obsidian (not done in this session — the shared headless Obsidian test instance was in use by another concurrent task)