### PR TITLE
Fix issue #179: thumbnail sidebar overlays instead of resizing the page view

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1279,6 +1279,9 @@ export class SupernoteView extends FileView {
 		this.updateThumbSidebarOffset();
 
 		const body = container.createDiv({ cls: 'supernote-body' });
+		// Issue #179: still a sibling of pagesEl inside body, but see CSS -
+		// they now share a single CSS Grid cell (stacked, not side-by-side in
+		// a flex row) so the sidebar overlays pagesEl instead of squeezing it.
 		this.buildThumbSidebar(body, sn.pages.length, sn.pageWidth, sn.pageHeight);
 
 		this.pagesEl = body.createDiv({ cls: 'supernote-pages' });
@@ -1935,16 +1938,10 @@ export class SupernoteView extends FileView {
 		this.thumbToggleBtn?.toggleClass('is-active', this.thumbnailsVisible);
 		if (this.thumbnailsVisible) this.updateThumbSidebarOffset();
 
-		// Showing/hiding the sidebar changes how much horizontal room pagesEl
-		// actually has, but that's an internal flex redistribution within
-		// contentEl, not a change to contentEl's own box — the ResizeObserver
-		// driving auto-refit on window/pane resize never fires for it. Without
-		// this, a page already fit to the full width just sits there too wide
-		// once the sidebar eats into that space, spilling into horizontal
-		// scroll instead of shrinking to match.
-		if (this.fitWidthEnabled) {
-			this.applyFitWidth();
-		}
+		// Unlike before issue #179's fix, the sidebar now overlays pagesEl
+		// (see CSS `.supernote-thumb-sidebar`) instead of sitting alongside it
+		// in the same flex row, so toggling it never changes pagesEl's own
+		// width - no fit-width re-render needed here.
 	}
 
 	// The thumbnail sidebar is sticky below the header, not at top:0 like the
@@ -2138,9 +2135,10 @@ export class SupernoteView extends FileView {
 	}
 
 	// Scales the page so its rendered width matches however much horizontal
-	// space is actually available (pagesEl's content box, which already
-	// accounts for the thumbnail sidebar if it's open) minus the page
-	// container's own margin.
+	// space is actually available (pagesEl's content box - the thumbnail
+	// sidebar overlays pagesEl rather than sharing its flex row, so this
+	// doesn't need to account for whether it's open, see
+	// applyThumbSidebarVisibility()) minus the page container's own margin.
 	private applyFitWidth() {
 		const state = this.pageStates[0];
 		if (!state || !this.pagesEl || state.nativeWidth <= 0) return;

--- a/styles.css
+++ b/styles.css
@@ -209,31 +209,53 @@ div.supernote-canvas-wrap canvas {
     font-size: var(--font-smaller);
 }
 
+/* Issue #179: .supernote-pages and .supernote-thumb-sidebar both sit in this
+   single grid cell (see grid-row/grid-column below) instead of splitting a
+   flex row between them. Previously, opening/closing the sidebar changed how
+   much of that row pagesEl got, which fit-width then re-rendered every page's
+   size against, reflowing the whole note and bouncing whatever page was
+   currently in view. Stacking them means pagesEl always gets the cell's full
+   width regardless of whether the sidebar is showing - it overlays pagesEl
+   instead of squeezing it. */
 .supernote-body {
-    display: flex;
-    align-items: flex-start;
-    gap: 1em;
+    display: grid;
+    grid-template-columns: 1fr;
 }
 
 .supernote-pages {
-    flex: 1 1 auto;
+    grid-column: 1;
+    grid-row: 1;
     min-width: 0;
 }
 
+/* justify-self/align-self (not the old flex gap/align-items on .supernote-body)
+   position this within the shared grid cell - hugging the top-right corner,
+   same spot it occupied back when it was a flex sibling. Still position:
+   sticky (unchanged from before this issue - that part already worked, it's
+   only the flex-row width-sharing that caused the bounce) so it keeps
+   tracking scroll the same way .supernote-header does. z-index lifts it
+   above pagesEl's own (unpositioned, z-index: auto) canvases so it visibly
+   overlays them rather than being painted underneath. */
 .supernote-thumb-sidebar {
     display: flex;
+    grid-column: 1;
+    grid-row: 1;
+    justify-self: end;
+    align-self: start;
     position: sticky;
-    align-self: flex-start;
+    z-index: 5;
     flex-flow: column;
     flex-shrink: 0;
     width: 140px;
     max-height: calc(100vh - 4em);
+    margin-right: 0.5em;
     overflow-y: auto;
     gap: 0.75em;
     padding: 0.5em;
     background: var(--background-secondary);
     border: 1px solid var(--background-modifier-border);
     border-radius: var(--radius-s);
+    box-shadow: var(--shadow-l);
 }
 
 .supernote-thumb-item {

--- a/styles.css
+++ b/styles.css
@@ -229,18 +229,19 @@ div.supernote-canvas-wrap canvas {
 }
 
 /* justify-self/align-self (not the old flex gap/align-items on .supernote-body)
-   position this within the shared grid cell - hugging the top-right corner,
-   same spot it occupied back when it was a flex sibling. Still position:
-   sticky (unchanged from before this issue - that part already worked, it's
-   only the flex-row width-sharing that caused the bounce) so it keeps
-   tracking scroll the same way .supernote-header does. z-index lifts it
-   above pagesEl's own (unpositioned, z-index: auto) canvases so it visibly
-   overlays them rather than being painted underneath. */
+   position this within the shared grid cell - hugging the top-left corner,
+   same spot it occupied back when it was a flex sibling (it's built before
+   pagesEl in the DOM, so it landed first/left in that flex row). Still
+   position: sticky (unchanged from before this issue - that part already
+   worked, it's only the flex-row width-sharing that caused the bounce) so it
+   keeps tracking scroll the same way .supernote-header does. z-index lifts
+   it above pagesEl's own (unpositioned, z-index: auto) canvases so it
+   visibly overlays them rather than being painted underneath. */
 .supernote-thumb-sidebar {
     display: flex;
     grid-column: 1;
     grid-row: 1;
-    justify-self: end;
+    justify-self: start;
     align-self: start;
     position: sticky;
     z-index: 5;
@@ -248,7 +249,7 @@ div.supernote-canvas-wrap canvas {
     flex-shrink: 0;
     width: 140px;
     max-height: calc(100vh - 4em);
-    margin-right: 0.5em;
+    margin-left: 0.5em;
     overflow-y: auto;
     gap: 0.75em;
     padding: 0.5em;


### PR DESCRIPTION
## Summary

- Fixes #179: opening/closing the thumbnail sidebar used to "bounce" the currently-viewed page.
- Root cause: `.supernote-thumb-sidebar` and `.supernote-pages` were flex siblings splitting one row, so toggling the sidebar changed `pagesEl`'s width. `applyThumbSidebarVisibility()` then called `applyFitWidth()` to compensate, which re-rendered every page at the new width, reflowing the whole note and changing scroll position.
- Fix: `.supernote-body` is now a single-column CSS Grid, with `.supernote-pages` and `.supernote-thumb-sidebar` sharing one grid cell (stacked, not side-by-side). The sidebar keeps its existing `position: sticky` behavior (unchanged - that part already worked) but now overlays the page view instead of squeezing it, so `pagesEl`'s width - and therefore fit-width/page layout - never changes when the sidebar toggles. Removed the now-unnecessary `applyFitWidth()` call from the toggle handler.

## Test plan

- [x] `npm run build` (tsc typecheck + esbuild production bundle)
- [x] `npm run lint` (0 errors, pre-existing warnings only)
- [x] `npm test` (98/98 passing)
- [x] Manually verified in a real headless Obsidian instance (`scripts/obsidian-headless`): jumped to a mid-document page, toggled the sidebar open/closed/scrolled - the in-view page content never moved, zoom level stayed fixed, and the sidebar correctly overlays the right edge of the page content and stays pinned (sticky) while scrolling.