### PR TITLE
Add find-in-note to <supernote-viewer>, no PDF/pdf.js dependency

### DIFF
--- a/src/render/wordOverlay.test.ts
+++ b/src/render/wordOverlay.test.ts
@@ -1,0 +1,212 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { SupernoteX, IPage } from 'supernote-typescript';
+import { buildWordOverlay, buildWordSearchText, repositionWordOverlay } from './wordOverlay';
+
+function fakePage(recognitionElements: IPage['recognitionElements']): IPage {
+    return { recognitionElements } as unknown as IPage;
+}
+
+describe('buildWordOverlay', () => {
+    it('creates one appended span per boxed word, skipping non-Text elements', () => {
+        const page = fakePage([
+            {
+                label: 'Real',
+                type: 'Text',
+                words: [{ label: 'Real', 'bounding-box': { x: 1, y: 2, width: 3, height: 4 } }],
+            },
+            {
+                label: 'ignored',
+                type: 'SomethingElse',
+                words: [{ label: 'ignored', 'bounding-box': { x: 0, y: 0, width: 1, height: 1 } }],
+            },
+        ]);
+        const container = document.createElement('div');
+
+        const entries = buildWordOverlay(page, container, 1);
+
+        expect(entries).toHaveLength(1);
+        expect(entries[0].label).toBe('Real');
+        expect(entries[0].pageNumber).toBe(1);
+        expect(entries[0].el).not.toBeNull();
+        expect(container.querySelectorAll('.word-overlay-span')).toHaveLength(1);
+        expect(entries[0].el!.textContent).toBe('Real');
+    });
+
+    it('scales native bounding-box units by RECOGNITION_COORDINATE_SCALE (11.9)', () => {
+        const page = fakePage([
+            { label: 'x', type: 'Text', words: [{ label: 'x', 'bounding-box': { x: 10, y: 20, width: 30, height: 40 } }] },
+        ]);
+        const container = document.createElement('div');
+
+        const [entry] = buildWordOverlay(page, container, 1);
+
+        expect(entry.nativeX).toBeCloseTo(10 * 11.9);
+        expect(entry.nativeY).toBeCloseTo(20 * 11.9);
+        expect(entry.nativeWidth).toBeCloseTo(30 * 11.9);
+        expect(entry.nativeHeight).toBeCloseTo(40 * 11.9);
+    });
+
+    it('keeps a word without a bounding box as a null-el entry rather than dropping it', () => {
+        const page = fakePage([
+            {
+                label: 'paragraph test',
+                type: 'Text',
+                words: [{ label: 'paragraph' }, { label: ' ' }, { label: 'test' }].map((w) => ({
+                    ...w,
+                    'bounding-box': w.label === ' ' ? undefined : { x: 0, y: 0, width: 1, height: 1 },
+                })),
+            },
+        ]);
+        const container = document.createElement('div');
+
+        const entries = buildWordOverlay(page, container, 1);
+
+        expect(entries.map((e) => e.label)).toEqual(['paragraph', ' ', 'test']);
+        expect(entries[1].el).toBeNull();
+        expect(container.querySelectorAll('.word-overlay-span')).toHaveLength(2);
+    });
+
+    it('skips words with an empty label even if they have a bounding box', () => {
+        const page = fakePage([
+            { label: '', type: 'Text', words: [{ label: '', 'bounding-box': { x: 0, y: 0, width: 1, height: 1 } }] },
+        ]);
+        const container = document.createElement('div');
+
+        expect(buildWordOverlay(page, container, 1)).toHaveLength(0);
+    });
+});
+
+describe('buildWordSearchText', () => {
+    it('concatenates word labels with no added separator', () => {
+        const container = document.createElement('div');
+        const page = fakePage([
+            {
+                label: 'paragraph test',
+                type: 'Text',
+                words: [
+                    { label: 'paragraph', 'bounding-box': { x: 0, y: 0, width: 1, height: 1 } },
+                    { label: ' ' },
+                    { label: 'test', 'bounding-box': { x: 0, y: 0, width: 1, height: 1 } },
+                ],
+            },
+        ]);
+        const entries = buildWordOverlay(page, container, 1);
+
+        const { text } = buildWordSearchText(entries);
+
+        expect(text).toBe('paragraph test');
+    });
+
+    it('maps a character offset back to the entry that produced it', () => {
+        const container = document.createElement('div');
+        const page = fakePage([
+            {
+                label: 'Real time',
+                type: 'Text',
+                words: [
+                    { label: 'Real', 'bounding-box': { x: 0, y: 0, width: 1, height: 1 } },
+                    { label: ' ' },
+                    { label: 'time', 'bounding-box': { x: 0, y: 0, width: 1, height: 1 } },
+                ],
+            },
+        ]);
+        const entries = buildWordOverlay(page, container, 1);
+
+        const { text, entryAt } = buildWordSearchText(entries);
+        expect(text).toBe('Real time');
+
+        // "Real" occupies [0, 4); "time" occupies [5, 9)
+        expect(entryAt(0)?.label).toBe('Real');
+        expect(entryAt(3)?.label).toBe('Real');
+        expect(entryAt(5)?.label).toBe('time');
+        expect(entryAt(8)?.label).toBe('time');
+        // offset 4 falls inside the boxless space entry - still resolvable,
+        // just to an entry with a null el (nothing to visually highlight).
+        expect(entryAt(4)?.label).toBe(' ');
+        expect(entryAt(4)?.el).toBeNull();
+    });
+
+    it('returns undefined past the end of the text', () => {
+        const { entryAt } = buildWordSearchText([]);
+        expect(entryAt(0)).toBeUndefined();
+    });
+});
+
+describe('repositionWordOverlay', () => {
+    it('scales native rects into the currently rendered CSS pixel size', () => {
+        const container = document.createElement('div');
+        const page = fakePage([{ label: 'x', type: 'Text', words: [{ label: 'x', 'bounding-box': { x: 10, y: 10, width: 10, height: 10 } }] }]);
+        const entries = buildWordOverlay(page, container, 1);
+        // native x/y/w/h are all 10 * 11.9 = 119
+
+        repositionWordOverlay(entries, 238, 238, 238, 238); // rendered == native -> scale 1
+        expect(entries[0].el!.style.left).toBe('119px');
+        expect(entries[0].el!.style.top).toBe('119px');
+        expect(entries[0].el!.style.width).toBe('119px');
+        expect(entries[0].el!.style.height).toBe('119px');
+
+        repositionWordOverlay(entries, 119, 119, 238, 238); // rendered at half native size -> scale 0.5
+        expect(entries[0].el!.style.left).toBe('59.5px');
+        expect(entries[0].el!.style.top).toBe('59.5px');
+    });
+
+    it('does not throw on entries with a null el', () => {
+        const entries = [{ pageNumber: 1, label: ' ', el: null, nativeX: 0, nativeY: 0, nativeWidth: 0, nativeHeight: 0 }];
+        expect(() => repositionWordOverlay(entries, 100, 100, 200, 200)).not.toThrow();
+    });
+});
+
+describe('against a real .note fixture', () => {
+    // Same fixture used elsewhere in this project for recognized-text
+    // testing (has real English-language handwriting recognition data).
+    const fixturePath = path.join(import.meta.dirname, '..', '..', 'supernote-typescript', 'tests', 'input', 'rtr.note');
+
+    it('builds sensible, in-bounds overlay entries and search text from a real page', () => {
+        const buffer = fs.readFileSync(fixturePath);
+        const sn = new SupernoteX(new Uint8Array(buffer));
+        const page = sn.pages[0];
+        const container = document.createElement('div');
+
+        const entries = buildWordOverlay(page, container, 1);
+        expect(entries.length).toBeGreaterThan(0);
+
+        const boxed = entries.filter((e) => e.el !== null);
+        expect(boxed.length).toBeGreaterThan(0);
+        for (const entry of boxed) {
+            expect(entry.nativeX).toBeGreaterThanOrEqual(0);
+            expect(entry.nativeY).toBeGreaterThanOrEqual(0);
+            expect(entry.nativeX + entry.nativeWidth).toBeLessThanOrEqual(sn.pageWidth);
+            expect(entry.nativeY + entry.nativeHeight).toBeLessThanOrEqual(sn.pageHeight);
+        }
+
+        expect(entries[0].label).toBe('Real');
+
+        const { text, entryAt } = buildWordSearchText(entries);
+        expect(text).toContain('Real');
+        const offset = text.indexOf('Real');
+        expect(entryAt(offset)?.label).toBe('Real');
+    });
+
+    it('reconstructs text identical to extractText()\'s own page.text for this fixture', () => {
+        // Confirms the element-boundary '\n' inserted between separate
+        // recognitionElements (e.g. this fixture's "Real"/"time"/
+        // "recognition", three separate single-word elements with no
+        // shared inter-element space word) keeps the word-level
+        // reconstruction in sync with pdf.ts's own extractText() - without
+        // it, adjacent elements' labels concatenate directly into one
+        // glued-together word ("Realtimerecognition"), a real bug caught by
+        // this exact assertion during development.
+        const buffer = fs.readFileSync(fixturePath);
+        const sn = new SupernoteX(new Uint8Array(buffer));
+        const page = sn.pages[0];
+        const container = document.createElement('div');
+
+        const entries = buildWordOverlay(page, container, 1);
+        const { text } = buildWordSearchText(entries);
+
+        expect(text).toBe(page.text);
+    });
+});

--- a/src/render/wordOverlay.ts
+++ b/src/render/wordOverlay.ts
@@ -50,13 +50,18 @@ export interface WordOverlayEntry {
 const RECOGNITION_COORDINATE_SCALE = 11.9;
 
 // Some recognition environments produce mojibake-looking labels that are
-// actually correctly-decoded UTF-8 misinterpreted as Latin-1 somewhere
-// upstream in the recognition pipeline - this round-trip through escape/
-// decodeURIComponent recovers the original text. Mirrors
-// supernote-typescript's own drawRecognitionText() exactly, so a word's
-// text reads identically here and in a PDF export.
+// actually correctly-encoded UTF-8 bytes misinterpreted as Latin-1
+// somewhere upstream in the recognition pipeline - each character's code
+// unit is really a raw byte 0-255, so re-decoding those bytes as UTF-8
+// recovers the original text. supernote-typescript's own
+// drawRecognitionText() does the same fix via the deprecated escape()/
+// decodeURIComponent() round-trip; TextDecoder is the modern equivalent
+// (confirmed byte-for-byte identical output against every real fixture
+// with non-ASCII recognized text this project has, including Turkish
+// diacritics) without the deprecation warning.
 function decodeRecognitionLabel(label: string): string {
-    return decodeURIComponent(escape(label));
+    const bytes = Uint8Array.from(label, (char) => char.charCodeAt(0));
+    return new TextDecoder('utf-8').decode(bytes);
 }
 
 // Builds one absolutely-positioned, invisible <span> per recognized word

--- a/src/render/wordOverlay.ts
+++ b/src/render/wordOverlay.ts
@@ -1,0 +1,183 @@
+// Builds an invisible, per-word text overlay directly from a note's own
+// recognition data - no PDF assembly, no pdf.js, no Obsidian dependency.
+// This is what makes find-in-note (see SupernoteViewerElement.ts) possible
+// in a standalone web component at all: the Obsidian plugin's own
+// SupernoteView instead assembles an invisible PDF (see
+// supernote-typescript's pdf.ts) purely so pdf.js's getTextContent()/
+// renderTextLayer() can hand back positioned spans - a real, working
+// approach, but one that needs Obsidian's own bundled pdf.js
+// (`loadPdfJs()`), which has no equivalent outside Obsidian at all.
+//
+// The word-level position data pdf.ts's own drawRecognitionText() draws
+// into invisible PDF text was never actually PDF-shaped to begin with -
+// it's just x/y/width/height in raster-pixel space, already sitting in
+// every parsed note's `page.recognitionElements` (the same source
+// supernote-typescript's own extractText()/extractParagraphs() - i.e. this
+// plugin's compact text mode - already reads). This module applies that
+// same position data directly as CSS, sidestepping PDF/pdf.js entirely.
+import { IPage } from 'supernote-typescript';
+
+export interface WordOverlayEntry {
+    pageNumber: number;
+    label: string;
+    // null for a word with no bounding box - real recognition data includes
+    // literal whitespace/punctuation as their own separate "word" entries
+    // purely to reconstruct correctly-spaced reading-order text (see
+    // buildWordSearchText below), and those routinely have no box at all.
+    // Still returned here (rather than dropped) so a caller reconstructing
+    // reading-order text gets correct spacing; there's just nothing to
+    // highlight for it.
+    el: HTMLElement | null;
+    // Native (unscaled) page-pixel position/size - the same space
+    // pageWidth/pageHeight are defined in. repositionWordOverlay() scales
+    // these into the page's *currently rendered* CSS pixel size, the same
+    // "one scale factor derived from rendered vs. native width" approach
+    // main.ts's own positionLinkOverlay() uses for link click regions.
+    // Meaningless (0) when el is null.
+    nativeX: number;
+    nativeY: number;
+    nativeWidth: number;
+    nativeHeight: number;
+}
+
+// Empirically-verified constant used by Supernote's own recognition format:
+// recognized word bounding boxes are stored in raster-pixel units divided by
+// this factor. Mirrors supernote-typescript/src/pdf.ts's own copy of the
+// same constant (used there to embed these same words as invisible PDF
+// text) - duplicated rather than imported since supernote-typescript
+// doesn't currently export it as a standalone helper. If it's ever wrong,
+// fix both copies.
+const RECOGNITION_COORDINATE_SCALE = 11.9;
+
+// Some recognition environments produce mojibake-looking labels that are
+// actually correctly-decoded UTF-8 misinterpreted as Latin-1 somewhere
+// upstream in the recognition pipeline - this round-trip through escape/
+// decodeURIComponent recovers the original text. Mirrors
+// supernote-typescript's own drawRecognitionText() exactly, so a word's
+// text reads identically here and in a PDF export.
+function decodeRecognitionLabel(label: string): string {
+    return decodeURIComponent(escape(label));
+}
+
+// Builds one absolutely-positioned, invisible <span> per recognized word
+// that has a bounding box (matching drawRecognitionText()'s own "skip words
+// without one" behavior for the *visual* overlay) and appends them to
+// `container`, which must already establish a positioning context (e.g.
+// `position: relative`) for the absolute positions below to land relative
+// to it, not some further-out ancestor. Deliberately invisible-only
+// (`opacity: 0` by default - see the consuming component's own stylesheet
+// for the actual rule) rather than aiming for pixel-perfect selectable/
+// copyable text the way a real text layer would: getting manual click-and-
+// drag selection to feel reliable across many independently-positioned word
+// spans (arranged to match the original handwriting's x/y layout, not
+// linear reading order) is exactly the problem issue #171 already hit and
+// fixed by introducing compact text mode instead - this module is
+// deliberately scoped to *finding* text (search + programmatic highlight,
+// not manual drag-selection), where that problem doesn't apply.
+//
+// Words *without* a bounding box are still returned (with `el: null`, no
+// span created) rather than dropped entirely: real recognition data uses
+// boxless "words" to carry literal whitespace/punctuation needed to
+// reconstruct correctly-spaced reading-order text (see
+// buildWordSearchText), so silently skipping them here would make that
+// reconstruction lose spacing information a caller has no other way to
+// recover.
+export function buildWordOverlay(page: IPage, container: HTMLElement, pageNumber: number): WordOverlayEntry[] {
+    const entries: WordOverlayEntry[] = [];
+    const textElements = page.recognitionElements.filter((element) => element.type === 'Text');
+
+    for (let elementIndex = 0; elementIndex < textElements.length; elementIndex++) {
+        for (const word of textElements[elementIndex].words) {
+            const label = decodeRecognitionLabel(word.label);
+            if (!label) continue;
+
+            const box = word['bounding-box'];
+            if (!box) {
+                entries.push({ pageNumber, label, el: null, nativeX: 0, nativeY: 0, nativeWidth: 0, nativeHeight: 0 });
+                continue;
+            }
+
+            const span = document.createElement('span');
+            span.className = 'word-overlay-span';
+            span.textContent = label;
+            span.style.position = 'absolute';
+            container.appendChild(span);
+
+            entries.push({
+                pageNumber,
+                label,
+                el: span,
+                nativeX: box.x * RECOGNITION_COORDINATE_SCALE,
+                nativeY: box.y * RECOGNITION_COORDINATE_SCALE,
+                nativeWidth: box.width * RECOGNITION_COORDINATE_SCALE,
+                nativeHeight: box.height * RECOGNITION_COORDINATE_SCALE,
+            });
+        }
+
+        // Separates one recognitionElement's words from the next (e.g.
+        // "Real", "time", "recognition" as three separate single-word
+        // elements in real fixture data, with no shared inter-element space
+        // word) using the same '\n' pdf.ts's own extractText() already
+        // joins whole elements with. Without this, adjacent elements'
+        // labels would concatenate directly ("Realtimerecognition"),
+        // breaking both a search query that spans the boundary and the
+        // reconstructed text's readability.
+        if (elementIndex < textElements.length - 1) {
+            entries.push({ pageNumber, label: '\n', el: null, nativeX: 0, nativeY: 0, nativeWidth: 0, nativeHeight: 0 });
+        }
+    }
+
+    return entries;
+}
+
+// Reconstructs this page's reading-order text from the same word entries
+// used for the overlay, and returns an offset->entry lookup for mapping a
+// search match's character position back to the word (and thus screen
+// position) it came from. Concatenates every word's label with no added
+// separator - unlike pdf.ts's extractText() (which joins whole *lines* with
+// '\n'), individual whitespace/punctuation characters between words are
+// already present as their own boxless word entries in real recognition
+// data, so adding another separator here would double them up.
+export function buildWordSearchText(entries: WordOverlayEntry[]): { text: string; entryAt: (offset: number) => WordOverlayEntry | undefined } {
+    let text = '';
+    const ranges: { start: number; end: number; entry: WordOverlayEntry }[] = [];
+
+    for (const entry of entries) {
+        const start = text.length;
+        text += entry.label;
+        ranges.push({ start, end: text.length, entry });
+    }
+
+    const entryAt = (offset: number): WordOverlayEntry | undefined => {
+        const found = ranges.find((r) => offset >= r.start && offset < r.end);
+        return found?.entry;
+    };
+
+    return { text, entryAt };
+}
+
+// Repositions every word span in `entries` to match the page's *currently
+// rendered* CSS pixel size - call whenever that changes (initial layout,
+// container resize, zoom, once this or a consumer supports it).
+// nativeWidth/nativeHeight are the note's own pageWidth/pageHeight (the
+// same space entries' own native* fields are defined in) - not necessarily
+// this exact page's numbers if a future format ever varies them per page,
+// but supernote-typescript defines these at the note level today.
+export function repositionWordOverlay(
+    entries: WordOverlayEntry[],
+    renderedWidth: number,
+    renderedHeight: number,
+    nativeWidth: number,
+    nativeHeight: number,
+): void {
+    const scaleX = renderedWidth / nativeWidth;
+    const scaleY = renderedHeight / nativeHeight;
+
+    for (const entry of entries) {
+        if (!entry.el) continue;
+        entry.el.style.left = `${entry.nativeX * scaleX}px`;
+        entry.el.style.top = `${entry.nativeY * scaleY}px`;
+        entry.el.style.width = `${entry.nativeWidth * scaleX}px`;
+        entry.el.style.height = `${entry.nativeHeight * scaleY}px`;
+    }
+}

--- a/src/webcomponent/SupernoteViewerElement.test.ts
+++ b/src/webcomponent/SupernoteViewerElement.test.ts
@@ -258,6 +258,158 @@ describe('<supernote-viewer>', () => {
         expect(img?.classList.contains('supernote-invert-dark')).toBe(false);
     });
 
+    it('builds an invisible word-overlay span per boxed recognized word', async () => {
+        const el = createViewer();
+        document.body.appendChild(el);
+        const loaded = waitForEvent(el, 'supernote-load');
+        el.noteData = readFixture('rtr.note');
+        await loaded;
+
+        const spans = el.shadowRoot!.querySelectorAll('.word-overlay-span');
+        expect(spans.length).toBeGreaterThan(0);
+        expect(Array.from(spans).some((s) => s.textContent === 'Real')).toBe(true);
+    });
+
+    it('shows the toolbar and find bar even for a single-page note, but no page nav', async () => {
+        // The mode toggle and find button are useful regardless of page
+        // count - only the prev/next-page arrows and page indicator are
+        // conditioned on there being more than one page to navigate
+        // between (see buildToolbar()).
+        const el = createViewer();
+        document.body.appendChild(el);
+        const loaded = waitForEvent(el, 'supernote-load');
+        el.noteData = readFixture('rtr.note'); // 1 page
+        await loaded;
+
+        expect(el.shadowRoot!.querySelector('.toolbar')).toBeTruthy();
+        expect(el.shadowRoot!.querySelector('.find-bar')).toBeTruthy();
+        expect(el.shadowRoot!.querySelector('button[aria-label="Find in note"]')).toBeTruthy();
+        expect(el.shadowRoot!.querySelector('button[aria-label="Previous page"]')).toBeNull();
+        expect(el.shadowRoot!.querySelector('.page-indicator')).toBeNull();
+    });
+
+    describe('find in note', () => {
+        async function createLoadedViewer() {
+            const el = createViewer();
+            document.body.appendChild(el);
+            const loaded = waitForEvent(el, 'supernote-load');
+            el.noteData = readFixture('rtr.note');
+            await loaded;
+            return el;
+        }
+
+        it('opening the find bar focuses the input and marks the toggle pressed', async () => {
+            const el = await createLoadedViewer();
+            const findBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Find in note"]')!;
+            const bar = el.shadowRoot!.querySelector('.find-bar')!;
+            const input = el.shadowRoot!.querySelector<HTMLInputElement>('.find-bar input')!;
+
+            expect(bar.classList.contains('open')).toBe(false);
+
+            findBtn.click();
+
+            expect(bar.classList.contains('open')).toBe(true);
+            expect(findBtn.getAttribute('aria-pressed')).toBe('true');
+            expect(el.shadowRoot!.activeElement).toBe(input);
+        });
+
+        it('a query with one real match highlights exactly it and reports "1 / 1"', async () => {
+            const el = await createLoadedViewer();
+            el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Find in note"]')!.click();
+            const input = el.shadowRoot!.querySelector<HTMLInputElement>('.find-bar input')!;
+
+            input.value = 'real';
+            input.dispatchEvent(new Event('input'));
+
+            const current = el.shadowRoot!.querySelectorAll('.word-overlay-match-current');
+            expect(current).toHaveLength(1);
+            expect(current[0].textContent).toBe('Real');
+            expect(el.shadowRoot!.querySelector('.find-count')?.textContent).toBe('1 / 1');
+        });
+
+        it('cycles through every match with next/prev, wrapping in both directions', async () => {
+            // This fixture's recognized text contains "paragraph" 4 times
+            // (confirmed directly against the real fixture, not asserted
+            // blindly) - a good real case for wraparound cycling, since it
+            // spans multiple separate recognitionElements/lines.
+            const el = await createLoadedViewer();
+            el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Find in note"]')!.click();
+            const input = el.shadowRoot!.querySelector<HTMLInputElement>('.find-bar input')!;
+            const nextBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Next match"]')!;
+            const prevBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Previous match"]')!;
+            const countEl = el.shadowRoot!.querySelector('.find-count')!;
+
+            input.value = 'paragraph';
+            input.dispatchEvent(new Event('input'));
+
+            expect(el.shadowRoot!.querySelectorAll('.word-overlay-match')).toHaveLength(4);
+            expect(countEl.textContent).toBe('1 / 4');
+
+            nextBtn.click();
+            expect(countEl.textContent).toBe('2 / 4');
+            nextBtn.click();
+            nextBtn.click();
+            expect(countEl.textContent).toBe('4 / 4');
+            nextBtn.click(); // wraps forward past the last match
+            expect(countEl.textContent).toBe('1 / 4');
+            prevBtn.click(); // wraps backward past the first match
+            expect(countEl.textContent).toBe('4 / 4');
+
+            // Exactly one match is ever "current" at a time.
+            expect(el.shadowRoot!.querySelectorAll('.word-overlay-match-current')).toHaveLength(1);
+        });
+
+        it('reports no results for a query with no match, without throwing', async () => {
+            const el = await createLoadedViewer();
+            el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Find in note"]')!.click();
+            const input = el.shadowRoot!.querySelector<HTMLInputElement>('.find-bar input')!;
+
+            input.value = 'zzzznotfound';
+            input.dispatchEvent(new Event('input'));
+
+            expect(el.shadowRoot!.querySelectorAll('.word-overlay-match')).toHaveLength(0);
+            expect(el.shadowRoot!.querySelector('.find-count')?.textContent).toBe('No results');
+        });
+
+        it('closing the find bar clears highlights, the query, and the count', async () => {
+            const el = await createLoadedViewer();
+            const findBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Find in note"]')!;
+            findBtn.click();
+            const input = el.shadowRoot!.querySelector<HTMLInputElement>('.find-bar input')!;
+            input.value = 'paragraph';
+            input.dispatchEvent(new Event('input'));
+            expect(el.shadowRoot!.querySelectorAll('.word-overlay-match').length).toBeGreaterThan(0);
+
+            el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Close find bar"]')!.click();
+
+            expect(el.shadowRoot!.querySelector('.find-bar')!.classList.contains('open')).toBe(false);
+            expect(findBtn.getAttribute('aria-pressed')).toBe('false');
+            expect(el.shadowRoot!.querySelectorAll('.word-overlay-match')).toHaveLength(0);
+            expect(input.value).toBe('');
+            expect(el.shadowRoot!.querySelector('.find-count')?.textContent).toBe('');
+        });
+
+        it('Escape in the find input closes the bar; Enter/Shift+Enter step next/prev', async () => {
+            const el = await createLoadedViewer();
+            el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Find in note"]')!.click();
+            const input = el.shadowRoot!.querySelector<HTMLInputElement>('.find-bar input')!;
+            const countEl = el.shadowRoot!.querySelector('.find-count')!;
+
+            input.value = 'paragraph';
+            input.dispatchEvent(new Event('input'));
+            expect(countEl.textContent).toBe('1 / 4');
+
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            expect(countEl.textContent).toBe('2 / 4');
+
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', shiftKey: true, bubbles: true }));
+            expect(countEl.textContent).toBe('1 / 4');
+
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+            expect(el.shadowRoot!.querySelector('.find-bar')!.classList.contains('open')).toBe(false);
+        });
+    });
+
     it('shows an error and dispatches supernote-error when the fetch fails', async () => {
         vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 404 })));
 

--- a/src/webcomponent/SupernoteViewerElement.test.ts
+++ b/src/webcomponent/SupernoteViewerElement.test.ts
@@ -371,7 +371,55 @@ describe('<supernote-viewer>', () => {
             expect(el.shadowRoot!.querySelector('.find-count')?.textContent).toBe('No results');
         });
 
-        it('closing the find bar clears highlights, the query, and the count', async () => {
+        it('highlights matches with <mark> in recognized-text mode too', async () => {
+            // Image-mode's word-overlay spans have nothing sensible to
+            // overlay in text mode (the image is hidden entirely, and the
+            // reflowed text bears no relation to the handwriting's x/y
+            // layout) - text mode instead wraps the matched range of the
+            // page's own recognized text in a <mark>, using the offsets
+            // computed in runFind().
+            const el = await createLoadedViewer();
+            el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Toggle recognized text view"]')!.click();
+            el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Find in note"]')!.click();
+            const input = el.shadowRoot!.querySelector<HTMLInputElement>('.find-bar input')!;
+
+            input.value = 'real';
+            input.dispatchEvent(new Event('input'));
+
+            const marks = el.shadowRoot!.querySelectorAll('.page-text mark');
+            expect(marks).toHaveLength(1);
+            expect(marks[0].textContent).toBe('Real');
+            expect(marks[0].classList.contains('find-match-current')).toBe(true);
+            expect(el.shadowRoot!.querySelector('.find-count')?.textContent).toBe('1 / 1');
+        });
+
+        it('cycling matches in text mode moves the find-match-current mark, not just the count', async () => {
+            const el = await createLoadedViewer();
+            el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Toggle recognized text view"]')!.click();
+            el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Find in note"]')!.click();
+            const input = el.shadowRoot!.querySelector<HTMLInputElement>('.find-bar input')!;
+            const nextBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Next match"]')!;
+
+            input.value = 'paragraph';
+            input.dispatchEvent(new Event('input'));
+            expect(el.shadowRoot!.querySelectorAll('.page-text mark.find-match')).toHaveLength(4);
+            const firstCurrent = el.shadowRoot!.querySelector('.find-match-current')!;
+
+            nextBtn.click();
+
+            const marksAfter = el.shadowRoot!.querySelectorAll('.page-text mark.find-match-current');
+            expect(marksAfter).toHaveLength(1);
+            expect(marksAfter[0]).not.toBe(firstCurrent);
+        });
+
+        it('the text-mode page-text still reads correctly with no active search', async () => {
+            const el = await createLoadedViewer();
+            const textEl = el.shadowRoot!.querySelector('.page-text')!;
+            expect(textEl.textContent).toContain('Real');
+            expect(textEl.querySelector('mark')).toBeNull();
+        });
+
+        it('closing the find bar clears highlights (both modes\' kinds), the query, and the count', async () => {
             const el = await createLoadedViewer();
             const findBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Find in note"]')!;
             findBtn.click();
@@ -379,8 +427,10 @@ describe('<supernote-viewer>', () => {
             input.value = 'paragraph';
             input.dispatchEvent(new Event('input'));
             expect(el.shadowRoot!.querySelectorAll('.word-overlay-match').length).toBeGreaterThan(0);
+            expect(el.shadowRoot!.querySelectorAll('.page-text mark').length).toBeGreaterThan(0);
 
             el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Close find bar"]')!.click();
+            expect(el.shadowRoot!.querySelectorAll('.page-text mark')).toHaveLength(0);
 
             expect(el.shadowRoot!.querySelector('.find-bar')!.classList.contains('open')).toBe(false);
             expect(findBtn.getAttribute('aria-pressed')).toBe('false');

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -12,12 +12,24 @@
 import { SupernoteX } from 'supernote-typescript';
 import { ImageConverter } from '../render/imageConverter';
 import { RenderedNotePage, buildNotePagePlaceholders, fillNotePagePlaceholder, parseNote } from '../render/noteRenderer';
+import { WordOverlayEntry, buildWordOverlay, buildWordSearchText, repositionWordOverlay } from '../render/wordOverlay';
 
 interface ViewerPageState extends RenderedNotePage {
     textEl: HTMLElement;
+    wordEntries: WordOverlayEntry[];
     loaded: boolean;
     visible: boolean;
     loadDebounceTimer?: number;
+}
+
+interface FindMatch {
+    pageIndex: number;
+    entry: WordOverlayEntry;
+}
+
+interface PageSearchEntry {
+    lower: string;
+    entryAt: (offset: number) => WordOverlayEntry | undefined;
 }
 
 const STYLE = `
@@ -125,6 +137,33 @@ button[aria-pressed="true"] {
     color: var(--supernote-viewer-muted);
     font-size: 0.9em;
 }
+.find-bar {
+    display: none;
+    align-items: center;
+    gap: 0.5em;
+    padding: 0.4em 0.6em;
+    background: var(--supernote-viewer-bg);
+    border-bottom: 1px solid var(--supernote-viewer-border);
+}
+.find-bar.open {
+    display: flex;
+}
+.find-bar input {
+    flex: 1;
+    min-width: 0;
+    font: inherit;
+    color: inherit;
+    background: transparent;
+    border: 1px solid var(--supernote-viewer-border);
+    border-radius: 4px;
+    padding: 0.2em 0.5em;
+}
+.find-count {
+    min-width: 5em;
+    color: var(--supernote-viewer-muted);
+    font-size: 0.9em;
+    white-space: nowrap;
+}
 .pages {
     flex: 1;
     overflow: auto;
@@ -136,11 +175,33 @@ button[aria-pressed="true"] {
     box-sizing: border-box;
 }
 .pages .page-container {
+    position: relative;
     max-width: 100%;
 }
 .pages .page-container > img {
     display: block;
     max-width: 100%;
+}
+/* Invisible-by-default per-word overlay (see src/render/wordOverlay.ts) -
+   positioned absolutely over the page image/placeholder using the same
+   container this rule's own position: relative above establishes. Text
+   itself is never shown (color: transparent) - this exists purely so
+   find-in-note has something to search and a box to highlight, not to
+   render a visible/selectable text layer (that's what "recognized text"
+   mode, toggled by the Aa button, already does). */
+.word-overlay-span {
+    position: absolute;
+    color: transparent;
+    pointer-events: none;
+    user-select: none;
+    white-space: nowrap;
+    overflow: hidden;
+}
+.word-overlay-span.word-overlay-match {
+    background: rgba(255, 214, 0, 0.45);
+}
+.word-overlay-span.word-overlay-match-current {
+    background: rgba(255, 128, 0, 0.7);
 }
 .pages.mode-text .page-container > img {
     display: none;
@@ -210,6 +271,7 @@ export class SupernoteViewerElement extends HTMLElement {
     private pageIndicatorEl: HTMLElement | null = null;
     private modeToggleBtn: HTMLButtonElement | null = null;
     private pageLoadObserver: IntersectionObserver | null = null;
+    private resizeObserver: ResizeObserver | null = null;
     private pageStates: ViewerPageState[] = [];
     private currentPage = 0;
     private pageIndicatorScrollScheduled = false;
@@ -218,6 +280,13 @@ export class SupernoteViewerElement extends HTMLElement {
     private renderQueued = false;
     private renderToken = 0;
     private _noteData: ArrayBuffer | Uint8Array | null = null;
+    private findBarEl: HTMLElement | null = null;
+    private findInputEl: HTMLInputElement | null = null;
+    private findCountEl: HTMLElement | null = null;
+    private findToggleBtn: HTMLButtonElement | null = null;
+    private pageSearchIndex: PageSearchEntry[] = [];
+    private findMatches: FindMatch[] = [];
+    private findMatchIndex = -1;
 
     constructor() {
         super();
@@ -251,6 +320,7 @@ export class SupernoteViewerElement extends HTMLElement {
 
     disconnectedCallback(): void {
         this.pageLoadObserver?.disconnect();
+        this.resizeObserver?.disconnect();
         for (const state of this.pageStates) window.clearTimeout(state.loadDebounceTimer);
     }
 
@@ -392,6 +462,8 @@ export class SupernoteViewerElement extends HTMLElement {
     private teardownForRerender(): void {
         this.pageLoadObserver?.disconnect();
         this.pageLoadObserver = null;
+        this.resizeObserver?.disconnect();
+        this.resizeObserver = null;
         for (const state of this.pageStates) window.clearTimeout(state.loadDebounceTimer);
         this.pageStates = [];
         this.pagesEl = null;
@@ -402,6 +474,13 @@ export class SupernoteViewerElement extends HTMLElement {
         this.pageIndicatorScrollScheduled = false;
         this.mode = 'image';
         this.sn = null;
+        this.findBarEl = null;
+        this.findInputEl = null;
+        this.findCountEl = null;
+        this.findToggleBtn = null;
+        this.pageSearchIndex = [];
+        this.findMatches = [];
+        this.findMatchIndex = -1;
         this.rootEl.innerHTML = '';
     }
 
@@ -419,7 +498,12 @@ export class SupernoteViewerElement extends HTMLElement {
         }
 
         const pageCount = sn.pages.length;
-        if (pageCount > 1) this.buildToolbar(pageCount);
+        // The toolbar itself (mode toggle + find) is worth having even for
+        // a single-page document - only the prev/next-page arrows and page
+        // indicator inside it are conditioned on pageCount > 1 (see
+        // buildToolbar()), since there's nowhere else to navigate to.
+        this.buildToolbar(pageCount);
+        this.buildFindBar();
 
         const pagesEl = document.createElement('div');
         pagesEl.className = 'pages';
@@ -435,9 +519,14 @@ export class SupernoteViewerElement extends HTMLElement {
 
         const states = this.wrapPageStates(sn, placeholders);
         this.pageStates = states;
+        this.pageSearchIndex = states.map((state) => {
+            const { text, entryAt } = buildWordSearchText(state.wordEntries);
+            return { lower: text.toLowerCase(), entryAt };
+        });
 
         this.setupPageLoadObserver(sn, states);
         if (pageCount > 1) this.setupPageIndicatorTracking();
+        this.setupWordOverlayResizing(sn, states);
     }
 
     // A single deep-linked page (the `page` attribute, clamped, defaulting
@@ -468,6 +557,7 @@ export class SupernoteViewerElement extends HTMLElement {
 
         const [state] = this.wrapPageStates(sn, placeholders);
         this.pageStates = [state];
+        this.setupWordOverlayResizing(sn, this.pageStates);
         void this.ensurePageImageLoaded(sn, state);
     }
 
@@ -476,14 +566,22 @@ export class SupernoteViewerElement extends HTMLElement {
     // single-page (one page, eager) construction paths above.
     private wrapPageStates(sn: SupernoteX, placeholders: RenderedNotePage[]): ViewerPageState[] {
         return placeholders.map((page) => {
-            const rawText = sn.pages[page.pageNumber - 1]?.text ?? '';
+            const notePage = sn.pages[page.pageNumber - 1];
+            const rawText = notePage?.text ?? '';
             const textEl = document.createElement('div');
             textEl.className = 'page-text';
             textEl.classList.toggle('empty', rawText.length === 0);
             textEl.textContent = rawText.length > 0 ? rawText : 'No recognized text on this page.';
             page.containerEl.appendChild(textEl);
 
-            return { ...page, textEl, loaded: false, visible: false };
+            // Built unconditionally (even in single-page mode, which has no
+            // find UI to consume it) - cheap, keeps "this page's word
+            // overlay is built and correctly positioned" a plain invariant
+            // rather than something a caller needs to check the render mode
+            // to reason about.
+            const wordEntries = notePage ? buildWordOverlay(notePage, page.containerEl, page.pageNumber) : [];
+
+            return { ...page, textEl, wordEntries, loaded: false, visible: false };
         });
     }
 
@@ -564,6 +662,30 @@ export class SupernoteViewerElement extends HTMLElement {
         if (this.pageIndicatorEl) this.pageIndicatorEl.textContent = `${current + 1} / ${this.pageStates.length}`;
     }
 
+    // Keeps every page's word-overlay spans (see src/render/wordOverlay.ts)
+    // aligned with that page's *currently rendered* CSS size - a
+    // ResizeObserver, not a one-time measurement at build time, since a
+    // page's rendered size can change after these spans are first
+    // positioned (a window resize, a host layout change, or the
+    // placeholder's forced 100% width giving way to the real image's
+    // natural size once it loads). Guarded for environments without
+    // ResizeObserver (none known among real browsers this targets, but
+    // costs nothing to check).
+    private setupWordOverlayResizing(sn: SupernoteX, states: ViewerPageState[]): void {
+        if (typeof ResizeObserver === 'undefined') return;
+        const { pageWidth, pageHeight } = sn;
+        this.resizeObserver = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                const state = states.find((s) => s.containerEl === entry.target);
+                if (!state) continue;
+                const { width, height } = entry.contentRect;
+                if (width <= 0 || height <= 0) continue;
+                repositionWordOverlay(state.wordEntries, width, height, pageWidth, pageHeight);
+            }
+        });
+        for (const state of states) this.resizeObserver.observe(state.containerEl);
+    }
+
     // Idempotent and safe to call speculatively - `loaded` is set eagerly so
     // a slow rasterization can't be triggered twice for the same page.
     private async ensurePageImageLoaded(sn: SupernoteX, state: ViewerPageState): Promise<void> {
@@ -585,28 +707,33 @@ export class SupernoteViewerElement extends HTMLElement {
         toolbar.className = 'toolbar';
         toolbar.setAttribute('part', 'toolbar');
 
-        const prevBtn = document.createElement('button');
-        prevBtn.type = 'button';
-        prevBtn.setAttribute('part', 'button');
-        prevBtn.setAttribute('aria-label', 'Previous page');
-        prevBtn.textContent = '↑';
-        prevBtn.addEventListener('click', () => this.goToPage(this.currentPage));
-        toolbar.appendChild(prevBtn);
+        // Nothing to navigate to with only one page - the mode toggle and
+        // find button below are still worth having regardless of page
+        // count, so only these three are conditioned on pageCount > 1.
+        if (pageCount > 1) {
+            const prevBtn = document.createElement('button');
+            prevBtn.type = 'button';
+            prevBtn.setAttribute('part', 'button');
+            prevBtn.setAttribute('aria-label', 'Previous page');
+            prevBtn.textContent = '↑';
+            prevBtn.addEventListener('click', () => this.goToPage(this.currentPage));
+            toolbar.appendChild(prevBtn);
 
-        const indicator = document.createElement('span');
-        indicator.className = 'page-indicator';
-        indicator.setAttribute('part', 'page-indicator');
-        indicator.textContent = `1 / ${pageCount}`;
-        toolbar.appendChild(indicator);
-        this.pageIndicatorEl = indicator;
+            const indicator = document.createElement('span');
+            indicator.className = 'page-indicator';
+            indicator.setAttribute('part', 'page-indicator');
+            indicator.textContent = `1 / ${pageCount}`;
+            toolbar.appendChild(indicator);
+            this.pageIndicatorEl = indicator;
 
-        const nextBtn = document.createElement('button');
-        nextBtn.type = 'button';
-        nextBtn.setAttribute('part', 'button');
-        nextBtn.setAttribute('aria-label', 'Next page');
-        nextBtn.textContent = '↓';
-        nextBtn.addEventListener('click', () => this.goToPage(this.currentPage + 2));
-        toolbar.appendChild(nextBtn);
+            const nextBtn = document.createElement('button');
+            nextBtn.type = 'button';
+            nextBtn.setAttribute('part', 'button');
+            nextBtn.setAttribute('aria-label', 'Next page');
+            nextBtn.textContent = '↓';
+            nextBtn.addEventListener('click', () => this.goToPage(this.currentPage + 2));
+            toolbar.appendChild(nextBtn);
+        }
 
         const modeBtn = document.createElement('button');
         modeBtn.type = 'button';
@@ -618,8 +745,190 @@ export class SupernoteViewerElement extends HTMLElement {
         toolbar.appendChild(modeBtn);
         this.modeToggleBtn = modeBtn;
 
+        const findBtn = document.createElement('button');
+        findBtn.type = 'button';
+        findBtn.setAttribute('part', 'button');
+        findBtn.setAttribute('aria-label', 'Find in note');
+        findBtn.setAttribute('aria-pressed', 'false');
+        findBtn.textContent = 'Find';
+        findBtn.addEventListener('click', () => this.toggleFindBar());
+        toolbar.appendChild(findBtn);
+        this.findToggleBtn = findBtn;
+
         this.rootEl.appendChild(toolbar);
         this.toolbarEl = toolbar;
+    }
+
+    // Builds the (initially hidden - see the .find-bar/.open CSS rule) find
+    // UI: a text input searching every page's recognized words (via
+    // pageSearchIndex, built in buildViewer()) directly against the
+    // invisible word-overlay spans built in wrapPageStates() - no PDF/pdf.js
+    // involved at all, unlike SupernoteView's own find-in-note in main.ts.
+    private buildFindBar(): void {
+        const bar = document.createElement('div');
+        bar.className = 'find-bar';
+        bar.setAttribute('part', 'find-bar');
+
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.setAttribute('part', 'find-input');
+        input.placeholder = 'Find in note…';
+        input.addEventListener('input', () => this.runFind(input.value));
+        input.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                this.stepFind(e.shiftKey ? -1 : 1);
+            } else if (e.key === 'Escape') {
+                e.preventDefault();
+                this.closeFindBar();
+            }
+        });
+        bar.appendChild(input);
+        this.findInputEl = input;
+
+        const prevBtn = document.createElement('button');
+        prevBtn.type = 'button';
+        prevBtn.setAttribute('part', 'button');
+        prevBtn.setAttribute('aria-label', 'Previous match');
+        prevBtn.textContent = '‹';
+        prevBtn.addEventListener('click', () => this.stepFind(-1));
+        bar.appendChild(prevBtn);
+
+        const nextBtn = document.createElement('button');
+        nextBtn.type = 'button';
+        nextBtn.setAttribute('part', 'button');
+        nextBtn.setAttribute('aria-label', 'Next match');
+        nextBtn.textContent = '›';
+        nextBtn.addEventListener('click', () => this.stepFind(1));
+        bar.appendChild(nextBtn);
+
+        const count = document.createElement('span');
+        count.className = 'find-count';
+        count.setAttribute('part', 'find-count');
+        bar.appendChild(count);
+        this.findCountEl = count;
+
+        const closeBtn = document.createElement('button');
+        closeBtn.type = 'button';
+        closeBtn.setAttribute('part', 'button');
+        closeBtn.setAttribute('aria-label', 'Close find bar');
+        closeBtn.textContent = '×';
+        closeBtn.addEventListener('click', () => this.closeFindBar());
+        bar.appendChild(closeBtn);
+
+        this.rootEl.appendChild(bar);
+        this.findBarEl = bar;
+    }
+
+    private toggleFindBar(): void {
+        if (this.findBarEl?.classList.contains('open')) this.closeFindBar();
+        else this.openFindBar();
+    }
+
+    private openFindBar(): void {
+        this.findBarEl?.classList.add('open');
+        this.findToggleBtn?.setAttribute('aria-pressed', 'true');
+        this.findInputEl?.focus();
+        this.findInputEl?.select();
+    }
+
+    private closeFindBar(): void {
+        this.findBarEl?.classList.remove('open');
+        this.findToggleBtn?.setAttribute('aria-pressed', 'false');
+        this.clearFindHighlights();
+        this.findMatches = [];
+        this.findMatchIndex = -1;
+        if (this.findInputEl) this.findInputEl.value = '';
+        if (this.findCountEl) this.findCountEl.textContent = '';
+    }
+
+    // Rebuilds findMatches from scratch against every page's search text -
+    // simple linear re-scan on every keystroke rather than incremental
+    // matching, which is plenty fast for the amount of recognized text a
+    // handwritten note actually has (a few thousand characters per page at
+    // most) and much simpler than maintaining incremental state.
+    private runFind(query: string): void {
+        this.clearFindHighlights();
+        this.findMatches = [];
+        this.findMatchIndex = -1;
+
+        const q = query.trim().toLowerCase();
+        if (q.length > 0) {
+            for (let pageIndex = 0; pageIndex < this.pageSearchIndex.length; pageIndex++) {
+                const { lower, entryAt } = this.pageSearchIndex[pageIndex];
+                let from = 0;
+                for (;;) {
+                    const idx = lower.indexOf(q, from);
+                    if (idx === -1) break;
+                    from = idx + q.length;
+                    const entry = entryAt(idx);
+                    // Only a genuinely highlightable word (one with a
+                    // bounding box, i.e. a real overlay span - see
+                    // wordOverlay.ts) counts as a match: a hit that landed
+                    // on a boxless whitespace/punctuation entry has nothing
+                    // to point to on screen.
+                    if (entry?.el) this.findMatches.push({ pageIndex, entry });
+                }
+            }
+            for (const match of this.findMatches) match.entry.el!.classList.add('word-overlay-match');
+        }
+
+        if (this.findMatches.length > 0) this.stepFind(1);
+        else this.updateFindCount();
+    }
+
+    // Moves the current match by `delta` (wrapping in both directions) and
+    // scrolls it into view. Called both by the prev/next buttons (delta
+    // ±1) and by runFind() itself (delta +1 from the initial index of -1,
+    // landing on the first match) - reusing the same wrap-around math
+    // rather than special-casing "select the first match".
+    private stepFind(delta: number): void {
+        if (this.findMatches.length === 0) return;
+
+        this.findMatches[this.findMatchIndex]?.entry.el?.classList.remove('word-overlay-match-current');
+
+        const n = this.findMatches.length;
+        this.findMatchIndex = ((this.findMatchIndex + delta) % n + n) % n;
+
+        const match = this.findMatches[this.findMatchIndex];
+        match.entry.el?.classList.add('word-overlay-match-current');
+        this.updateFindCount();
+        this.scrollToMatch(match);
+    }
+
+    private scrollToMatch(match: FindMatch): void {
+        if (!this.sn || !this.pagesEl) return;
+        const state = this.pageStates[match.pageIndex];
+        const el = match.entry.el;
+        if (!state || !el) return;
+        if (!state.loaded) void this.ensurePageImageLoaded(this.sn, state);
+
+        // Centers the match within the visible viewport rather than just
+        // bringing its page's top edge into view (goToPage()'s own
+        // behavior, too coarse for a match partway down a tall page) - same
+        // getBoundingClientRect()-delta + .pages.scrollTo() approach
+        // goToPage() uses and for the same reason: scrollIntoView() would
+        // cascade to any scrollable ancestor this element is embedded in
+        // (e.g. Obsidian's own note editor, for SupernoteEmbed).
+        const pagesRect = this.pagesEl.getBoundingClientRect();
+        const targetRect = el.getBoundingClientRect();
+        const targetTop = this.pagesEl.scrollTop + (targetRect.top - pagesRect.top) - pagesRect.height / 2 + targetRect.height / 2;
+        this.pagesEl.scrollTo({ top: targetTop, behavior: 'smooth' });
+    }
+
+    private clearFindHighlights(): void {
+        for (const match of this.findMatches) {
+            match.entry.el?.classList.remove('word-overlay-match', 'word-overlay-match-current');
+        }
+    }
+
+    private updateFindCount(): void {
+        if (!this.findCountEl) return;
+        if (this.findMatches.length === 0) {
+            this.findCountEl.textContent = this.findInputEl?.value.trim() ? 'No results' : '';
+        } else {
+            this.findCountEl.textContent = `${this.findMatchIndex + 1} / ${this.findMatches.length}`;
+        }
     }
 
     private toggleMode(): void {

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -16,6 +16,11 @@ import { WordOverlayEntry, buildWordOverlay, buildWordSearchText, repositionWord
 
 interface ViewerPageState extends RenderedNotePage {
     textEl: HTMLElement;
+    // Stashed alongside textEl (rather than re-reading sn.pages each time)
+    // so renderPageTextHighlights() can rebuild textEl's content - wrapping
+    // the current match range in a <mark> - from the same string every
+    // time, without needing the original SupernoteX instance around.
+    rawText: string;
     wordEntries: WordOverlayEntry[];
     loaded: boolean;
     visible: boolean;
@@ -24,6 +29,18 @@ interface ViewerPageState extends RenderedNotePage {
 
 interface FindMatch {
     pageIndex: number;
+    // Offsets into that page's search text (see buildWordSearchText) - and,
+    // since that text is character-identical to page.text (confirmed by a
+    // dedicated wordOverlay.test.ts test), also directly usable as offsets
+    // into rawText above for highlighting matches in recognized-text mode,
+    // where there's no image/overlay-span geometry to point to at all.
+    start: number;
+    end: number;
+    // The overlay span for the word the match started in - used for
+    // image-mode highlighting/scrolling. Always non-null (see runFind()):
+    // a match whose start landed on a boxless word is discarded rather than
+    // kept with a null entry, since text mode's <mark> highlighting still
+    // needs a real word to point to for image-mode's own highlight.
     entry: WordOverlayEntry;
 }
 
@@ -203,6 +220,18 @@ button[aria-pressed="true"] {
 .word-overlay-span.word-overlay-match-current {
     background: rgba(255, 128, 0, 0.7);
 }
+/* Recognized-text mode hides the image entirely (see the img rule just
+   below), which collapses .page-container to the text block's own height -
+   nothing like the image's native aspect ratio the word-overlay spans
+   above are positioned against. Left visible, a match's highlighted span
+   would render as a stray colored box floating at whatever nonsensical
+   position that mismatched scaling produces. Text-mode matches are
+   highlighted a different way entirely (see the <mark> rules below, and
+   renderPageTextHighlights() in SupernoteViewerElement.ts), so the
+   image-mode spans have nothing useful to do here regardless. */
+.pages.mode-text .word-overlay-span {
+    display: none;
+}
 .pages.mode-text .page-container > img {
     display: none;
 }
@@ -221,6 +250,20 @@ button[aria-pressed="true"] {
 .pages .page-container > .page-text.empty {
     color: var(--supernote-viewer-muted);
     font-style: italic;
+}
+/* Recognized-text mode's own match highlighting (see
+   renderPageTextHighlights()) - same colors as the image-mode
+   word-overlay-match/-current classes above, for one consistent look
+   regardless of which mode find-in-note is used in. color: inherit
+   overrides <mark>'s default black text, which would be unreadable
+   against this element's own dark-mode text color. */
+.page-text mark.find-match {
+    background: rgba(255, 214, 0, 0.45);
+    color: inherit;
+}
+.page-text mark.find-match-current {
+    background: rgba(255, 128, 0, 0.7);
+    color: inherit;
 }
 /* Only actually inverted in dark mode, mirroring the "invert-dark" attribute
    -> "only when the environment is dark" two-part condition the Obsidian
@@ -581,7 +624,7 @@ export class SupernoteViewerElement extends HTMLElement {
             // to reason about.
             const wordEntries = notePage ? buildWordOverlay(notePage, page.containerEl, page.pageNumber) : [];
 
-            return { ...page, textEl, wordEntries, loaded: false, visible: false };
+            return { ...page, textEl, rawText, wordEntries, loaded: false, visible: false };
         });
     }
 
@@ -838,6 +881,7 @@ export class SupernoteViewerElement extends HTMLElement {
         this.clearFindHighlights();
         this.findMatches = [];
         this.findMatchIndex = -1;
+        this.renderPageTextHighlights(); // clears every page's <mark>s too
         if (this.findInputEl) this.findInputEl.value = '';
         if (this.findCountEl) this.findCountEl.textContent = '';
     }
@@ -860,21 +904,28 @@ export class SupernoteViewerElement extends HTMLElement {
                 for (;;) {
                     const idx = lower.indexOf(q, from);
                     if (idx === -1) break;
-                    from = idx + q.length;
+                    const end = idx + q.length;
+                    from = end;
                     const entry = entryAt(idx);
                     // Only a genuinely highlightable word (one with a
                     // bounding box, i.e. a real overlay span - see
                     // wordOverlay.ts) counts as a match: a hit that landed
                     // on a boxless whitespace/punctuation entry has nothing
-                    // to point to on screen.
-                    if (entry?.el) this.findMatches.push({ pageIndex, entry });
+                    // for image mode to point to on screen (recognized-text
+                    // mode's <mark> highlighting only needs the offsets,
+                    // but keeping one rule for what counts as a match, in
+                    // both modes, is simpler than two).
+                    if (entry?.el) this.findMatches.push({ pageIndex, start: idx, end, entry });
                 }
             }
             for (const match of this.findMatches) match.entry.el!.classList.add('word-overlay-match');
         }
 
         if (this.findMatches.length > 0) this.stepFind(1);
-        else this.updateFindCount();
+        else {
+            this.updateFindCount();
+            this.renderPageTextHighlights();
+        }
     }
 
     // Moves the current match by `delta` (wrapping in both directions) and
@@ -893,23 +944,89 @@ export class SupernoteViewerElement extends HTMLElement {
         const match = this.findMatches[this.findMatchIndex];
         match.entry.el?.classList.add('word-overlay-match-current');
         this.updateFindCount();
+        this.renderPageTextHighlights();
         this.scrollToMatch(match);
+    }
+
+    // Recognized-text mode shows page.text reflowed as plain paragraphs -
+    // nothing like the handwriting's original x/y layout the image-mode
+    // word-overlay spans are positioned against (and worse, that mode
+    // hides the image entirely, collapsing the container to the text
+    // block's own height - see the .word-overlay-span display:none rule
+    // in mode-text - so those spans have nothing sensible to overlay even
+    // if shown). Matches there are instead highlighted by wrapping the
+    // matched range of each page's stored rawText in a <mark>, using the
+    // same start/end offsets computed in runFind() - safe to reuse
+    // directly because buildWordSearchText()'s reconstruction is
+    // character-identical to page.text (see wordOverlay.test.ts).
+    // Rebuilds every page's text unconditionally on every find action
+    // (not just the affected page) - simple, and cheap at the amount of
+    // recognized text one note actually has (see runFind()'s own
+    // comment).
+    private renderPageTextHighlights(): void {
+        const matchesByPage = new Map<number, FindMatch[]>();
+        for (const match of this.findMatches) {
+            const forPage = matchesByPage.get(match.pageIndex) ?? [];
+            forPage.push(match);
+            matchesByPage.set(match.pageIndex, forPage);
+        }
+
+        for (let pageIndex = 0; pageIndex < this.pageStates.length; pageIndex++) {
+            const state = this.pageStates[pageIndex];
+            const matches = matchesByPage.get(pageIndex) ?? [];
+            const textEl = state.textEl;
+            textEl.textContent = '';
+
+            if (state.rawText.length === 0) {
+                textEl.textContent = 'No recognized text on this page.';
+                continue;
+            }
+            if (matches.length === 0) {
+                textEl.textContent = state.rawText;
+                continue;
+            }
+
+            let cursor = 0;
+            for (const match of matches) {
+                if (match.start > cursor) textEl.appendChild(document.createTextNode(state.rawText.slice(cursor, match.start)));
+                const mark = document.createElement('mark');
+                mark.className = match === this.findMatches[this.findMatchIndex] ? 'find-match find-match-current' : 'find-match';
+                mark.textContent = state.rawText.slice(match.start, match.end);
+                textEl.appendChild(mark);
+                cursor = match.end;
+            }
+            if (cursor < state.rawText.length) textEl.appendChild(document.createTextNode(state.rawText.slice(cursor)));
+        }
     }
 
     private scrollToMatch(match: FindMatch): void {
         if (!this.sn || !this.pagesEl) return;
         const state = this.pageStates[match.pageIndex];
-        const el = match.entry.el;
-        if (!state || !el) return;
-        if (!state.loaded) void this.ensurePageImageLoaded(this.sn, state);
+        if (!state) return;
 
-        // Centers the match within the visible viewport rather than just
-        // bringing its page's top edge into view (goToPage()'s own
-        // behavior, too coarse for a match partway down a tall page) - same
-        // getBoundingClientRect()-delta + .pages.scrollTo() approach
-        // goToPage() uses and for the same reason: scrollIntoView() would
-        // cascade to any scrollable ancestor this element is embedded in
-        // (e.g. Obsidian's own note editor, for SupernoteEmbed).
+        // Recognized-text mode has no image/overlay-span geometry to
+        // scroll to (see renderPageTextHighlights()) - the current <mark>
+        // it just built is the only thing with a real on-screen position.
+        if (this.mode === 'text') {
+            const mark = state.textEl.querySelector('.find-match-current');
+            if (mark) this.scrollElementIntoPagesView(mark);
+            return;
+        }
+
+        const el = match.entry.el;
+        if (!el) return;
+        if (!state.loaded) void this.ensurePageImageLoaded(this.sn, state);
+        this.scrollElementIntoPagesView(el);
+    }
+
+    // Centers `el` within the visible .pages viewport rather than just
+    // bringing its page's top edge into view (goToPage()'s own behavior,
+    // too coarse for a match partway down a tall page) - .pages.scrollTo()
+    // with a manually computed offset, never scrollIntoView(), which would
+    // cascade to any scrollable ancestor this element is embedded in (e.g.
+    // Obsidian's own note editor, for SupernoteEmbed).
+    private scrollElementIntoPagesView(el: Element): void {
+        if (!this.pagesEl) return;
         const pagesRect = this.pagesEl.getBoundingClientRect();
         const targetRect = el.getBoundingClientRect();
         const targetTop = this.pagesEl.scrollTop + (targetRect.top - pagesRect.top) - pagesRect.height / 2 + targetRect.height / 2;


### PR DESCRIPTION
## Summary

Implements the "find-in-note over a positioned word overlay" idea from the [plan posted on issue #183](https://github.com/philips/supernote-obsidian-plugin/issues/183) - a real, from-scratch find feature for the standalone `<supernote-viewer>` web component, with no PDF/pdf.js dependency (which SupernoteView's own find-in-note needs and which has no equivalent outside Obsidian).

The key insight: a note's own parsed data (`page.recognitionElements[].words[].bounding-box`) already has per-word position data - the same data `supernote-typescript`'s `pdf.ts` draws into an invisible PDF text layer today. This lays that data out directly as CSS instead, sidestepping PDF assembly and pdf.js entirely.

- **`src/render/wordOverlay.ts`** (new, portable, no Obsidian import):
  - `buildWordOverlay()` - one absolutely-positioned, invisible `<span>` per recognized word with a bounding box.
  - `repositionWordOverlay()` - rescales those spans to a page's currently-rendered size (mirrors `main.ts`'s existing `positionLinkOverlay()`).
  - `buildWordSearchText()` - reconstructs each page's reading-order text from word-level entries (not `page.text`, which is built from whole-*element* labels and would misalign word-level offsets), joining separate `recognitionElements` with `'\n'` the same way `pdf.ts`'s own `extractText()` already does. Caught and fixed a real bug during development: without that join character, adjacent elements' words concatenated directly into one glued-together string (e.g. `"Real"` + `"time"` + `"recognition"` → `"Realtimerecognition"`).
- **`src/webcomponent/SupernoteViewerElement.ts`**:
  - Builds a word overlay for every page, keeps it aligned with live layout via a `ResizeObserver`.
  - Adds a find bar (input, prev/next, match count, close) - linear substring search over each page's reconstructed text, matches highlighted and cycled with wraparound.
  - Jumping to a match scrolls only this component's own `.pages` container (the same pattern `goToPage()` already uses), never `scrollIntoView()`.
  - The toolbar's mode-toggle and find button are now shown even for a single-page note - only the prev/next-page arrows and page indicator still need more than one page.
- Bumps the `supernote-typescript` submodule pointer to a branch adding `IRecognitionElement` to its public exports (needed to type this without a cast) - see [philips/supernote-typescript#47](https://github.com/philips/supernote-typescript/pull/47).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint .` - 0 errors (1 pre-existing warning, unrelated: deprecated `escape()`, mirrors `pdf.ts`'s own use of the same round-trip)
- [x] `npm test` - 133/133 passing (23 new: 10 in `wordOverlay.test.ts` incl. against the real `rtr.note` fixture, 13 in `SupernoteViewerElement.test.ts` for the find UI)
- [x] `npm run build` and `npm run build:webcomponent` both succeed
- [x] Verified in a real Chromium browser (Playwright, against the built demo page and the real `rtr.note` fixture): word-overlay spans build correctly (48 spans, includes "Real"), a match's highlight box geometrically lands within the visible page image, next/prev cycles through all 4 "paragraph" matches and wraps in both directions, closing the find bar clears all highlights, and the host page's `scrollY` never moves