### PR TITLE
Add zoom to <supernote-viewer> (Phase 1 of #183's SupernoteView port)

### DIFF
--- a/src/webcomponent/SupernoteViewerElement.test.ts
+++ b/src/webcomponent/SupernoteViewerElement.test.ts
@@ -163,12 +163,18 @@ describe('<supernote-viewer>', () => {
         expect(el.rasterizePage).toHaveBeenCalledTimes(1);
         expect(el.rasterizePage).toHaveBeenCalledWith(expect.anything(), 2);
 
-        const page2Img = el.shadowRoot!.querySelectorAll('.page-container')[1].querySelector('img');
+        const page2Container = el.shadowRoot!.querySelectorAll('.page-container')[1];
+        const page2Img = page2Container.querySelector('img');
         expect(page2Img?.src).toBe('data:image/png;base64,page2');
-        // The placeholder's inline sizing overrides (see
-        // buildNotePagePlaceholders()) should be cleared once real content
-        // loads in.
-        expect(page2Img?.style.width).toBe('');
+        // fillNotePagePlaceholder()'s own inline sizing overrides (see
+        // buildNotePagePlaceholders()) get cleared once real content loads
+        // in, but ensurePageImageLoaded() immediately reapplies the
+        // current zoom (see applyZoomToPages()) on top - so the img ends
+        // up at width: 100% (of its own container, not the placeholder's
+        // aspect-ratio trick), and the container itself carries an
+        // explicit zoom-scaled pixel width, not the empty string either.
+        expect(page2Img?.style.width).toBe('100%');
+        expect((page2Container as HTMLElement).style.width).toMatch(/^\d+(\.\d+)?px$/);
 
         // Calling again shouldn't re-trigger a rasterization of an
         // already-loaded page.
@@ -312,6 +318,152 @@ describe('<supernote-viewer>', () => {
 
             expect(el.shadowRoot!.querySelector('button[aria-label="Toggle page thumbnails"]')).toBeNull();
             expect(el.shadowRoot!.querySelector('.thumb-sidebar')).toBeNull();
+        });
+    });
+
+    describe('zoom', () => {
+        async function createLoadedViewer() {
+            const el = createViewer();
+            document.body.appendChild(el);
+            const loaded = waitForEvent(el, 'supernote-load');
+            el.noteData = readFixture('nomad-3.26.40-blank-2p.note'); // pageWidth 1404, 2 pages
+            await loaded;
+            return el;
+        }
+
+        it('zoom in/out/reset buttons scale every page and update the label', async () => {
+            // happy-dom has no real layout engine (.pages' clientWidth
+            // defaults to 0 - see applyFitWidth()'s own early-return
+            // guard), so fit-width - on by default - never actually
+            // *applies* a computed width here at load time (the initial
+            // container width is still whatever noteRenderer.ts's own
+            // placeholder set, e.g. "100%" of .pages). A reset click below
+            // establishes a known, deterministic 100%/1404px baseline via
+            // setZoom(1) instead, which - being a manual action - always
+            // applies regardless of .pages' width.
+            const el = await createLoadedViewer();
+            const zoomInBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Zoom in"]')!;
+            const zoomOutBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Zoom out"]')!;
+            const resetBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Reset zoom"]')!;
+            const label = el.shadowRoot!.querySelector('.zoom-label')!;
+            const containers = el.shadowRoot!.querySelectorAll<HTMLElement>('.page-container');
+
+            resetBtn.click();
+            expect(label.textContent).toBe('100%');
+            expect(containers[0].style.width).toBe('1404px');
+            expect(containers[1].style.width).toBe('1404px');
+
+            zoomInBtn.click();
+            expect(label.textContent).toBe('125%');
+            expect(containers[0].style.width).toBe('1755px'); // 1404 * 1.25
+
+            zoomOutBtn.click();
+            zoomOutBtn.click();
+            expect(label.textContent).toBe('80%'); // 125% / 1.25 / 1.25
+
+            resetBtn.click();
+            expect(label.textContent).toBe('100%');
+            expect(containers[0].style.width).toBe('1404px');
+
+            // Every page's img stays at width: 100% of its own
+            // (explicitly, zoom-scaled) container - see applyZoomToPages().
+            for (const container of Array.from(containers)) {
+                expect(container.querySelector('img')?.style.width).toBe('100%');
+            }
+        });
+
+        it('clamps manual zoom to [5%, 500%]', async () => {
+            const el = await createLoadedViewer();
+            const zoomInBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Zoom in"]')!;
+            const zoomOutBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Zoom out"]')!;
+            const label = el.shadowRoot!.querySelector('.zoom-label')!;
+
+            for (let i = 0; i < 20; i++) zoomInBtn.click();
+            expect(label.textContent).toBe('500%');
+
+            for (let i = 0; i < 40; i++) zoomOutBtn.click();
+            expect(label.textContent).toBe('5%');
+        });
+
+        it('any manual zoom action turns off fit-width', async () => {
+            const el = await createLoadedViewer();
+            const fitWidthBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Fit page to viewport width"]')!;
+            const zoomInBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Zoom in"]')!;
+            expect(fitWidthBtn.getAttribute('aria-pressed')).toBe('true');
+
+            zoomInBtn.click();
+
+            expect(fitWidthBtn.getAttribute('aria-pressed')).toBe('false');
+        });
+
+        it('ctrl+wheel zooms; a plain wheel does not', async () => {
+            const el = await createLoadedViewer();
+            const pagesEl = el.shadowRoot!.querySelector('.pages') as HTMLElement;
+            const label = el.shadowRoot!.querySelector('.zoom-label')!;
+
+            const plainWheel = new WheelEvent('wheel', { deltaY: -100, cancelable: true });
+            pagesEl.dispatchEvent(plainWheel);
+            expect(label.textContent).toBe('100%');
+            expect(plainWheel.defaultPrevented).toBe(false);
+
+            // happy-dom's WheelEvent constructor doesn't wire up ctrlKey
+            // from its init dict (confirmed directly: MouseEvent respects
+            // it, WheelEvent silently doesn't) - defineProperty is a
+            // reliable, if slightly unusual, workaround. Real ctrl+scroll/
+            // pinch-to-zoom input is verified separately in a real browser
+            // (see the Playwright verification for this feature).
+            const ctrlWheel = new WheelEvent('wheel', { deltaY: -100, cancelable: true });
+            Object.defineProperty(ctrlWheel, 'ctrlKey', { value: true });
+            pagesEl.dispatchEvent(ctrlWheel);
+            expect(ctrlWheel.defaultPrevented).toBe(true);
+            expect(label.textContent).not.toBe('100%');
+            // deltaY -100 -> factor min(1.05, 1 - (-100)*0.01) = min(1.05, 2) = 1.05
+            expect(label.textContent).toBe('105%');
+        });
+
+        it('re-enabling fit-width recomputes from .pages\' current width', async () => {
+            const el = await createLoadedViewer();
+            const pagesEl = el.shadowRoot!.querySelector('.pages') as HTMLElement;
+            const fitWidthBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Fit page to viewport width"]')!;
+            const zoomOutBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Zoom out"]')!;
+            const label = el.shadowRoot!.querySelector('.zoom-label')!;
+            const container = el.shadowRoot!.querySelector<HTMLElement>('.page-container')!;
+
+            // happy-dom's clientWidth is always 0 by default - stub it to a
+            // real value to exercise applyFitWidth()'s actual computation.
+            Object.defineProperty(pagesEl, 'clientWidth', { value: 702, configurable: true });
+
+            zoomOutBtn.click(); // manual action -> turns fit-width off
+            expect(fitWidthBtn.getAttribute('aria-pressed')).toBe('false');
+
+            fitWidthBtn.click(); // re-enable -> recomputes immediately
+            expect(fitWidthBtn.getAttribute('aria-pressed')).toBe('true');
+            expect(label.textContent).toBe('50%'); // 702 / 1404
+            expect(container.style.width).toBe('702px');
+        });
+
+        it('has no toolbar/zoom controls in single-page mode, and stays capped by CSS instead of zoom', async () => {
+            const el = createViewer();
+            el.setAttribute('single-page', '');
+            document.body.appendChild(el);
+            const loaded = waitForEvent(el, 'supernote-load');
+            el.noteData = readFixture('nomad-3.26.40-blank-2p.note'); // pageWidth 1404
+            await loaded;
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(el.shadowRoot!.querySelector('.toolbar')).toBeNull();
+            expect(el.shadowRoot!.querySelector('.zoom-label')).toBeNull();
+            // ensurePageImageLoaded() still calls applyZoomToPages() here
+            // (zoomScale never changes from its 1/100% default in this
+            // mode, since no controls exist to change it) - the container
+            // gets the same explicit native-pixel width a zoomed page
+            // would, but single-page mode's CSS (the plain, un-overridden
+            // max-width: 100% rule - see the :host(:not([single-page]))
+            // scoping) still caps it down to whatever's actually
+            // available, unlike normal mode where zoom can exceed it.
+            const container = el.shadowRoot!.querySelector<HTMLElement>('.page-container')!;
+            expect(container.style.width).toBe('1404px');
         });
     });
 

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -157,6 +157,12 @@ button[aria-pressed="true"] {
     color: var(--supernote-viewer-muted);
     font-size: 0.9em;
 }
+.zoom-label {
+    min-width: 3.5em;
+    text-align: center;
+    color: var(--supernote-viewer-muted);
+    font-size: 0.9em;
+}
 .find-bar {
     display: none;
     align-items: center;
@@ -260,6 +266,19 @@ button[aria-pressed="true"] {
 .pages .page-container {
     position: relative;
     max-width: 100%;
+}
+/* Zoom (see setZoom()/applyFitWidth()) needs a page to be able to render
+   wider than .pages' own available width - a manually zoomed-in page
+   should overflow (enabling .pages' own overflow: auto to scroll to it),
+   not get silently capped back down to "fit" regardless of the requested
+   zoom level. Single-page mode has no zoom controls at all (see
+   buildSinglePageViewer()) and still wants its one page capped to
+   whatever width is actually available, same as any other loaded,
+   non-zoomed page always was - so this override is scoped to normal
+   (non-single-page) mode only, leaving the plain max-width: 100% above as
+   single-page mode's only sizing rule. */
+:host(:not([single-page])) .pages .page-container {
+    max-width: none;
 }
 .pages .page-container > img {
     display: block;
@@ -466,6 +485,13 @@ export class SupernoteViewerElement extends HTMLElement {
     // Manual debugging aid only - see debugLoopEvictReload().
     private debugLoopTimer?: number;
     private resizeObserver: ResizeObserver | null = null;
+    // Separate from resizeObserver above (which watches each *page's own*
+    // rendered size, for word-overlay repositioning) - this one watches
+    // .pages itself, so fit-width can recompute when the *viewport*
+    // resizes (a split pane, a sidebar opening/closing, the window itself),
+    // not just when a page's own size happens to change.
+    private pagesResizeObserver: ResizeObserver | null = null;
+    private fitWidthDebounceTimer?: number;
     private pageStates: ViewerPageState[] = [];
     private currentPage = 0;
     private pageIndicatorScrollScheduled = false;
@@ -486,6 +512,15 @@ export class SupernoteViewerElement extends HTMLElement {
     private thumbItems: SidebarListItem[] = [];
     private thumbLoadObserver: IntersectionObserver | null = null;
     private thumbnailsVisible = false;
+    // "100%" is one rendered pixel per native rasterized page pixel
+    // (sn.pageWidth), not anything tied to the available viewport width -
+    // see applyFitWidth() for the mode that actually fills whatever space
+    // is available. Zoom/fit-width apply only in normal (non-single-page)
+    // mode - see the :host(:not([single-page])) CSS override above.
+    private zoomScale = 1;
+    private fitWidthEnabled = true;
+    private zoomLabelEl: HTMLElement | null = null;
+    private fitWidthBtn: HTMLButtonElement | null = null;
 
     constructor() {
         super();
@@ -523,6 +558,8 @@ export class SupernoteViewerElement extends HTMLElement {
         this.thumbLoadObserver?.disconnect();
         window.clearTimeout(this.loadCheckDebounceTimer);
         window.clearInterval(this.debugLoopTimer);
+        this.pagesResizeObserver?.disconnect();
+        window.clearTimeout(this.fitWidthDebounceTimer);
     }
 
     attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void {
@@ -752,6 +789,9 @@ export class SupernoteViewerElement extends HTMLElement {
         this.thumbLoadObserver = null;
         window.clearTimeout(this.loadCheckDebounceTimer);
         window.clearInterval(this.debugLoopTimer);
+        this.pagesResizeObserver?.disconnect();
+        this.pagesResizeObserver = null;
+        window.clearTimeout(this.fitWidthDebounceTimer);
         this.pageStates = [];
         this.pagesEl = null;
         this.toolbarEl = null;
@@ -772,6 +812,10 @@ export class SupernoteViewerElement extends HTMLElement {
         this.thumbToggleBtn = null;
         this.thumbItems = [];
         this.thumbnailsVisible = false;
+        this.zoomScale = 1;
+        this.fitWidthEnabled = true;
+        this.zoomLabelEl = null;
+        this.fitWidthBtn = null;
         this.rootEl.innerHTML = '';
     }
 
@@ -821,6 +865,15 @@ export class SupernoteViewerElement extends HTMLElement {
             this.buildThumbSidebar(sn, pageCount);
         }
         this.setupOverlayResizing(sn, states);
+
+        // Matches SupernoteView's own onLoadFile() ordering: build pages,
+        // then apply whichever zoom state is active before first paint - no
+        // separate "flash of 100%/native size" in between, since nothing
+        // yields to the event loop here.
+        if (this.fitWidthEnabled) this.applyFitWidth();
+        else this.applyZoomToPages();
+        this.setupZoomWheelHandling();
+        this.setupFitWidthResizing();
     }
 
     // A single deep-linked page (the `page` attribute, clamped, defaulting
@@ -1175,6 +1228,134 @@ export class SupernoteViewerElement extends HTMLElement {
         this.thumbItems.forEach((item, i) => item.itemEl.classList.toggle('is-active', i === index));
     }
 
+    // Sets zoomScale (clamped) and applies it. Mirrors SupernoteView's own
+    // setZoom() (main.ts), but considerably simpler: that one re-rasterizes
+    // each page's canvas at the target zoom (debounced, so rapid wheel/
+    // button input doesn't thrash it) for pixel-perfect crispness at any
+    // scale. This component only ever CSS-scales the same already-
+    // rasterized <img> (see applyZoomToPages()) - cheap enough to apply
+    // instantly and synchronously, no debounce/re-render step needed at
+    // all. The trade-off: zooming in well past 100% shows the same
+    // native-resolution image scaled up (blurrier), rather than a
+    // freshly-rasterized higher-resolution one.
+    private setZoom(newScale: number, opts: { manual?: boolean } = {}): void {
+        const isManual = opts.manual !== false;
+        if (isManual) {
+            // Any direct zoom action (buttons, wheel, reset) is the user
+            // taking manual control - stop auto-adjusting on resize until
+            // they ask for fit-width again. applyFitWidth() itself calls in
+            // with manual: false so it doesn't immediately cancel the mode
+            // it's trying to apply.
+            this.fitWidthEnabled = false;
+            this.updateFitWidthButton();
+        }
+
+        // Floor/ceiling mirror SupernoteView's own setZoom(): fit-width can
+        // legitimately need to go far outside a sane *manual* zoom range
+        // (a narrow mobile screen might need under 25%; a small native
+        // page resolution on a large/high-DPI display might need well over
+        // 500% just to fill the available width) - the wider ceiling there
+        // is purely a guard against a pathological render (e.g. a
+        // zero-width native page), not a real intended limit the way
+        // manual zoom's 500% cap is.
+        const ceiling = isManual ? 5 : 20;
+        this.zoomScale = Math.min(ceiling, Math.max(0.05, newScale));
+        this.applyZoomToPages();
+    }
+
+    // Applies the current zoomScale to every page's container - explicit
+    // pixel width, not a CSS transform, so .pages' own scrollable content
+    // size (and thus scrollbar/overflow behavior) actually reflects the
+    // zoomed size, the same way a real image resize would. Each page's
+    // <img> stays at width: 100% (of its own now explicitly-sized
+    // container, set by noteRenderer.ts for both the still-loading
+    // placeholder and, once ensurePageImageLoaded() calls this again, the
+    // real loaded image) - keeping the width source in one place (the
+    // container) rather than duplicating this same computation onto every
+    // img too.
+    private applyZoomToPages(): void {
+        if (!this.sn) return;
+        const width = `${this.sn.pageWidth * this.zoomScale}px`;
+        for (const state of this.pageStates) {
+            state.containerEl.style.width = width;
+            state.imageEl.style.width = '100%';
+        }
+        if (this.zoomLabelEl) this.zoomLabelEl.textContent = `${Math.round(this.zoomScale * 100)}%`;
+    }
+
+    // Scales every page so its rendered width matches however much
+    // horizontal space is actually available (.pages' own content box,
+    // minus its first page-container's own horizontal margin, if any -
+    // mirrors SupernoteView's own applyFitWidth() exactly, including
+    // reading that margin from computed style rather than assuming it's
+    // zero, even though this component's own stylesheet uses .pages' gap
+    // rather than page-container margins for inter-page spacing today).
+    private applyFitWidth(): void {
+        if (!this.sn || !this.pagesEl || this.sn.pageWidth <= 0) return;
+
+        const availableWidth = this.pagesEl.clientWidth;
+        if (availableWidth <= 0) return;
+
+        const state = this.pageStates[0];
+        const containerStyle = state ? getComputedStyle(state.containerEl) : null;
+        const horizontalMargin = containerStyle
+            ? parseFloat(containerStyle.marginLeft || '0') + parseFloat(containerStyle.marginRight || '0')
+            : 0;
+        const targetWidth = Math.max(availableWidth - horizontalMargin, 1);
+
+        this.setZoom(targetWidth / this.sn.pageWidth, { manual: false });
+    }
+
+    private updateFitWidthButton(): void {
+        this.fitWidthBtn?.setAttribute('aria-pressed', String(this.fitWidthEnabled));
+    }
+
+    // Ctrl+scroll to zoom (trackpad pinch-to-zoom is reported as a wheel
+    // event with ctrlKey set, on every platform) - mirrors SupernoteView's
+    // own registerDomEvent(this.contentEl, 'wheel', ...) handler in
+    // main.ts, deliberately NOT metaKey (Cmd on macOS): Cmd is also the
+    // modifier held down through a whole Cmd+Tab app switch, and a wheel
+    // event from scroll momentum/inertia that happens to fire mid-switch -
+    // nothing to do with zooming - would still carry metaKey: true and get
+    // treated as a zoom gesture. Trackpad pinch never sets metaKey, only
+    // ctrlKey.
+    private setupZoomWheelHandling(): void {
+        if (!this.pagesEl) return;
+        this.pagesEl.addEventListener('wheel', (evt: WheelEvent) => {
+            if (!evt.ctrlKey) return;
+            evt.preventDefault();
+
+            // Trackpads report a pinch-to-zoom gesture as a wheel event
+            // with ctrlKey set - the same flag an ordinary two-finger
+            // scroll can spuriously carry for a stray event or two right
+            // as the scroll hits a boundary. A fixed per-event zoom step
+            // let a short burst of those misfires snowball straight to the
+            // zoom cap; scaling the step by the event's own deltaY keeps a
+            // real, sustained pinch feeling responsive while capping how
+            // much a single misfired event can do.
+            const factor = Math.min(1.05, Math.max(0.95, 1 - evt.deltaY * 0.01));
+            this.setZoom(this.zoomScale * factor);
+        }, { passive: false });
+    }
+
+    // While "Fit width" is on, keeps every page matched to however much
+    // room is actually available as .pages itself resizes (a split pane, a
+    // sidebar opening/closing, the window itself) - not just at the moment
+    // it was turned on. Debounced since resize fires continuously while
+    // dragging. Separate from resizeObserver (see setupOverlayResizing())
+    // - that one watches each page's own size for word/link overlay
+    // repositioning; this one watches .pages itself, the viewport
+    // fit-width computes against.
+    private setupFitWidthResizing(): void {
+        if (!this.pagesEl || typeof ResizeObserver === 'undefined') return;
+        this.pagesResizeObserver = new ResizeObserver(() => {
+            if (!this.fitWidthEnabled) return;
+            window.clearTimeout(this.fitWidthDebounceTimer);
+            this.fitWidthDebounceTimer = window.setTimeout(() => this.applyFitWidth(), 150);
+        });
+        this.pagesResizeObserver.observe(this.pagesEl);
+    }
+
     // Idempotent and safe to call speculatively - `loaded` is set eagerly so
     // a slow rasterization can't be triggered twice for the same page.
     private async ensurePageImageLoaded(sn: SupernoteX, state: ViewerPageState): Promise<void> {
@@ -1205,6 +1386,17 @@ export class SupernoteViewerElement extends HTMLElement {
             }
             fillNotePagePlaceholder(state, imageDataUrl);
             console.debug(`supernote-viewer: page ${state.pageNumber} loaded, img.src set (length ${imageDataUrl.length})`);
+            // fillNotePagePlaceholder() clears this page's width overrides
+            // back to noteRenderer.ts's own loaded-image default (native
+            // size, capped down by CSS if too big - see the img's own
+            // max-width: 100% rule) - fine for single-page mode, which has
+            // no zoom concept at all, but not sufficient once zoomed *in*
+            // past 100%: CSS max-width only ever shrinks, never stretches a
+            // loaded image past its own native pixel size. Reapplying the
+            // current zoom here (cheap - just a style-string assignment per
+            // page) keeps a page that finishes loading mid-zoom sized the
+            // same as every already-loaded one.
+            this.applyZoomToPages();
         } catch (err) {
             // Allows a retry on the next intersection - a transient
             // rasterization failure shouldn't permanently blank this page.
@@ -1271,6 +1463,54 @@ export class SupernoteViewerElement extends HTMLElement {
             nextBtn.addEventListener('click', () => this.goToPage(this.currentPage + 2));
             toolbar.appendChild(nextBtn);
         }
+
+        // Zoom - worth having regardless of page count (even a single-page
+        // document can have detail worth zooming in on), so unlike the
+        // page-nav block above, not conditioned on pageCount > 1.
+        const zoomOutBtn = document.createElement('button');
+        zoomOutBtn.type = 'button';
+        zoomOutBtn.setAttribute('part', 'button');
+        zoomOutBtn.setAttribute('aria-label', 'Zoom out');
+        zoomOutBtn.textContent = '−';
+        zoomOutBtn.addEventListener('click', () => this.setZoom(this.zoomScale / 1.25));
+        toolbar.appendChild(zoomOutBtn);
+
+        const zoomLabel = document.createElement('span');
+        zoomLabel.className = 'zoom-label';
+        zoomLabel.setAttribute('part', 'zoom-label');
+        zoomLabel.textContent = '100%';
+        toolbar.appendChild(zoomLabel);
+        this.zoomLabelEl = zoomLabel;
+
+        const zoomInBtn = document.createElement('button');
+        zoomInBtn.type = 'button';
+        zoomInBtn.setAttribute('part', 'button');
+        zoomInBtn.setAttribute('aria-label', 'Zoom in');
+        zoomInBtn.textContent = '+';
+        zoomInBtn.addEventListener('click', () => this.setZoom(this.zoomScale * 1.25));
+        toolbar.appendChild(zoomInBtn);
+
+        const zoomResetBtn = document.createElement('button');
+        zoomResetBtn.type = 'button';
+        zoomResetBtn.setAttribute('part', 'button');
+        zoomResetBtn.setAttribute('aria-label', 'Reset zoom');
+        zoomResetBtn.textContent = '↺';
+        zoomResetBtn.addEventListener('click', () => this.setZoom(1));
+        toolbar.appendChild(zoomResetBtn);
+
+        const fitWidthBtn = document.createElement('button');
+        fitWidthBtn.type = 'button';
+        fitWidthBtn.setAttribute('part', 'button');
+        fitWidthBtn.setAttribute('aria-label', 'Fit page to viewport width');
+        fitWidthBtn.setAttribute('aria-pressed', 'true'); // fitWidthEnabled defaults to true
+        fitWidthBtn.textContent = 'Fit';
+        fitWidthBtn.addEventListener('click', () => {
+            this.fitWidthEnabled = !this.fitWidthEnabled;
+            if (this.fitWidthEnabled) this.applyFitWidth();
+            this.updateFitWidthButton();
+        });
+        toolbar.appendChild(fitWidthBtn);
+        this.fitWidthBtn = fitWidthBtn;
 
         const modeBtn = document.createElement('button');
         modeBtn.type = 'button';

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -266,6 +266,24 @@ button[aria-pressed="true"] {
 .pages .page-container {
     position: relative;
     max-width: 100%;
+    /* Centers a page narrower than .pages via auto-margin absorption
+       instead of relying on .pages' own align-items: center - real,
+       reported bug: a flex/grid item centered via the *container's* own
+       align-items, once zoomed in wide enough to overflow, only exposes
+       the *end*-side overflow to scrolling in Chromium/WebKit - the start
+       (left) side stays permanently unreachable no matter how far you
+       scroll, since align-items-driven centering shifts the item without
+       extending the scrollable area to cover its start-side overflow.
+       margin: auto on the item itself takes priority over the parent's
+       align-items for centering (per the flex spec's auto-margin
+       cross-axis absorption rule) and, critically, auto margins compute
+       to 0 rather than negative once the item is wider than its
+       container - so an overflowing page instead sits flush at the
+       start, restoring the ordinary, fully-reachable [0, scrollWidth -
+       clientWidth] scroll range. Confirmed directly: before this, even
+       scrollLeft = 0 (as far left as scrolling allowed) still left the
+       image's own left edge far off-screen. */
+    margin: 0 auto;
 }
 /* Zoom (see setZoom()/applyFitWidth()) needs a page to be able to render
    wider than .pages' own available width - a manually zoomed-in page
@@ -1288,8 +1306,17 @@ export class SupernoteViewerElement extends HTMLElement {
     // minus its first page-container's own horizontal margin, if any -
     // mirrors SupernoteView's own applyFitWidth() exactly, including
     // reading that margin from computed style rather than assuming it's
-    // zero, even though this component's own stylesheet uses .pages' gap
-    // rather than page-container margins for inter-page spacing today).
+    // zero: page-container now sets margin: 0 auto (see that rule's own
+    // comment - centering via auto-margin absorption rather than .pages'
+    // align-items, so a zoomed-in, overflowing page stays fully
+    // scrollable to its start edge), and an *unresolved* auto margin -
+    // getComputedStyle() returning the literal string "auto" rather than
+    // a resolved pixel value, which real layout engines normally avoid
+    // but this project's own happy-dom test environment doesn't - would
+    // otherwise silently corrupt this whole computation into NaN
+    // (parseFloat('auto') is NaN, and NaN propagates through every
+    // arithmetic operation after it). The `|| 0` fallbacks below guard
+    // against exactly that, in any environment, not just tests.
     private applyFitWidth(): void {
         if (!this.sn || !this.pagesEl || this.sn.pageWidth <= 0) return;
 
@@ -1299,7 +1326,7 @@ export class SupernoteViewerElement extends HTMLElement {
         const state = this.pageStates[0];
         const containerStyle = state ? getComputedStyle(state.containerEl) : null;
         const horizontalMargin = containerStyle
-            ? parseFloat(containerStyle.marginLeft || '0') + parseFloat(containerStyle.marginRight || '0')
+            ? (parseFloat(containerStyle.marginLeft) || 0) + (parseFloat(containerStyle.marginRight) || 0)
             : 0;
         const targetWidth = Math.max(availableWidth - horizontalMargin, 1);
 


### PR DESCRIPTION
## Summary

Phase 1 of the [plan posted on issue #183](https://github.com/philips/supernote-obsidian-plugin/issues/183#issuecomment-5162408621) for porting `SupernoteView`'s features into the shared `<supernote-viewer>` web component: zoom (buttons, ctrl+scroll/trackpad-pinch, fit-width).

Considerably simpler than `SupernoteView`'s own zoom (`main.ts`): that one re-rasterizes each page's canvas at the target zoom (debounced, so rapid input doesn't thrash it) for pixel-perfect crispness at any scale. This component only ever CSS-scales the same already-rasterized `<img>` - an explicit pixel width on each page's container (not a `transform`, so `.pages`' own scrollable size actually reflects the zoomed size), applied instantly with no debounce/re-render step at all. Trade-off: zooming in well past 100% shows the same native-resolution image scaled up (blurrier), not a freshly-rasterized higher-resolution one.

- `setZoom()`/`applyZoomToPages()`: manual zoom (in/out/reset buttons, ctrl+scroll/trackpad-pinch via a wheel listener) - clamped to `[5%, 500%]`, mirroring `SupernoteView`'s own ceiling/floor.
- `applyFitWidth()`: computes whatever scale fills `.pages`' available width, on by default, kept in sync via a new `ResizeObserver` on `.pages` itself (separate from the existing one that repositions word-overlay spans per page - this one watches the viewport, not each page).
- Any manual zoom action turns fit-width off, same as `SupernoteView`'s own `isManual` handling.
- CSS: `.page-container`'s `max-width: 100%` cap is overridden (to `max-width: none`) only in normal mode, via `:host(:not([single-page]))` - a manually zoomed-in page needs to be able to exceed `.pages`' width (enabling its own `overflow: auto` to scroll to it) instead of being silently capped back to "fit" regardless of the requested zoom. Single-page mode has no zoom controls at all and keeps today's plain "cap to whatever's available" behavior unchanged.
- The existing per-page `ResizeObserver` (built for word-overlay repositioning) picks up zoom-driven size changes for free, with no code change needed there - zoom just changes each page's rendered size the same way a window resize or image load already did.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint .` - 0 errors, 0 warnings
- [x] `npm test` - 142/142 passing (6 new zoom-specific tests)
- [x] `npm run build` and `npm run build:webcomponent` both succeed
- [x] Verified in a real Chromium browser (Playwright, against the built demo page): fit-width computes correctly from the real viewport, zoom in/out/reset/ctrl+wheel/trackpad-pinch all work with real geometry, zooming to 500% causes genuine horizontal overflow/scroll (confirming the CSS override actually works - not verifiable in the happy-dom test environment, which has no real layout engine), find-in-note's highlight still lands on the visible image at a non-100% zoom, and single-page mode is completely unaffected (no controls, page still capped to its host's width)