### PR TITLE
Add page thumbnail sidebar to <supernote-viewer> (Phase 2 of #183's SupernoteView port)

### DIFF
--- a/src/render/sidebarList.test.ts
+++ b/src/render/sidebarList.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi } from 'vitest';
+import { buildSidebarList, setupLazyListLoading, fillSidebarThumbnail } from './sidebarList';
+
+describe('buildSidebarList', () => {
+    it('builds one item per spec, in order, with a thumbnail reserving the given aspect ratio', () => {
+        const container = document.createElement('div');
+        const items = buildSidebarList(
+            container,
+            [{ label: '1' }, { label: '2' }, { label: '3' }],
+            { thumbnailAspectRatio: { width: 1404, height: 1872 } },
+        );
+
+        expect(items).toHaveLength(3);
+        expect(container.querySelectorAll('.sidebar-list-item')).toHaveLength(3);
+        for (const item of items) {
+            expect(item.imgEl.style.aspectRatio).toBe('1404 / 1872');
+            expect(item.imgEl.src).toBe('');
+        }
+    });
+
+    it('renders a plain label (no checkbox) when checkbox is omitted', () => {
+        const container = document.createElement('div');
+        const [item] = buildSidebarList(container, [{ label: 'Page 1' }], {
+            thumbnailAspectRatio: { width: 100, height: 200 },
+        });
+
+        expect(item.itemEl.querySelector('input[type="checkbox"]')).toBeNull();
+        expect(item.itemEl.querySelector('.sidebar-list-label')?.textContent).toBe('Page 1');
+    });
+
+    it('renders a checkbox (checked state + label) when provided, and calls onChange with the new checked state', () => {
+        const container = document.createElement('div');
+        const onChange = vi.fn();
+        const [item] = buildSidebarList(
+            container,
+            [{ label: 'Background', checkbox: { checked: true, onChange } }],
+            { thumbnailAspectRatio: { width: 100, height: 200 } },
+        );
+
+        const checkbox = item.itemEl.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+        expect(checkbox.checked).toBe(true);
+        expect(item.itemEl.querySelector('.sidebar-list-checkbox-label')?.textContent).toContain('Background');
+        // No separate .sidebar-list-label - the checkbox's own <label> already carries the text.
+        expect(item.itemEl.querySelector('.sidebar-list-label')).toBeNull();
+
+        checkbox.checked = false;
+        checkbox.dispatchEvent(new Event('change'));
+        expect(onChange).toHaveBeenCalledWith(false);
+    });
+
+    it('calls onItemClick with the clicked item\'s index when the row is clicked', () => {
+        const container = document.createElement('div');
+        const onItemClick = vi.fn();
+        const items = buildSidebarList(container, [{ label: 'a' }, { label: 'b' }], {
+            thumbnailAspectRatio: { width: 1, height: 1 },
+            onItemClick,
+        });
+
+        items[1].itemEl.click();
+
+        expect(onItemClick).toHaveBeenCalledWith(1);
+        expect(onItemClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not attach a click handler when onItemClick is omitted (no error on click)', () => {
+        const container = document.createElement('div');
+        const [item] = buildSidebarList(container, [{ label: 'a' }], { thumbnailAspectRatio: { width: 1, height: 1 } });
+        expect(() => item.itemEl.click()).not.toThrow();
+    });
+});
+
+describe('fillSidebarThumbnail', () => {
+    it('sets the item\'s img src', () => {
+        const container = document.createElement('div');
+        const [item] = buildSidebarList(container, [{ label: 'a' }], { thumbnailAspectRatio: { width: 1, height: 1 } });
+        fillSidebarThumbnail(item, 'data:image/png;base64,aaa');
+        expect(item.imgEl.src).toBe('data:image/png;base64,aaa');
+    });
+});
+
+describe('setupLazyListLoading', () => {
+    // happy-dom's IntersectionObserver never actually fires callbacks (no
+    // real layout engine - see this project's other test files' own
+    // comments on the same limitation), so this only exercises the setup
+    // itself (every item gets observed) - the debounce/re-check behavior
+    // is verified in a real browser instead (see the Playwright
+    // verification for this feature).
+    it('observes every item element against the given root', () => {
+        const root = document.createElement('div');
+        const items = [document.createElement('div'), document.createElement('div')];
+        const observeSpy = vi.spyOn(IntersectionObserver.prototype, 'observe');
+
+        setupLazyListLoading(root, items, () => {});
+
+        expect(observeSpy).toHaveBeenCalledTimes(2);
+        expect(observeSpy).toHaveBeenCalledWith(items[0]);
+        expect(observeSpy).toHaveBeenCalledWith(items[1]);
+        observeSpy.mockRestore();
+    });
+
+    it('returns a real IntersectionObserver instance', () => {
+        const root = document.createElement('div');
+        const observer = setupLazyListLoading(root, [], () => {});
+        expect(observer).toBeInstanceOf(IntersectionObserver);
+    });
+});

--- a/src/render/sidebarList.ts
+++ b/src/render/sidebarList.ts
@@ -1,0 +1,165 @@
+// Portable "lazy-loaded thumbnail list" building block - a scrollable
+// sidebar of items, each with a thumbnail image (loaded lazily, via a
+// debounced IntersectionObserver, once it nears the viewport) and a label,
+// optionally with a checkbox instead of a plain click-to-select row.
+//
+// Extracted from SupernoteView's own thumbnail sidebar (main.ts,
+// buildThumbSidebar()) - the same debounced load-on-approach pattern that
+// fixed a real out-of-memory crash scrolling a long document's sidebar
+// quickly (issue #154) - so <supernote-viewer>'s own page-thumbnail
+// sidebar (SupernoteViewerElement.ts) and a future, similarly-shaped list
+// can share it instead of each reimplementing the same lazy-load/debounce
+// machinery from scratch. The checkbox option exists specifically for
+// that future case: a Supernote Atelier (.spd) file's layer toggle (see
+// atelierView.ts's own buildLayerToggle(), today a plain, non-portable,
+// non-lazy checkbox list with no thumbnail preview at all - a .spd file
+// only ever has a handful of layers, so it's never needed lazy loading,
+// but a thumbnail preview per layer would be a genuine improvement it
+// could get for free by building on this module instead).
+export interface SidebarListItemSpec {
+    label: string;
+    // Rendered as a checkbox before the label if provided (the
+    // layer-toggle use case: checked = that layer/surface is visible).
+    // Omitted entirely for a plain click-to-select row (the page-thumbnail
+    // use case: clicking navigates, no checkbox).
+    checkbox?: {
+        checked: boolean;
+        onChange: (checked: boolean) => void;
+    };
+}
+
+export interface SidebarListItem {
+    itemEl: HTMLElement;
+    imgEl: HTMLImageElement;
+}
+
+export interface BuildSidebarListOptions {
+    // Every item's thumbnail reserves this aspect ratio before its image
+    // loads - the same "reserve the box size up front" trick
+    // buildNotePagePlaceholders() uses and for the same reason: an <img>
+    // with no src/dimensions otherwise collapses to ~0 height, so it
+    // "pops" to full size right as it loads, reflowing every later item's
+    // position (confirmed, in the original thumbnail sidebar this was
+    // extracted from, to be why scrolling it for a while could still crash
+    // - issue #154 - even after loading itself was bounded to "only what's
+    // visible": each pop re-triggers the observer for a large swath of
+    // items at once). One ratio for the whole list, not per item, since
+    // every page of a note (or every layer of an Atelier file, composited
+    // against one shared tile-grid - see SupernoteAtelier.toImage()'s own
+    // doc comment) shares one native size.
+    thumbnailAspectRatio: { width: number; height: number };
+    onItemClick?: (index: number) => void;
+}
+
+// Builds one item per entry in `items` and appends them to `container` -
+// plain DOM APIs only, no Obsidian dependency, so this can run in a
+// standalone browser context same as the rest of src/render/. Doesn't load
+// any thumbnail image itself (see setupLazyListLoading()) or build the
+// scrollable container/toggle button around the list - callers layer that
+// on top of the returned elements, the same division of responsibility
+// noteRenderer.ts's own buildNotePagePlaceholders() has.
+export function buildSidebarList(
+    container: HTMLElement,
+    items: SidebarListItemSpec[],
+    options: BuildSidebarListOptions,
+): SidebarListItem[] {
+    const { width, height } = options.thumbnailAspectRatio;
+
+    return items.map((spec, index) => {
+        const itemEl = document.createElement('div');
+        itemEl.className = 'sidebar-list-item';
+        itemEl.dataset.index = String(index);
+
+        if (spec.checkbox) {
+            const checkboxLabel = document.createElement('label');
+            checkboxLabel.className = 'sidebar-list-checkbox-label';
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.checked = spec.checkbox.checked;
+            checkbox.addEventListener('change', () => spec.checkbox!.onChange(checkbox.checked));
+            checkboxLabel.appendChild(checkbox);
+            checkboxLabel.appendChild(document.createTextNode(spec.label));
+            itemEl.appendChild(checkboxLabel);
+        }
+
+        const img = document.createElement('img');
+        img.className = 'sidebar-list-thumb';
+        img.style.aspectRatio = `${width} / ${height}`;
+        itemEl.appendChild(img);
+
+        // A plain click-to-select row (no checkbox) still needs its own
+        // visible label - the layer-toggle row above already put its label
+        // text inside the checkbox's own <label>, so this only runs for
+        // the other case.
+        if (!spec.checkbox) {
+            const labelEl = document.createElement('span');
+            labelEl.className = 'sidebar-list-label';
+            labelEl.textContent = spec.label;
+            itemEl.appendChild(labelEl);
+        }
+
+        if (options.onItemClick) {
+            itemEl.addEventListener('click', () => options.onItemClick!(index));
+        }
+
+        container.appendChild(itemEl);
+        return { itemEl, imgEl: img };
+    });
+}
+
+// Debounced IntersectionObserver-driven lazy loader - mirrors
+// SupernoteView's own thumbObserver (buildThumbSidebar()) exactly,
+// including its debounce: confirmed by testing there that scrolling a long
+// sidebar *quickly* still triggered a rasterization storm without one,
+// even once loading was already bounded to "only what's currently
+// visible" (issue #154) - a fast scroll flings most items past the
+// viewport well within the debounce window, so only ones actually lingered
+// near for a moment trigger a real load.
+export function setupLazyListLoading(
+    root: HTMLElement,
+    itemEls: HTMLElement[],
+    loadItem: (index: number) => void,
+    options: { rootMargin?: string; debounceMs?: number } = {},
+): IntersectionObserver {
+    const rootMargin = options.rootMargin ?? '100% 0px';
+    const debounceMs = options.debounceMs ?? 200;
+    const debounceTimers = new Map<number, number>();
+    const currentlyVisible = new Set<number>();
+
+    const observer = new IntersectionObserver((entries) => {
+        for (const entry of entries) {
+            const index = itemEls.indexOf(entry.target as HTMLElement);
+            if (index === -1) continue;
+
+            if (entry.isIntersecting) currentlyVisible.add(index);
+            else currentlyVisible.delete(index);
+
+            window.clearTimeout(debounceTimers.get(index));
+            if (!entry.isIntersecting) continue;
+
+            debounceTimers.set(index, window.setTimeout(() => {
+                // Re-checks rather than assuming still true - the timer
+                // firing doesn't mean nothing happened since it was
+                // scheduled (see this function's own comment).
+                if (currentlyVisible.has(index)) loadItem(index);
+            }, debounceMs));
+        }
+    }, { root, rootMargin });
+
+    for (const el of itemEls) observer.observe(el);
+    return observer;
+}
+
+// Fills in a lazily-loaded item's thumbnail. Split out from
+// setupLazyListLoading()'s loadItem callback only because both
+// SupernoteViewerElement.ts (page thumbnails) and a future Atelier
+// layer-toggle would otherwise duplicate this same "load once, keep
+// forever" shape - unlike a page's own full-resolution image (see
+// noteRenderer.ts's fillNotePagePlaceholder()), a thumbnail is never
+// evicted once loaded: a full document's worth of these amounts to a few
+// MB total at typical thumbnail scale (see issue #154), not enough memory
+// pressure to bother evicting for, and keeping them around means
+// scrolling back to an already-visited thumbnail never has to redecode.
+export function fillSidebarThumbnail(item: SidebarListItem, imageDataUrl: string): void {
+    item.imgEl.src = imageDataUrl;
+}

--- a/src/webcomponent/SupernoteViewerElement.test.ts
+++ b/src/webcomponent/SupernoteViewerElement.test.ts
@@ -182,6 +182,119 @@ describe('<supernote-viewer>', () => {
         expect(scrollIntoViewSpy).not.toHaveBeenCalled();
     });
 
+    describe('thumbnail sidebar', () => {
+        async function createLoadedViewer() {
+            const el = createViewer();
+            document.body.appendChild(el);
+            const loaded = waitForEvent(el, 'supernote-load');
+            el.noteData = readFixture('nomad-3.26.40-blank-2p.note'); // pageWidth 1404, pageHeight 1872, 2 pages
+            await loaded;
+            return el;
+        }
+
+        it('builds one item per page, reserving the note\'s own aspect ratio, initially closed', async () => {
+            const el = await createLoadedViewer();
+
+            const toggleBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Toggle page thumbnails"]');
+            expect(toggleBtn).toBeTruthy();
+            expect(toggleBtn!.getAttribute('aria-pressed')).toBe('false');
+
+            const sidebar = el.shadowRoot!.querySelector('.thumb-sidebar');
+            expect(sidebar).toBeTruthy();
+            expect(sidebar!.classList.contains('open')).toBe(false);
+
+            const items = el.shadowRoot!.querySelectorAll('.sidebar-list-item');
+            expect(items).toHaveLength(2);
+            for (const item of Array.from(items)) {
+                expect(item.querySelector<HTMLImageElement>('.sidebar-list-thumb')?.style.aspectRatio).toBe('1404 / 1872');
+            }
+        });
+
+        it('toggle button opens and closes the sidebar', async () => {
+            const el = await createLoadedViewer();
+            const toggleBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Toggle page thumbnails"]')!;
+            const sidebar = el.shadowRoot!.querySelector('.thumb-sidebar')!;
+
+            toggleBtn.click();
+            expect(sidebar.classList.contains('open')).toBe(true);
+            expect(toggleBtn.getAttribute('aria-pressed')).toBe('true');
+
+            toggleBtn.click();
+            expect(sidebar.classList.contains('open')).toBe(false);
+            expect(toggleBtn.getAttribute('aria-pressed')).toBe('false');
+        });
+
+        it('clicking a thumbnail navigates to that page', async () => {
+            const el = await createLoadedViewer();
+            const items = el.shadowRoot!.querySelectorAll<HTMLElement>('.sidebar-list-item');
+
+            items[1].click();
+            // ensurePageImageLoaded() (triggered by goToPage()) is async.
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(el.rasterizePage).toHaveBeenCalledWith(expect.anything(), 2);
+        });
+
+        it('highlights the thumbnail for whatever page is actually scrolled into view', async () => {
+            // Mirrors the page-indicator test's own approach: happy-dom has
+            // no real layout engine, so this stubs each page's geometry
+            // directly to exercise updateCurrentPageIndicator()'s
+            // threshold-scanning logic (which now also drives thumbnail
+            // highlighting) deterministically.
+            const el = await createLoadedViewer();
+            const pagesEl = el.shadowRoot!.querySelector('.pages')!;
+            const [page1, page2] = Array.from(el.shadowRoot!.querySelectorAll('.page-container'));
+            const [thumb1, thumb2] = Array.from(el.shadowRoot!.querySelectorAll('.sidebar-list-item'));
+            vi.spyOn(pagesEl, 'getBoundingClientRect').mockReturnValue({ top: 0 } as DOMRect);
+
+            vi.spyOn(page1, 'getBoundingClientRect').mockReturnValue({ top: -5 } as DOMRect);
+            vi.spyOn(page2, 'getBoundingClientRect').mockReturnValue({ top: 895 } as DOMRect);
+            pagesEl.dispatchEvent(new Event('scroll'));
+            await new Promise((resolve) => window.requestAnimationFrame(resolve));
+            expect(thumb1.classList.contains('is-active')).toBe(true);
+            expect(thumb2.classList.contains('is-active')).toBe(false);
+
+            vi.spyOn(page1, 'getBoundingClientRect').mockReturnValue({ top: -905 } as DOMRect);
+            vi.spyOn(page2, 'getBoundingClientRect').mockReturnValue({ top: -5 } as DOMRect);
+            pagesEl.dispatchEvent(new Event('scroll'));
+            await new Promise((resolve) => window.requestAnimationFrame(resolve));
+            expect(thumb1.classList.contains('is-active')).toBe(false);
+            expect(thumb2.classList.contains('is-active')).toBe(true);
+        });
+
+        it('opening the find bar repositions the sidebar without throwing', async () => {
+            const el = await createLoadedViewer();
+            el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Toggle page thumbnails"]')!.click();
+            const findBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Find in note"]')!;
+            expect(() => findBtn.click()).not.toThrow();
+            expect(el.shadowRoot!.querySelector('.thumb-sidebar')).toBeTruthy();
+        });
+
+        it('has no toolbar/thumbnail sidebar for a single-page note', async () => {
+            const el = createViewer();
+            document.body.appendChild(el);
+            const loaded = waitForEvent(el, 'supernote-load');
+            el.noteData = readFixture('rtr.note'); // 1 page
+            await loaded;
+
+            expect(el.shadowRoot!.querySelector('button[aria-label="Toggle page thumbnails"]')).toBeNull();
+            expect(el.shadowRoot!.querySelector('.thumb-sidebar')).toBeNull();
+        });
+
+        it('has no toolbar/thumbnail sidebar in single-page (attribute) mode', async () => {
+            const el = createViewer();
+            el.setAttribute('single-page', '');
+            document.body.appendChild(el);
+            const loaded = waitForEvent(el, 'supernote-load');
+            el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+            await loaded;
+
+            expect(el.shadowRoot!.querySelector('button[aria-label="Toggle page thumbnails"]')).toBeNull();
+            expect(el.shadowRoot!.querySelector('.thumb-sidebar')).toBeNull();
+        });
+    });
+
     it('shows recognized text in text mode, unrasterized', async () => {
         const el = createViewer();
         document.body.appendChild(el);

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -13,6 +13,7 @@ import { SupernoteX } from 'supernote-typescript';
 import { ImageConverter } from '../render/imageConverter';
 import { RenderedNotePage, buildNotePagePlaceholders, fillNotePagePlaceholder, parseNote } from '../render/noteRenderer';
 import { WordOverlayEntry, buildWordOverlay, buildWordSearchText, repositionWordOverlay } from '../render/wordOverlay';
+import { SidebarListItem, buildSidebarList, fillSidebarThumbnail, setupLazyListLoading } from '../render/sidebarList';
 
 interface ViewerPageState extends RenderedNotePage {
     textEl: HTMLElement;
@@ -100,6 +101,7 @@ const STYLE = `
     --supernote-viewer-muted: #a0a0a0;
 }
 .root {
+    position: relative;
     display: flex;
     flex-direction: column;
     height: 100%;
@@ -180,6 +182,69 @@ button[aria-pressed="true"] {
     color: var(--supernote-viewer-muted);
     font-size: 0.9em;
     white-space: nowrap;
+}
+/* Overlays .pages (position: absolute against .root's own position:
+   relative above) rather than sharing a flex row with it - the same
+   lesson SupernoteView's own thumbnail sidebar already learned the hard
+   way (issue #179): if opening/closing this changed how much width .pages
+   itself got, fit-width would re-render every page's size against that,
+   reflowing the whole note and bouncing whatever page was currently in
+   view. Overlaying instead means toggling this never affects .pages'
+   own width at all. "top" is set from JS (see
+   updateThumbSidebarOffset()) to sit just below the toolbar/find-bar,
+   since neither is a fixed, CSS-only height (the find bar toggles
+   open/closed, changing the total header height beneath which this
+   should start). */
+.thumb-sidebar {
+    display: none;
+    position: absolute;
+    left: 0;
+    z-index: 2;
+    flex-direction: column;
+    width: 140px;
+    max-height: calc(100% - 1em);
+    margin: 0.5em;
+    overflow-y: auto;
+    gap: 0.6em;
+    padding: 0.5em;
+    background: var(--supernote-viewer-bg);
+    border: 1px solid var(--supernote-viewer-border);
+    border-radius: 4px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.25);
+    box-sizing: border-box;
+}
+.thumb-sidebar.open {
+    display: flex;
+}
+.sidebar-list-item {
+    cursor: pointer;
+    text-align: center;
+    padding: 0.25em;
+    border: 2px solid transparent;
+    border-radius: 4px;
+}
+.sidebar-list-item:hover {
+    background: rgba(128, 128, 128, 0.2);
+}
+.sidebar-list-item.is-active {
+    border-color: var(--supernote-viewer-fg);
+}
+.sidebar-list-thumb {
+    display: block;
+    width: 100%;
+    border-radius: 2px;
+}
+.sidebar-list-label {
+    display: block;
+    margin-top: 0.25em;
+    color: var(--supernote-viewer-muted);
+    font-size: 0.85em;
+}
+.sidebar-list-checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
+    cursor: pointer;
 }
 .pages {
     flex: 1;
@@ -330,6 +395,11 @@ export class SupernoteViewerElement extends HTMLElement {
     private pageSearchIndex: PageSearchEntry[] = [];
     private findMatches: FindMatch[] = [];
     private findMatchIndex = -1;
+    private thumbSidebarEl: HTMLElement | null = null;
+    private thumbToggleBtn: HTMLButtonElement | null = null;
+    private thumbItems: SidebarListItem[] = [];
+    private thumbLoadObserver: IntersectionObserver | null = null;
+    private thumbnailsVisible = false;
 
     constructor() {
         super();
@@ -364,6 +434,7 @@ export class SupernoteViewerElement extends HTMLElement {
     disconnectedCallback(): void {
         this.pageLoadObserver?.disconnect();
         this.resizeObserver?.disconnect();
+        this.thumbLoadObserver?.disconnect();
         for (const state of this.pageStates) window.clearTimeout(state.loadDebounceTimer);
     }
 
@@ -507,6 +578,8 @@ export class SupernoteViewerElement extends HTMLElement {
         this.pageLoadObserver = null;
         this.resizeObserver?.disconnect();
         this.resizeObserver = null;
+        this.thumbLoadObserver?.disconnect();
+        this.thumbLoadObserver = null;
         for (const state of this.pageStates) window.clearTimeout(state.loadDebounceTimer);
         this.pageStates = [];
         this.pagesEl = null;
@@ -524,6 +597,10 @@ export class SupernoteViewerElement extends HTMLElement {
         this.pageSearchIndex = [];
         this.findMatches = [];
         this.findMatchIndex = -1;
+        this.thumbSidebarEl = null;
+        this.thumbToggleBtn = null;
+        this.thumbItems = [];
+        this.thumbnailsVisible = false;
         this.rootEl.innerHTML = '';
     }
 
@@ -568,7 +645,10 @@ export class SupernoteViewerElement extends HTMLElement {
         });
 
         this.setupPageLoadObserver(sn, states);
-        if (pageCount > 1) this.setupPageIndicatorTracking();
+        if (pageCount > 1) {
+            this.setupPageIndicatorTracking();
+            this.buildThumbSidebar(sn, pageCount);
+        }
         this.setupWordOverlayResizing(sn, states);
     }
 
@@ -703,6 +783,7 @@ export class SupernoteViewerElement extends HTMLElement {
 
         this.currentPage = current;
         if (this.pageIndicatorEl) this.pageIndicatorEl.textContent = `${current + 1} / ${this.pageStates.length}`;
+        this.highlightThumbnail(current);
     }
 
     // Keeps every page's word-overlay spans (see src/render/wordOverlay.ts)
@@ -729,6 +810,89 @@ export class SupernoteViewerElement extends HTMLElement {
         for (const state of states) this.resizeObserver.observe(state.containerEl);
     }
 
+    // Downsample factor for ensureThumbnailLoaded() below - the sidebar
+    // only ever displays a thumbnail at ~140px CSS width (see
+    // .sidebar-list-thumb), so a full-resolution rasterization would be
+    // needless decode/memory cost for a preview this small. Mirrors
+    // SupernoteView's own THUMBNAIL_SCALE (main.ts) exactly.
+    private static readonly THUMBNAIL_SCALE = 4;
+
+    // Builds the (initially closed - see .thumb-sidebar/.open) page
+    // thumbnail sidebar: one item per page (via the portable
+    // src/render/sidebarList.ts, built to be reusable by a future
+    // Supernote Atelier/.spd layer-toggle view too - see that module's own
+    // header comment), each lazily rasterized once it nears the sidebar's
+    // own viewport. Only built for pageCount > 1 (see buildToolbar()) -
+    // nothing to navigate to via thumbnails on a single-page document
+    // either.
+    private buildThumbSidebar(sn: SupernoteX, pageCount: number): void {
+        const sidebar = document.createElement('div');
+        sidebar.className = 'thumb-sidebar';
+        sidebar.setAttribute('part', 'thumb-sidebar');
+        this.rootEl.appendChild(sidebar);
+        this.thumbSidebarEl = sidebar;
+
+        const specs = Array.from({ length: pageCount }, (_, i) => ({ label: String(i + 1) }));
+        this.thumbItems = buildSidebarList(sidebar, specs, {
+            thumbnailAspectRatio: { width: sn.pageWidth, height: sn.pageHeight },
+            onItemClick: (index) => this.goToPage(index + 1),
+        });
+
+        this.thumbLoadObserver = setupLazyListLoading(
+            sidebar,
+            this.thumbItems.map((item) => item.itemEl),
+            (index) => void this.ensureThumbnailLoaded(sn, index),
+        );
+
+        this.updateThumbSidebarOffset();
+    }
+
+    private toggleThumbSidebar(): void {
+        this.thumbnailsVisible = !this.thumbnailsVisible;
+        this.thumbSidebarEl?.classList.toggle('open', this.thumbnailsVisible);
+        this.thumbToggleBtn?.setAttribute('aria-pressed', String(this.thumbnailsVisible));
+        // Toggling never changes .pages' own width (the sidebar overlays
+        // it - see .thumb-sidebar's own CSS comment), so there's no
+        // fit-width re-render to trigger here, unlike zoom's own resize
+        // handling.
+        if (this.thumbnailsVisible) this.updateThumbSidebarOffset();
+    }
+
+    // The thumbnail sidebar overlays .pages (position: absolute against
+    // .root) rather than sharing a flex row with it - see its own CSS
+    // comment for why - so its `top` has to be set from here instead of a
+    // fixed CSS value: neither the toolbar nor the find bar has a fixed
+    // height (the find bar toggles open/closed, changing the total header
+    // height beneath which this should start). pagesEl's own offsetTop
+    // already reflects however much space both of those actually take up,
+    // whatever that combined height happens to be, without this needing
+    // to know about either one individually.
+    private updateThumbSidebarOffset(): void {
+        if (!this.thumbSidebarEl || !this.pagesEl) return;
+        this.thumbSidebarEl.style.top = `${this.pagesEl.offsetTop}px`;
+    }
+
+    // Idempotent - a page's thumbnail is loaded once and never evicted
+    // (see fillSidebarThumbnail()'s own comment for why) - checking the
+    // <img>'s own src rather than a separate loaded flag keeps this in
+    // sync with the DOM directly, with nothing else to fall out of sync.
+    private async ensureThumbnailLoaded(sn: SupernoteX, index: number): Promise<void> {
+        const item = this.thumbItems[index];
+        if (!item || item.imgEl.src) return;
+        try {
+            const [dataUrl] = await new ImageConverter().convertToImages(
+                sn, [index + 1], SupernoteViewerElement.THUMBNAIL_SCALE,
+            );
+            fillSidebarThumbnail(item, dataUrl);
+        } catch (err) {
+            console.error(`supernote-viewer: page ${index + 1}'s thumbnail failed to load`, err);
+        }
+    }
+
+    private highlightThumbnail(index: number): void {
+        this.thumbItems.forEach((item, i) => item.itemEl.classList.toggle('is-active', i === index));
+    }
+
     // Idempotent and safe to call speculatively - `loaded` is set eagerly so
     // a slow rasterization can't be triggered twice for the same page.
     private async ensurePageImageLoaded(sn: SupernoteX, state: ViewerPageState): Promise<void> {
@@ -752,8 +916,18 @@ export class SupernoteViewerElement extends HTMLElement {
 
         // Nothing to navigate to with only one page - the mode toggle and
         // find button below are still worth having regardless of page
-        // count, so only these three are conditioned on pageCount > 1.
+        // count, so only these four are conditioned on pageCount > 1.
         if (pageCount > 1) {
+            const thumbBtn = document.createElement('button');
+            thumbBtn.type = 'button';
+            thumbBtn.setAttribute('part', 'button');
+            thumbBtn.setAttribute('aria-label', 'Toggle page thumbnails');
+            thumbBtn.setAttribute('aria-pressed', 'false');
+            thumbBtn.textContent = '☰';
+            thumbBtn.addEventListener('click', () => this.toggleThumbSidebar());
+            toolbar.appendChild(thumbBtn);
+            this.thumbToggleBtn = thumbBtn;
+
             const prevBtn = document.createElement('button');
             prevBtn.type = 'button';
             prevBtn.setAttribute('part', 'button');
@@ -873,6 +1047,10 @@ export class SupernoteViewerElement extends HTMLElement {
         this.findToggleBtn?.setAttribute('aria-pressed', 'true');
         this.findInputEl?.focus();
         this.findInputEl?.select();
+        // The find bar adds to the total header height the thumbnail
+        // sidebar sits below - see updateThumbSidebarOffset()'s own
+        // comment for why this can't just be a fixed CSS value.
+        this.updateThumbSidebarOffset();
     }
 
     private closeFindBar(): void {
@@ -884,6 +1062,7 @@ export class SupernoteViewerElement extends HTMLElement {
         this.renderPageTextHighlights(); // clears every page's <mark>s too
         if (this.findInputEl) this.findInputEl.value = '';
         if (this.findCountEl) this.findCountEl.textContent = '';
+        this.updateThumbSidebarOffset();
     }
 
     // Rebuilds findMatches from scratch against every page's search text -


### PR DESCRIPTION
## Summary

Phase 2 of the [plan posted on issue #183](https://github.com/philips/supernote-obsidian-plugin/issues/183#issuecomment-5162408621) for porting `SupernoteView`'s features into the shared `<supernote-viewer>` web component: a page thumbnail sidebar.

**Designed for reuse beyond today's page thumbnails** (per a follow-up request while planning this): `src/render/sidebarList.ts` is a new, portable, no-Obsidian-dependency module - a generic "lazy-loaded thumbnail list" building block, not something baked directly into `SupernoteViewerElement.ts`.

- `buildSidebarList()` builds one item per entry: a thumbnail + label, or a checkbox instead of a plain click-to-select row.
- `setupLazyListLoading()` is a debounced, `IntersectionObserver`-driven load-on-approach helper, mirroring `SupernoteView`'s own `thumbObserver` (`main.ts`) exactly, including its debounce - confirmed by testing there that a fast scroll still triggered a rasterization storm without one, even once loading was already bounded to "only what's visible" (issue #154).

The checkbox option exists specifically so a future Supernote Atelier (`.spd`) layer-toggle view could build on this instead of reimplementing the same lazy-load/debounce machinery from scratch - today's `atelierView.ts` has a plain, non-lazy, non-portable checkbox list with no thumbnail preview at all (a `.spd` file only ever has a handful of layers, so it's never needed lazy loading, but a thumbnail preview per layer would be a genuine improvement it could get for free by building on this module later). Not building `.spd`/Atelier support itself in this PR - out of scope for `<supernote-viewer>` today - just leaving the door open for it.

**`SupernoteViewerElement.ts`**: a new toolbar toggle button opens a sidebar of per-page thumbnails (rasterized at a downsampled scale, mirroring `SupernoteView`'s own `THUMBNAIL_SCALE`), click-to-navigate, with the active page kept highlighted via the existing `updateCurrentPageIndicator()` scroll tracking. The sidebar overlays `.pages` (`position: absolute` against `.root`) rather than sharing a flex row with it - the same "issue #179" lesson `SupernoteView`'s own thumbnail sidebar already learned the hard way: squeezing `.pages`' width when the sidebar opens would otherwise trigger a fit-width re-render, reflowing the whole note and bouncing whatever page was in view.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint .` - 0 errors, 0 warnings
- [x] `npm test` - 151/151 passing (8 new in `sidebarList.test.ts`, 8 new in `SupernoteViewerElement.test.ts`)
- [x] `npm run build` and `npm run build:webcomponent` both succeed
- [x] Verified in a real Chromium browser (Playwright, against the built demo page, a real 10-page fixture): toggling the sidebar never changes `.pages`' own width (no reflow), thumbnails genuinely lazy-load (only what's near the sidebar's own viewport loads initially, the rest after scrolling), and clicking a thumbnail navigates to and highlights the correct page