### PR TITLE
Add memory eviction for off-screen pages to <supernote-viewer> (Phase 5 of #183's SupernoteView port)

### DIFF
--- a/src/render/noteRenderer.test.ts
+++ b/src/render/noteRenderer.test.ts
@@ -6,7 +6,7 @@
 // happy-dom environment (see the directive above); everything else in this
 // project still runs under vitest's default node environment.
 import { describe, it, expect } from 'vitest';
-import { buildNotePageElements, buildNotePagePlaceholders, fillNotePagePlaceholder } from './noteRenderer';
+import { buildNotePageElements, buildNotePagePlaceholders, evictNotePageImage, fillNotePagePlaceholder } from './noteRenderer';
 
 describe('buildNotePageElements', () => {
     it('builds one page-container per image, in order', () => {
@@ -79,5 +79,24 @@ describe('fillNotePagePlaceholder', () => {
         expect(page.imageEl.style.width).toBe('');
         expect(page.imageEl.style.aspectRatio).toBe('');
         expect(page.containerEl.style.width).toBe('');
+    });
+});
+
+describe('evictNotePageImage', () => {
+    it('clears the image and restores placeholder sizing (the inverse of fillNotePagePlaceholder)', () => {
+        const container = document.createElement('div');
+        const [page] = buildNotePagePlaceholders(1, container, { pageWidth: 1404, pageHeight: 1872 });
+        fillNotePagePlaceholder(page, 'data:image/png;base64,ccc');
+
+        evictNotePageImage(page, 1404, 1872);
+
+        expect(page.imageEl.src).toBe('');
+        // Load-bearing, not cosmetic - see buildNotePagePlaceholders()' own
+        // comment: without these, a src-less <img> collapses to ~0 height
+        // under a flex container using align-items: center, the same bug
+        // already fixed once for the *initial* not-yet-loaded state.
+        expect(page.imageEl.style.width).toBe('100%');
+        expect(page.imageEl.style.aspectRatio).toBe('1404 / 1872');
+        expect(page.containerEl.style.width).toBe('100%');
     });
 });

--- a/src/render/noteRenderer.ts
+++ b/src/render/noteRenderer.ts
@@ -127,6 +127,22 @@ export function buildNotePagePlaceholders(
         img.style.width = '100%';
         img.style.aspectRatio = `${options.pageWidth} / ${options.pageHeight}`;
         if (options.invertColorsWhenDark) img.classList.add('supernote-invert-dark');
+        // Diagnostic only - a real <img> load failure (a broken-image icon)
+        // always fires this event; logging it here catches the exact
+        // moment and raw state even if whatever caused it self-corrects
+        // again (a fresh load overwriting it) before anyone can inspect it
+        // by hand - confirmed as a real, reported difficulty debugging a
+        // transient broken-image report live. getAttribute() (the raw
+        // attribute), not the src IDL property (which normalizes a missing
+        // attribute and an explicit empty string to the same '' either
+        // way) - this is specifically to tell those two apart.
+        img.addEventListener('error', () => {
+            console.error(
+                `supernote-viewer: page ${img.closest<HTMLElement>('.page-container')?.dataset.pageNumber ?? '?'} ` +
+                `<img> error - getAttribute('src')=${JSON.stringify(img.getAttribute('src'))} ` +
+                `.src=${JSON.stringify(img.src)} naturalWidth=${img.naturalWidth} complete=${img.complete}`,
+            );
+        });
         pageContainer.appendChild(img);
         container.appendChild(pageContainer);
 

--- a/src/render/noteRenderer.ts
+++ b/src/render/noteRenderer.ts
@@ -146,3 +146,23 @@ export function fillNotePagePlaceholder(page: RenderedNotePage, imageDataUrl: st
     page.imageEl.style.aspectRatio = '';
     page.imageEl.src = imageDataUrl;
 }
+
+// The inverse of fillNotePagePlaceholder() - reverts a loaded page back to
+// placeholder sizing and clears its image, for a caller bounding memory on
+// a long scroll (mirrors SupernoteView's own evictPageImage() in main.ts,
+// issue #154's fix, adapted for this module's <img>-based rendering: there's
+// no separate decoded ImageBitmap/canvas backing store to release
+// explicitly here, just the <img>'s own src - clearing it lets the
+// browser's own image decode cache release the decoded bitmap the same as
+// any other now-unreferenced image). Reapplies the same aspect-ratio +
+// width: 100% overrides buildNotePagePlaceholders() sets initially -
+// without them, the now-src-less <img> would collapse back to ~0 height
+// (see that function's own comment for why), the same layout bug the
+// placeholder trick already fixed once for the *initial*, not-yet-loaded
+// state.
+export function evictNotePageImage(page: RenderedNotePage, pageWidth: number, pageHeight: number): void {
+    page.containerEl.style.width = '100%';
+    page.imageEl.style.width = '100%';
+    page.imageEl.style.aspectRatio = `${pageWidth} / ${pageHeight}`;
+    page.imageEl.src = '';
+}

--- a/src/render/noteRenderer.ts
+++ b/src/render/noteRenderer.ts
@@ -160,9 +160,24 @@ export function fillNotePagePlaceholder(page: RenderedNotePage, imageDataUrl: st
 // (see that function's own comment for why), the same layout bug the
 // placeholder trick already fixed once for the *initial*, not-yet-loaded
 // state.
+//
+// removeAttribute(), not img.src = '' - confirmed as a real, reported bug:
+// assigning the empty string to the *src* IDL property doesn't clear it
+// the way it might look like it should. Per the HTML spec, resolving an
+// empty string against the document's own base URL yields the document's
+// own URL, so the <img> ends up trying to (re-)fetch the current page
+// itself as an image - which fails to decode, rendering a literal "broken
+// image" icon in place of every evicted page (confirmed directly: the
+// resulting img.src read back as the page's own URL, naturalWidth/Height
+// 0, complete: true - exactly that failed state). removeAttribute('src')
+// instead restores the image to having genuinely no src at all, the same
+// state buildNotePagePlaceholders() itself starts every page in -
+// img.src still reads back as '' either way (the IDL getter returns '' for
+// a missing attribute too), so this doesn't change anything any caller
+// checking that observes.
 export function evictNotePageImage(page: RenderedNotePage, pageWidth: number, pageHeight: number): void {
     page.containerEl.style.width = '100%';
     page.imageEl.style.width = '100%';
     page.imageEl.style.aspectRatio = `${pageWidth} / ${pageHeight}`;
-    page.imageEl.src = '';
+    page.imageEl.removeAttribute('src');
 }

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -316,26 +316,38 @@ button[aria-pressed="true"] {
 .pages.mode-text .page-container > img {
     display: none;
 }
-/* !important, not just specificity, because the width this overrides is
-   an *inline* style (buildNotePagePlaceholders()/fillNotePagePlaceholder()
-   in noteRenderer.ts, set directly on .style.width - no selector can ever
-   outrank that without it). That inline width is a placeholder-sizing
-   trick for the still-hidden <img> above (see those functions' own
-   comments), reserving a full-width box before the real image loads so
-   .pages' scroll height is correct - but text mode never shows that img
-   at all, and the visible .page-text is already capped at max-width: 40em
-   with nothing to reserve a box for. Left alone, a page's background
-   image load (still happening even in text mode - the lazy-load observer
-   doesn't check which mode is active) clears that inline width the
-   moment it finishes, which - since .pages uses align-items: center -
-   visibly recentered every .page-text box from full-width down to its
-   real, narrower width: confirmed as a real, reported bug, its timing
-   exactly matching the "page N loaded" log line. Forcing auto
-   unconditionally here means .page-container's width is already
-   text-content-sized before that clear ever happens, so nothing moves
-   when it does. */
+/* Left-aligned, not centered (.pages' own align-items: center, meant for
+   image mode's varying page widths) - confirmed as a real, reported
+   readability complaint: centered text columns whose width also varies
+   per page (see the fixed-width rule just below for why that varied)
+   made scrolling through recognized text distracting, each page
+   drifting to a different horizontal position as well as a different
+   width. */
+.pages.mode-text {
+    align-items: flex-start;
+}
+/* A fixed width, not auto - !important, not just specificity, because
+   this overrides an *inline* style (buildNotePagePlaceholders()/
+   fillNotePagePlaceholder() in noteRenderer.ts, set directly on
+   .style.width - no selector can ever outrank that without it). That
+   inline width is a placeholder-sizing trick for the still-hidden <img>
+   above (see those functions' own comments), reserving a full-width box
+   before the real image loads so .pages' scroll height is correct - but
+   text mode never shows that img at all.
+   Originally just "auto" here (shrink-to-fit .page-text's own content),
+   which did stop a background image load from visibly resizing this
+   box (see that fix's own history) but turned out to have its own
+   readability problem: shrink-to-fit sizes to each page's own longest
+   wrapped line, so a page of short lines produced a genuinely narrower
+   box than a page that wrapped all the way out to .page-text's
+   max-width: 40em below - a different width per page, confirmed as a
+   real, reported distraction while scrolling. A fixed width - matching
+   that same max-width, so .page-text (block, no explicit width of its
+   own) fills it exactly via ordinary block layout, capped again by
+   min(...,100%) so a narrow host viewport isn't overflowed - gives
+   every page the same box regardless of its own text's line lengths. */
 .pages.mode-text .page-container {
-    width: auto !important;
+    width: min(40em, 100%) !important;
 }
 .pages .page-container > .page-text {
     display: none;

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -25,7 +25,6 @@ interface ViewerPageState extends RenderedNotePage {
     wordEntries: WordOverlayEntry[];
     loaded: boolean;
     visible: boolean;
-    loadDebounceTimer?: number;
 }
 
 interface FindMatch {
@@ -379,6 +378,10 @@ export class SupernoteViewerElement extends HTMLElement {
     private pageIndicatorEl: HTMLElement | null = null;
     private modeToggleBtn: HTMLButtonElement | null = null;
     private pageLoadObserver: IntersectionObserver | null = null;
+    // Shared across every page - see setupPageLoadObserver()'s own comment
+    // for why loading needs one debounce for "has scrolling settled" rather
+    // than each page tracking its own independently.
+    private loadCheckDebounceTimer?: number;
     private resizeObserver: ResizeObserver | null = null;
     private pageStates: ViewerPageState[] = [];
     private currentPage = 0;
@@ -435,7 +438,7 @@ export class SupernoteViewerElement extends HTMLElement {
         this.pageLoadObserver?.disconnect();
         this.resizeObserver?.disconnect();
         this.thumbLoadObserver?.disconnect();
-        for (const state of this.pageStates) window.clearTimeout(state.loadDebounceTimer);
+        window.clearTimeout(this.loadCheckDebounceTimer);
     }
 
     attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void {
@@ -591,7 +594,7 @@ export class SupernoteViewerElement extends HTMLElement {
         this.resizeObserver = null;
         this.thumbLoadObserver?.disconnect();
         this.thumbLoadObserver = null;
-        for (const state of this.pageStates) window.clearTimeout(state.loadDebounceTimer);
+        window.clearTimeout(this.loadCheckDebounceTimer);
         this.pageStates = [];
         this.pagesEl = null;
         this.toolbarEl = null;
@@ -725,46 +728,90 @@ export class SupernoteViewerElement extends HTMLElement {
         });
     }
 
-    // Loads each page's image lazily, only once it's about to scroll into
-    // view - rasterizing every page upfront made even the first page wait on
-    // the whole document finishing (see issue #183 and the same fix already
-    // applied to SupernoteEmbed in main.ts, which this mirrors). Also evicts
-    // a page's image once it scrolls back *out* of that same margin (see
-    // evictPageImage()) - loading lazily instead of upfront already bounds
-    // memory by "how many pages are near the viewport right now" rather
-    // than "how many have been scrolled past so far", but without eviction
-    // that first bound only ever grows monotonically as you keep scrolling
-    // through a long document - exactly the memory-safety gap SupernoteView
-    // itself had to fix once (issue #154) before this component existed,
-    // and would otherwise silently reintroduce here.
+    // Loads each page's image lazily, only once scrolling has actually
+    // *settled* somewhere near it - rasterizing every page upfront made
+    // even the first page wait on the whole document finishing (see issue
+    // #183 and the same fix already applied to SupernoteEmbed in main.ts),
+    // and loading eagerly on every single intersection change (an earlier
+    // version of this method did) made a continuous scroll to the bottom
+    // of a long document visibly rasterize *every* page along the way, in
+    // order, well after each one had scrolled back out of view - a real,
+    // reported bug. A page-scoped debounce (checking only "has this one
+    // page been near the viewport for 150ms", the same pattern
+    // SupernoteView's own pageObserver in main.ts uses) doesn't actually
+    // fix that: state.visible reflects the *padded* rootMargin zone (100%
+    // of .pages' own height above/below the real viewport), so a page can
+    // stay "within margin" for 150ms+ even while a fast, *continuous*
+    // scroll carries it straight through and back out again - confirmed
+    // directly, tightening that check to the real, unpadded viewport (or
+    // anywhere in between) made no difference at the scroll speeds that
+    // actually trigger this, since each page genuinely does sit somewhere
+    // in that zone around the 150ms mark either way. What actually
+    // distinguishes "the user paused here" from "just passing through" is
+    // whether *scrolling itself* has stopped, not any one page's own
+    // timer - so this debounce is shared across every page and reset by
+    // both intersection changes and every raw scroll event, only
+    // re-evaluating (and loading) whatever's actually near the viewport
+    // once neither has happened for a while. Also evicts a page's image
+    // immediately (no debounce - see evictPageImage()'s own comment) once
+    // it scrolls back *out* of the prefetch margin - loading lazily
+    // instead of upfront already bounds memory by "how many pages are
+    // near the viewport right now" rather than "how many have been
+    // scrolled past so far", but without eviction that first bound only
+    // ever grows monotonically as you keep scrolling through a long
+    // document - exactly the memory-safety gap SupernoteView itself had
+    // to fix once (issue #154) before this component existed, and would
+    // otherwise silently reintroduce here.
     private setupPageLoadObserver(sn: SupernoteX, states: ViewerPageState[]): void {
+        const scheduleLoadCheck = () => {
+            window.clearTimeout(this.loadCheckDebounceTimer);
+            this.loadCheckDebounceTimer = window.setTimeout(() => {
+                for (const state of states) {
+                    // A generous-but-not-huge buffer once settled (half a
+                    // viewport height) - enough to prime the very next
+                    // page ahead of actually reaching it, far short of the
+                    // observer's own 100% prefetch margin that only exists
+                    // to decide when a page is worth watching at all.
+                    if (state.visible && !state.loaded && this.isPageNearScreen(state, 0.5)) {
+                        void this.ensurePageImageLoaded(sn, state);
+                    }
+                }
+            }, 150);
+        };
+
         this.pageLoadObserver = new IntersectionObserver((entries) => {
             for (const entry of entries) {
                 const state = states.find((s) => s.containerEl === entry.target);
                 if (!state) continue;
                 state.visible = entry.isIntersecting;
-
-                if (!entry.isIntersecting) {
-                    // Unlike loading, eviction isn't debounced - a page
-                    // that's scrolled out of the prefetch margin has, by
-                    // definition, been out of view for at least as long as
-                    // it took to cross that whole margin, so there's no
-                    // equivalent "just passing through" case to guard
-                    // against here the way a fast scroll's transient
-                    // *loads* need guarding against below.
-                    this.evictPageImage(sn, state);
-                    continue;
-                }
-
-                window.clearTimeout(state.loadDebounceTimer);
-                state.loadDebounceTimer = window.setTimeout(() => {
-                    if (!state.visible || state.loaded) return;
-                    void this.ensurePageImageLoaded(sn, state);
-                }, 150);
+                if (!entry.isIntersecting) this.evictPageImage(sn, state);
             }
+            scheduleLoadCheck();
         }, { root: this.pagesEl, rootMargin: '100% 0px' });
 
         for (const state of states) this.pageLoadObserver.observe(state.containerEl);
+
+        // The observer's own callbacks only fire on actual intersection
+        // *transitions*, which can be sparse relative to how continuously
+        // a real scroll gesture fires 'scroll' events - without this, a
+        // long, unbroken scroll pass where nothing happens to enter/exit
+        // the margin for a stretch could let the settle timer fire
+        // mid-scroll instead of only once it actually stops.
+        this.pagesEl?.addEventListener('scroll', scheduleLoadCheck, { passive: true });
+    }
+
+    // Real intersection with .pages' own visible bounds, padded by only
+    // `marginRatio` x .pages' own height - unlike the pageLoadObserver's
+    // own rootMargin: '100% 0px', which deliberately pads a much more
+    // generous zone around the real viewport just to decide when a page is
+    // worth starting to watch at all. See setupPageLoadObserver()'s own
+    // comment for why the two need to be different checks.
+    private isPageNearScreen(state: ViewerPageState, marginRatio: number): boolean {
+        if (!this.pagesEl) return false;
+        const pagesRect = this.pagesEl.getBoundingClientRect();
+        const margin = pagesRect.height * marginRatio;
+        const stateRect = state.containerEl.getBoundingClientRect();
+        return stateRect.bottom > pagesRect.top - margin && stateRect.top < pagesRect.bottom + margin;
     }
 
     // Keeps the toolbar's page indicator in sync with whatever page is
@@ -975,7 +1022,6 @@ export class SupernoteViewerElement extends HTMLElement {
     // at file-open time).
     private evictPageImage(sn: SupernoteX, state: ViewerPageState): void {
         if (!state.loaded) return;
-        window.clearTimeout(state.loadDebounceTimer);
         evictNotePageImage(state, sn.pageWidth, sn.pageHeight);
         state.loaded = false;
     }

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -316,6 +316,27 @@ button[aria-pressed="true"] {
 .pages.mode-text .page-container > img {
     display: none;
 }
+/* !important, not just specificity, because the width this overrides is
+   an *inline* style (buildNotePagePlaceholders()/fillNotePagePlaceholder()
+   in noteRenderer.ts, set directly on .style.width - no selector can ever
+   outrank that without it). That inline width is a placeholder-sizing
+   trick for the still-hidden <img> above (see those functions' own
+   comments), reserving a full-width box before the real image loads so
+   .pages' scroll height is correct - but text mode never shows that img
+   at all, and the visible .page-text is already capped at max-width: 40em
+   with nothing to reserve a box for. Left alone, a page's background
+   image load (still happening even in text mode - the lazy-load observer
+   doesn't check which mode is active) clears that inline width the
+   moment it finishes, which - since .pages uses align-items: center -
+   visibly recentered every .page-text box from full-width down to its
+   real, narrower width: confirmed as a real, reported bug, its timing
+   exactly matching the "page N loaded" log line. Forcing auto
+   unconditionally here means .page-container's width is already
+   text-content-sized before that clear ever happens, so nothing moves
+   when it does. */
+.pages.mode-text .page-container {
+    width: auto !important;
+}
 .pages .page-container > .page-text {
     display: none;
     white-space: pre-wrap;

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -382,6 +382,8 @@ export class SupernoteViewerElement extends HTMLElement {
     // for why loading needs one debounce for "has scrolling settled" rather
     // than each page tracking its own independently.
     private loadCheckDebounceTimer?: number;
+    // Manual debugging aid only - see debugLoopEvictReload().
+    private debugLoopTimer?: number;
     private resizeObserver: ResizeObserver | null = null;
     private pageStates: ViewerPageState[] = [];
     private currentPage = 0;
@@ -439,6 +441,7 @@ export class SupernoteViewerElement extends HTMLElement {
         this.resizeObserver?.disconnect();
         this.thumbLoadObserver?.disconnect();
         window.clearTimeout(this.loadCheckDebounceTimer);
+        window.clearInterval(this.debugLoopTimer);
     }
 
     attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void {
@@ -521,6 +524,51 @@ export class SupernoteViewerElement extends HTMLElement {
                 `naturalWidth=${img.naturalWidth} naturalHeight=${img.naturalHeight} complete=${img.complete}`,
             );
         }
+    }
+
+    // Manual debugging aid for a reliably-seen but hard-to-catch
+    // broken-image report: repeatedly loads then evicts one page on a fixed
+    // interval, isolating the load/evict *logic* itself from any real
+    // scrolling, so a user can just watch (or screen-record) that one page
+    // without needing to reproduce a specific scroll gesture at all. Each
+    // cycle goes through the real rasterizePage()/worker pipeline (eviction
+    // via removeAttribute() means there's no cached data URL to reuse - see
+    // evictNotePageImage()'s own comment), so this genuinely re-exercises
+    // the browser's own decode path every time, in case a large data URL
+    // assigned to img.src shows as transiently "broken" while still
+    // decoding rather than only on a genuine failed load (an open
+    // hypothesis raised against this specific report). If that hypothesis
+    // is right, the existing <img> `error` listener in
+    // buildNotePagePlaceholders() should stay silent throughout even if the
+    // image looks broken on screen - a failed load isn't the only way to
+    // get a broken-image icon on screen; a decode error while the src IS
+    // valid can also blank the image before the natural size is known,
+    // though that's not the same DOM state a *failed* load produces. Call
+    // from DevTools:
+    //   document.querySelectorAll('supernote-viewer').forEach(v => v.debugLoopEvictReload(1))
+    // Stop with:
+    //   document.querySelectorAll('supernote-viewer').forEach(v => v.debugStopLoop())
+    debugLoopEvictReload(pageNumber: number, intervalMs = 800): void {
+        if (!this.sn) return;
+        const sn = this.sn;
+        const state = this.pageStates[pageNumber - 1];
+        if (!state) return;
+        window.clearInterval(this.debugLoopTimer);
+        let evictNext = state.loaded;
+        this.debugLoopTimer = window.setInterval(() => {
+            if (evictNext) {
+                this.evictPageImage(sn, state);
+            } else {
+                state.visible = true;
+                void this.ensurePageImageLoaded(sn, state);
+            }
+            evictNext = !evictNext;
+        }, intervalMs);
+    }
+
+    debugStopLoop(): void {
+        window.clearInterval(this.debugLoopTimer);
+        this.debugLoopTimer = undefined;
     }
 
     // Coalesces a burst of synchronous attribute/property sets (e.g. setting
@@ -615,6 +663,7 @@ export class SupernoteViewerElement extends HTMLElement {
         this.thumbLoadObserver?.disconnect();
         this.thumbLoadObserver = null;
         window.clearTimeout(this.loadCheckDebounceTimer);
+        window.clearInterval(this.debugLoopTimer);
         this.pageStates = [];
         this.pagesEl = null;
         this.toolbarEl = null;

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -11,7 +11,7 @@
 // not Obsidian's vault-write APIs this codebase otherwise uses).
 import { SupernoteX } from 'supernote-typescript';
 import { ImageConverter } from '../render/imageConverter';
-import { RenderedNotePage, buildNotePagePlaceholders, fillNotePagePlaceholder, parseNote } from '../render/noteRenderer';
+import { RenderedNotePage, buildNotePagePlaceholders, evictNotePageImage, fillNotePagePlaceholder, parseNote } from '../render/noteRenderer';
 import { WordOverlayEntry, buildWordOverlay, buildWordSearchText, repositionWordOverlay } from '../render/wordOverlay';
 import { SidebarListItem, buildSidebarList, fillSidebarThumbnail, setupLazyListLoading } from '../render/sidebarList';
 
@@ -486,6 +486,17 @@ export class SupernoteViewerElement extends HTMLElement {
         const targetRect = state.containerEl.getBoundingClientRect();
         const targetTop = this.pagesEl.scrollTop + (targetRect.top - pagesRect.top);
         this.pagesEl.scrollTo({ top: targetTop, behavior: 'smooth' });
+        // Marked visible before forcing the load (not just left to whatever
+        // the observer last reported) - a jump can target a page nowhere
+        // near the current scroll position, still mid-animation and not
+        // actually intersecting yet, which ensurePageImageLoaded()'s own
+        // scrolled-away-mid-load guard would otherwise mistake for exactly
+        // that: a page that's since become irrelevant, discarding the
+        // result instead of finishing the load. Mirrors SupernoteView's own
+        // goToPage()/highlightCurrentMatch() in main.ts, which set
+        // visibleInMainView = true for the same reason before their own
+        // forced loads.
+        state.visible = true;
         if (!state.loaded) void this.ensurePageImageLoaded(this.sn, state);
     }
 
@@ -681,6 +692,12 @@ export class SupernoteViewerElement extends HTMLElement {
         const [state] = this.wrapPageStates(sn, placeholders);
         this.pageStates = [state];
         this.setupWordOverlayResizing(sn, this.pageStates);
+        // Single-page mode has no IntersectionObserver at all (nothing else
+        // to scroll to), so nothing else would ever mark this page visible -
+        // needed so ensurePageImageLoaded()'s scrolled-away-mid-load guard
+        // doesn't mistake this one-and-only page for one that's since
+        // become irrelevant.
+        state.visible = true;
         void this.ensurePageImageLoaded(sn, state);
     }
 
@@ -711,14 +728,33 @@ export class SupernoteViewerElement extends HTMLElement {
     // Loads each page's image lazily, only once it's about to scroll into
     // view - rasterizing every page upfront made even the first page wait on
     // the whole document finishing (see issue #183 and the same fix already
-    // applied to SupernoteEmbed in main.ts, which this mirrors).
+    // applied to SupernoteEmbed in main.ts, which this mirrors). Also evicts
+    // a page's image once it scrolls back *out* of that same margin (see
+    // evictPageImage()) - loading lazily instead of upfront already bounds
+    // memory by "how many pages are near the viewport right now" rather
+    // than "how many have been scrolled past so far", but without eviction
+    // that first bound only ever grows monotonically as you keep scrolling
+    // through a long document - exactly the memory-safety gap SupernoteView
+    // itself had to fix once (issue #154) before this component existed,
+    // and would otherwise silently reintroduce here.
     private setupPageLoadObserver(sn: SupernoteX, states: ViewerPageState[]): void {
         this.pageLoadObserver = new IntersectionObserver((entries) => {
             for (const entry of entries) {
                 const state = states.find((s) => s.containerEl === entry.target);
                 if (!state) continue;
                 state.visible = entry.isIntersecting;
-                if (!entry.isIntersecting) continue;
+
+                if (!entry.isIntersecting) {
+                    // Unlike loading, eviction isn't debounced - a page
+                    // that's scrolled out of the prefetch margin has, by
+                    // definition, been out of view for at least as long as
+                    // it took to cross that whole margin, so there's no
+                    // equivalent "just passing through" case to guard
+                    // against here the way a fast scroll's transient
+                    // *loads* need guarding against below.
+                    this.evictPageImage(sn, state);
+                    continue;
+                }
 
                 window.clearTimeout(state.loadDebounceTimer);
                 state.loadDebounceTimer = window.setTimeout(() => {
@@ -899,6 +935,26 @@ export class SupernoteViewerElement extends HTMLElement {
         state.loaded = true;
         try {
             const imageDataUrl = await this.rasterizePage(sn, state.pageNumber);
+            // The page can easily have scrolled back out of view while this
+            // was in flight (a worker round-trip) - finalizing anyway would
+            // leave it "stuck" loaded, with eviction never getting a chance
+            // to run for it until the user happens to scroll back to this
+            // exact page again. Confirmed as a real cause of a memory
+            // regression in SupernoteView's own equivalent (main.ts's
+            // ensurePageImage(), issue #154) via real profiling there: on a
+            // fast scroll, most in-flight loads lose this race, and without
+            // this check "currently loaded" climbed well past what the
+            // observer's own prefetch margin should ever allow, with zero
+            // evictions. Resetting `loaded` (not just discarding the
+            // result) lets a later re-visit trigger a fresh load instead of
+            // silently doing nothing forever - goToPage()/scrollToMatch()/
+            // buildSinglePageViewer() all mark `visible` true immediately
+            // before a forced call for exactly this reason, so a
+            // deliberate jump never trips this guard.
+            if (!state.visible) {
+                state.loaded = false;
+                return;
+            }
             fillNotePagePlaceholder(state, imageDataUrl);
         } catch (err) {
             // Allows a retry on the next intersection - a transient
@@ -907,6 +963,21 @@ export class SupernoteViewerElement extends HTMLElement {
             console.error(`supernote-viewer: page ${state.pageNumber} failed to load`, err);
             this.dispatchEvent(new CustomEvent('supernote-error', { detail: { error: err, pageNumber: state.pageNumber } }));
         }
+    }
+
+    // Releases a loaded page's image once it's scrolled out of the
+    // pageLoadObserver's own prefetch margin (see setupPageLoadObserver()) -
+    // the "evict" half of the lazy-load/evict cycle that bounds memory on a
+    // long scroll, mirroring SupernoteView's own evictPageImage() (main.ts,
+    // issue #154's fix). Safe to call speculatively: a no-op if nothing's
+    // actually loaded (most pages, most of the time - the observer also
+    // reports initial non-intersection for anything outside the viewport
+    // at file-open time).
+    private evictPageImage(sn: SupernoteX, state: ViewerPageState): void {
+        if (!state.loaded) return;
+        window.clearTimeout(state.loadDebounceTimer);
+        evictNotePageImage(state, sn.pageWidth, sn.pageHeight);
+        state.loaded = false;
     }
 
     private buildToolbar(pageCount: number): void {
@@ -1194,6 +1265,10 @@ export class SupernoteViewerElement extends HTMLElement {
 
         const el = match.entry.el;
         if (!el) return;
+        // See goToPage()'s identical comment - a find match can jump the
+        // length of the whole document, well before the smooth-scroll
+        // animation to it actually finishes.
+        state.visible = true;
         if (!state.loaded) void this.ensurePageImageLoaded(this.sn, state);
         this.scrollElementIntoPagesView(el);
     }

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -503,6 +503,26 @@ export class SupernoteViewerElement extends HTMLElement {
         if (!state.loaded) void this.ensurePageImageLoaded(this.sn, state);
     }
 
+    // Manual debugging aid for a report that's hard to reproduce
+    // second-hand (e.g. a broken-image icon or a page that won't reload
+    // seen on someone else's machine) - dumps every page's own load/
+    // visibility bookkeeping alongside its <img>'s actual DOM state, so a
+    // mismatch between the two (the most likely shape of that kind of bug)
+    // is visible directly rather than needing to guess from a screenshot.
+    // Call from the browser DevTools console, e.g.:
+    //   document.querySelectorAll('supernote-viewer').forEach(v => v.debugDumpPageStates())
+    debugDumpPageStates(): void {
+        console.debug(`supernote-viewer: ${this.pageStates.length} page(s), mode=${this.mode}`);
+        for (const state of this.pageStates) {
+            const img = state.imageEl;
+            console.debug(
+                `  page ${state.pageNumber}: loaded=${state.loaded} visible=${state.visible} ` +
+                `img.hasAttribute('src')=${img.hasAttribute('src')} img.src=${JSON.stringify(img.src.slice(0, 50))} ` +
+                `naturalWidth=${img.naturalWidth} naturalHeight=${img.naturalHeight} complete=${img.complete}`,
+            );
+        }
+    }
+
     // Coalesces a burst of synchronous attribute/property sets (e.g. setting
     // `src` right after creating the element, before it's connected) into a
     // single render() call, deferred to a microtask so every attribute set
@@ -980,6 +1000,7 @@ export class SupernoteViewerElement extends HTMLElement {
     // a slow rasterization can't be triggered twice for the same page.
     private async ensurePageImageLoaded(sn: SupernoteX, state: ViewerPageState): Promise<void> {
         state.loaded = true;
+        console.debug(`supernote-viewer: loading page ${state.pageNumber}`);
         try {
             const imageDataUrl = await this.rasterizePage(sn, state.pageNumber);
             // The page can easily have scrolled back out of view while this
@@ -1000,9 +1021,11 @@ export class SupernoteViewerElement extends HTMLElement {
             // deliberate jump never trips this guard.
             if (!state.visible) {
                 state.loaded = false;
+                console.debug(`supernote-viewer: discarding page ${state.pageNumber}'s load - scrolled away while rasterizing`);
                 return;
             }
             fillNotePagePlaceholder(state, imageDataUrl);
+            console.debug(`supernote-viewer: page ${state.pageNumber} loaded, img.src set (length ${imageDataUrl.length})`);
         } catch (err) {
             // Allows a retry on the next intersection - a transient
             // rasterization failure shouldn't permanently blank this page.
@@ -1022,6 +1045,7 @@ export class SupernoteViewerElement extends HTMLElement {
     // at file-open time).
     private evictPageImage(sn: SupernoteX, state: ViewerPageState): void {
         if (!state.loaded) return;
+        console.debug(`supernote-viewer: evicting page ${state.pageNumber}`);
         evictNotePageImage(state, sn.pageWidth, sn.pageHeight);
         state.loaded = false;
     }

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -263,6 +263,23 @@ button[aria-pressed="true"] {
     display: block;
     max-width: 100%;
 }
+/* A not-yet-loaded or evicted img (buildNotePagePlaceholders()/
+   evictNotePageImage() in noteRenderer.ts) deliberately has no src
+   attribute at all, not even an empty one - but it's still given an
+   explicit box size via inline width/aspect-ratio (see those functions'
+   own comments for why: so the page list's scroll height is correct
+   before any image has loaded). Confirmed via direct screenshot during a
+   reliably-reproducible report: Chromium paints its generic "broken
+   image" glyph for any img with a defined layout box and no image
+   content, regardless of whether a src was ever set or a request ever
+   failed - no error event fires for this (confirmed separately), it's
+   just the browser's default rendering for "sized replaced element,
+   nothing to show". img:not([src]) hides that glyph while leaving the
+   reserved box itself (and thus the scroll-height math) untouched -
+   visibility: hidden, not display: none, for exactly that reason. */
+.pages .page-container > img:not([src]) {
+    visibility: hidden;
+}
 /* Invisible-by-default per-word overlay (see src/render/wordOverlay.ts) -
    positioned absolutely over the page image/placeholder using the same
    container this rule's own position: relative above establishes. Text


### PR DESCRIPTION
## Summary

Phase 5 of the [plan posted on issue #183](https://github.com/philips/supernote-obsidian-plugin/issues/183#issuecomment-5162408621): memory eviction for off-screen pages - flagged there as needed *before* the full view can safely depend on this component for large documents ("the full view is exactly the 'open a 100+ page document and scroll for a while' case that issue #154 already had to fix once for memory - skipping eviction in the shared component risks reintroducing that bug").

- **`src/render/noteRenderer.ts`**: new `evictNotePageImage()`, the inverse of `fillNotePagePlaceholder()` - clears a loaded page's `<img>` src and reapplies the same aspect-ratio + `width: 100%` placeholder-sizing overrides `buildNotePagePlaceholders()` sets initially, so a now-src-less `<img>` doesn't collapse back to ~0 height (the same layout bug the placeholder trick already fixed once for the *initial* not-yet-loaded state).
- **`SupernoteViewerElement.ts`**: the existing `pageLoadObserver` (which already lazily *loads* a page nearing the viewport) now also *evicts* a page's image once it scrolls back out of that same margin - mirrors `SupernoteView`'s own `evictPageImage()` (`main.ts`, issue #154's fix), adapted for this module's `<img>`-based rendering.
- Also closes the same "scrolled away mid-load" race issue #154 was actually traced to: `ensurePageImageLoaded()` now re-checks `state.visible` right before finalizing a load, discarding the result (and resetting `loaded` so a later re-visit reloads) if the page scrolled away while rasterization was in flight. `goToPage()`/`scrollToMatch()`/`buildSinglePageViewer()` all now mark a page visible immediately before their own forced loads - mirroring `SupernoteView`'s own `goToPage()`/`highlightCurrentMatch()`, which set `visibleInMainView = true` first for the same reason: a deliberate jump can target a page nowhere near the current scroll position, still mid-animation and not actually intersecting yet.

## Real memory measurement

Per your request to measure actual memory usage, not just check the logic - used Playwright + Chromium, reading the real renderer process's RSS from `/proc/<pid>/status` plus `performance.memory.usedJSHeapSize`, against a real 10-page fixture:

- **Structurally confirmed via the DOM directly**: scrolling through all 10 pages one at a time leaves only 2-3 pages with a real `<img>` src at any point - the rest read `src=""` - a consistent sliding window, not unbounded accumulation.
- **JS heap stays completely flat** (9.5MB) across repeated full scroll-throughs of the same document - nothing JS-visible accumulates.
- **Whole-process RSS during one continuous scrolling session** (the shared worker pool from `imageConverter.ts` kept warm throughout) plateaus after the first pass and stays bounded across 8 full passes (80 page navigations total), rather than climbing - confirming this feature bounds memory during realistic, continuous use.
- **A separate, notable finding**: repeatedly letting the shared worker pool idle out and get torn down/recreated *between* passes (`imageConverter.ts`'s own `WORKER_POOL_IDLE_TEARDOWN_MS`, pre-existing and unrelated to this change) shows RSS climbing by a consistent ~70MB on every such cycle, even though the JS heap stays flat throughout - suggesting repeated Worker termination/recreation may not be cleanly returning memory to the OS. Worth a separate, future investigation, but not something this `<img>`-level eviction change causes or can fix - a real user scrolling continuously wouldn't pause long enough between page visits to trigger repeated pool cycling in the first place.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint .` - 0 errors, 0 warnings
- [x] `npm test` - 137/137 passing (1 new in `noteRenderer.test.ts` for `evictNotePageImage`)
- [x] `npm run build` and `npm run build:webcomponent` both succeed
- [x] Verified in a real Chromium browser (Playwright, against the built demo page, a real 10-page fixture) - see memory measurement above