### PR TITLE
Swap SupernoteView to wrap <supernote-viewer> (phase 6 of #183's port)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -546,6 +546,20 @@ export class SupernoteView extends FileView {
 		// Documented pattern (obsidian.d.ts View.scope) for registering hotkeys
 		// that are only active while this view has focus.
 		this.scope = new Scope(this.app.scope);
+		// Mirrors SupernoteEmbed's own identical registration/reasoning (see
+		// its constructor) - without this, <supernote-viewer>'s own light/
+		// dark default (the OS-level prefers-color-scheme media feature) is
+		// the only thing driving it, completely independent of Obsidian's
+		// own theme setting - confirmed as a real, reported bug: the full
+		// view stayed permanently dark (or light) regardless of Obsidian's
+		// theme, tracking only the OS's own scheme instead. registerEvent()
+		// is auto-cleaned-up by Component (View extends Component), so this
+		// needs no matching onClose() teardown.
+		this.registerEvent(this.app.workspace.on('css-change', () => this.updateDarkAttribute()));
+	}
+
+	private updateDarkAttribute(): void {
+		this.viewerEl?.setAttribute('dark', document.body.classList.contains('theme-dark') ? 'true' : 'false');
 	}
 
 	getViewType() {
@@ -669,6 +683,7 @@ export class SupernoteView extends FileView {
 			viewer.setAttribute('invert-dark', '');
 		}
 		this.viewerEl = viewer;
+		this.updateDarkAttribute();
 
 		viewer.addEventListener('supernote-load', ((e: CustomEvent<{ pageIds: string[] }>) => {
 			this.pageIds = e.detail.pageIds;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { installAtPolyfill } from './polyfills';
-import { App, Modal, Notice, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, Component, loadPdfJs, Scope, SearchComponent, setIcon, Platform } from 'obsidian';
+import { App, Modal, Notice, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, Component, Scope, Platform } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS, ImportFormat } from './settings';
-import { SupernoteX, ILink, RecognitionStatuses, fetchMirrorFrame, createPdfContext, addTextOnlyPdfPage, extractPdfPageData } from 'supernote-typescript';
+import { SupernoteX, ILink, RecognitionStatuses, fetchMirrorFrame, extractPdfPageData } from 'supernote-typescript';
 import { encode } from 'image-js';
 import { DownloadListModal, UploadListModal } from './FileListModal';
 import { ImportTodayModal } from './ImportTodayModal';
@@ -17,7 +17,6 @@ import type { SupernoteViewerElement } from './webcomponent/SupernoteViewerEleme
 import { replaceTextWithCustomDictionary } from './customDictionary';
 import { runDeviceSync, appendSyncLogEntry } from './syncEngine';
 import { formatSyncFailureLogEntry } from './deviceSync';
-import { parseLinkRect, bucketLinksByPage } from './render/linkOverlay';
 import { SupernoteAtelierEmbed, SupernoteAtelierView, VIEW_TYPE_SUPERNOTE_ATELIER, renderAtelierCompositeDataUrl, renderAtelierCompositeFromBuffer } from './atelierView';
 import { PDFDocument } from 'pdf-lib';
 
@@ -70,24 +69,6 @@ function generateMarkdownImageEmbed(app: App, file: TFile, sourcePath: string, a
 // returns a buffer sized to exactly this array's bytes.
 function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
     return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
-}
-
-// Hands a turn back to the browser between pages of pdf-lib assembly (see
-// assembleTextOnlyPdf() below) - pdf-lib's own embedPng()/save() etc. are
-// `async` in name, but the actual PNG decode/font-glyph-placement/
-// serialization work they do is synchronous CPU work with no real await
-// inside it, so a tight loop over 100+ pages never naturally yields to the
-// event loop and reads as the whole app locking up (no repaint, no input
-// handled) for as long as the loop runs. Confirmed on a real 100-page note's
-// PDF export (back when this ran on the main thread too - see
-// buildPdfInWorker() for why that moved into a Worker instead) that this
-// hung the main thread for ~30s. setTimeout(0) rather than
-// requestAnimationFrame so this still yields promptly even if the window
-// isn't currently focused/visible (rAF is throttled/suspended in the
-// background, and there's no reason this should stall just because the
-// user switched away while it ran).
-function yieldToMainThread(): Promise<void> {
-    return new Promise((resolve) => window.setTimeout(resolve, 0));
 }
 
 // Rasterizes and assembles the *entire* PDF for `sn` inside a dedicated
@@ -151,32 +132,6 @@ async function buildSinglePagePdf(pngDataUrl: string): Promise<Uint8Array> {
     const pdfPage = pdfDoc.addPage([widthPts, heightPts]);
     pdfPage.drawImage(pngImage, { x: 0, y: 0, width: widthPts, height: heightPts });
     return pdfDoc.save();
-}
-
-// Builds a PDF with only the invisible recognized-text layer, no page images
-// at all — for SupernoteView's internal pdfDocPromise, which exists purely
-// so pdf.js's getTextContent()/getViewport() can build a search/select text
-// layer over pages that are actually displayed via direct canvas rendering
-// (drawPageImage()); pdf.js's own render() is never called against it. A
-// real page image there would be pure dead weight: embedding one only for
-// pdf-lib to decode, recompress, and serialize turned out to be genuinely
-// expensive (multiple seconds for a many-page or high-resolution note) for
-// bytes nothing ever looks at. Don't use this for anything the user actually
-// opens/exports as a PDF — see buildPdfInWorker() for that.
-async function assembleTextOnlyPdf(sn: SupernoteX): Promise<Uint8Array> {
-    const ctx = await createPdfContext();
-    for (let i = 0; i < sn.pages.length; i++) {
-        // Per-page, not just before/after the whole loop: if this ever hangs
-        // or crashes partway through (see issue #147 - a hard crash with no
-        // catchable JS error, so the only trace of it is whatever was last
-        // logged), the last page number logged narrows it down to one page's
-        // recognition data rather than "somewhere in this note".
-        console.debug(`Supernote: text-only PDF — page ${i + 1}/${sn.pages.length}`);
-        await addTextOnlyPdfPage(ctx, sn.pages[i], sn.pageWidth, sn.pageHeight);
-        await yieldToMainThread();
-    }
-    console.debug(`Supernote: text-only PDF — saving (${sn.pages.length} page(s))`);
-    return ctx.pdfDoc.save();
 }
 
 /**
@@ -571,149 +526,6 @@ class VaultWriter {
 	}
 }
 
-// Obsidian's loadPdfJs() returns `any` since it hands back whatever pdf.js
-// build happens to be bundled with the user's Obsidian install, unpinned.
-// These types cover just the subset of that API this file touches, so calls
-// against it are type-checked without assuming a specific pdfjs-dist version
-// that may not match what's actually loaded at runtime.
-type PdfJsViewport = unknown; // opaque here — only ever handed back to pdf.js's own APIs
-
-interface PdfJsTextContentItem {
-	str?: string;
-}
-
-interface PdfJsTextContent {
-	items: PdfJsTextContentItem[];
-}
-
-interface PdfJsPage {
-	getViewport(params: { scale: number }): PdfJsViewport;
-	getTextContent(): Promise<PdfJsTextContent>;
-}
-
-interface PdfJsDocument {
-	getPage(pageNumber: number): Promise<PdfJsPage>;
-	// Releases this document's resources in pdf.js's own internal Worker -
-	// see onLoadFile()'s call to this before replacing pdfDocPromise with a
-	// new file's document. Without it, pdf.js's worker keeps every
-	// previously-opened note's parsed PDF resident for as long as the
-	// Supernote view itself stays open, accumulating across every note
-	// switch in a session (confirmed via a real Task Manager reading on
-	// issue #154: pdf.worker.min.mjs alone was 82.4MB).
-	destroy(): Promise<void>;
-}
-
-interface PdfJsTextLayer {
-	render(): Promise<void>;
-}
-
-interface PdfJsRenderTextLayerTask {
-	promise: Promise<void>;
-}
-
-interface PdfJsLib {
-	getDocument(params: { data: Uint8Array }): { promise: Promise<PdfJsDocument> };
-	TextLayer?: new (params: { textContentSource: PdfJsTextContent; container: HTMLElement; viewport: PdfJsViewport }) => PdfJsTextLayer;
-	renderTextLayer?: (params: { textContentSource: PdfJsTextContent; container: HTMLElement; viewport: PdfJsViewport }) => PdfJsRenderTextLayerTask;
-}
-
-// Renders a pdf.js text layer into `container`, preferring the modern
-// `TextLayer` class (pdf.js >=3.4) and falling back to the older
-// `renderTextLayer()` function on earlier bundles. Obsidian's `loadPdfJs()`
-// only promises the core pdfjsLib, not a pinned version, so neither API is
-// guaranteed — if neither exists, pages still render, they just lose
-// selectable text and find-in-note for that session.
-async function renderTextLayer(pdfjsLib: PdfJsLib, textContent: PdfJsTextContent, container: HTMLElement, viewport: PdfJsViewport): Promise<boolean> {
-	container.empty();
-
-	if (typeof pdfjsLib.TextLayer === 'function') {
-		const textLayer = new pdfjsLib.TextLayer({ textContentSource: textContent, container, viewport });
-		await textLayer.render();
-		return true;
-	}
-
-	if (typeof pdfjsLib.renderTextLayer === 'function') {
-		const task = pdfjsLib.renderTextLayer({ textContentSource: textContent, container, viewport });
-		await task.promise;
-		return true;
-	}
-
-	return false;
-}
-
-type PageRenderState = {
-	pageNumber: number;
-	// Fetched lazily — see SupernoteView.ensureTextLayer(). null until then.
-	pdfPage: PdfJsPage | null;
-	nativeWidth: number;
-	nativeHeight: number;
-	pageContainer: HTMLElement;
-	canvasWrap: HTMLElement;
-	canvas: HTMLCanvasElement;
-	textLayerDiv: HTMLElement;
-	linksLayerDiv: HTMLElement;
-	// Compact/reflowed text mode's own display element - see
-	// ensureCompactText(). Independent of textLayerDiv above, which stays
-	// word-positioned (used for search-highlighting over the page image
-	// regardless of layerMode) rather than reflowed.
-	compactTextDiv: HTMLElement;
-	// Guards ensureCompactText()'s one-time (per page) work, same pattern as
-	// textLayerLoaded below.
-	compactTextLoaded: boolean;
-	// Rendered once at page-build time, in native (unscaled) page-pixel
-	// coordinates; repositioned to the current CSS pixel size on every
-	// drawPageImage() call (initial render + each zoom redraw) — see
-	// positionLinkOverlay().
-	linkEls: { el: HTMLElement; rect: [number, number, number, number] }[];
-	// Decoded once from the already-rasterized page image and reused for
-	// every zoom redraw (see drawPageImage()) — no pdf.js/decode work on the
-	// zoom-critical path. null until ensurePageImage() loads it, and again
-	// after evictPageImage() frees it. Full page resolution - see
-	// thumbnailDataUrl below for the separate, cheap thumbnail-only path.
-	imageBitmap: ImageBitmap | null;
-	// This page's full-resolution rasterized PNG data URL, once
-	// ensurePageImage() loads it — needed for the "Save image to vault"
-	// button. null again after evictPageImage().
-	imageDataUrl: string | null;
-	// In-flight/completed load, so a page nearing the viewport (pageObserver),
-	// an explicit jump (goToPage), and "Save image to vault" can't each kick
-	// off their own separate rasterization of the same page. Reset to null
-	// by evictPageImage() so a later reload isn't mistaken for one already
-	// in flight/done.
-	imageLoadPromise: Promise<void> | null;
-	// This page's thumbnail, entirely independent of imageBitmap/imageDataUrl
-	// above: rasterized at THUMBNAIL_SCALE (a fraction of full page
-	// resolution, see ensureThumbnail()) rather than reusing the full-size
-	// image, since most of the time a visible thumbnail's page isn't also
-	// open in the main view. null until ensureThumbnail() loads it. Unlike
-	// the full-resolution image, this is never evicted once loaded - see
-	// ensureThumbnail()'s own comment for why that's cheap enough to be fine.
-	thumbnailDataUrl: string | null;
-	thumbnailLoadPromise: Promise<void> | null;
-	// Whether this page is currently within pageObserver's margin (main
-	// view), or its thumbnail item is within thumbObserver's margin
-	// (sidebar) - drives ensurePageImage()/evictPageImage() for the former,
-	// and just ensureThumbnail()'s load trigger for the latter (no thumbnail
-	// eviction - see that method).
-	visibleInMainView: boolean;
-	visibleInThumbnail: boolean;
-	// Debounces thumbObserver's load trigger (not eviction) - see its doc
-	// comment in buildThumbSidebar().
-	thumbLoadDebounceTimer: number | undefined;
-	// Same idea, but for pageObserver's main-view load trigger - see its doc
-	// comment in onOpen().
-	pageLoadDebounceTimer: number | undefined;
-	// Guards ensureTextLayer()'s one-time (per page) work.
-	textLayerLoaded: boolean;
-	text: string;
-	spans: HTMLSpanElement[];
-};
-
-type FindMatch = {
-	pageIndex: number;
-	spanIndex: number;
-};
-
 let vw: VaultWriter;
 export const VIEW_TYPE_SUPERNOTE = "supernote-view";
 
@@ -721,74 +533,12 @@ export class SupernoteView extends FileView {
 	declare file: TFile;
 	settings: SupernotePluginSettings;
 
-	private pdfjsLib: PdfJsLib | null = null;
-	private pageStates: PageRenderState[] = [];
-	private pagesEl: HTMLElement | null = null;
-	// This file's own pages' PAGEIDs, 0-indexed to match pageStates — lets a
-	// same-file link's PAGEID resolve to a page number without retaining the
-	// whole parsed SupernoteX. See handleLinkClick().
+	private viewerEl: SupernoteViewerElement | null = null;
+	// This file's own pages' PAGEIDs, from the component's own supernote-load
+	// event - lets handleNoteLinkClick() resolve a link naming this same file
+	// explicitly without re-parsing bytes already parsed once inside the
+	// component. Same field, same reason, as SupernoteEmbed's own copy below.
 	private pageIds: string[] = [];
-	// Retained (rather than a local in onLoadFile) so ensurePageImage() can
-	// rasterize a single page on demand, well after onLoadFile() itself has
-	// returned — see issue #147.
-	private sn: SupernoteX | null = null;
-
-	private zoomScale = 1;
-	private renderedZoomScale = 1;
-	private zoomDebounceTimer: number | undefined;
-	private zoomLabelEl: HTMLElement | null = null;
-	// True from the moment setZoom() schedules a debounced commitZoom() until
-	// that commit actually redraws pages at their final size. goToPage() waits
-	// this out — see waitForZoomToSettle() for why.
-	private zoomCommitPending = false;
-	private zoomSettleResolvers: Array<() => void> = [];
-
-	private fitWidthEnabled = true;
-	private fitWidthBtn: HTMLElement | null = null;
-	private fitWidthDebounceTimer: number | undefined;
-	private resizeObserver: ResizeObserver | null = null;
-
-	// The combined PDF (image + invisible RTR text per page) is assembled
-	// and loaded into pdf.js in the background, not awaited before the first
-	// paint — pages are visible immediately from their own rasterized image
-	// (see drawPageImage()), which doesn't depend on this at all. Only the
-	// text layer (selection/search) needs it, and only when a given page is
-	// actually loaded — see ensureTextLayer()/pageObserver.
-	private pdfDocPromise: Promise<PdfJsDocument> | null = null;
-	private pageObserver: IntersectionObserver | null = null;
-	// Scoped to the thumbnail sidebar's own scroll container, not contentEl -
-	// re-created per file load in buildThumbSidebar() (thumbSidebarEl itself
-	// is a fresh element each load, and root can't be changed after an
-	// IntersectionObserver is constructed). Drives ensureThumbnail(),
-	// entirely independent of pageObserver/ensurePageImage()/
-	// evictPageImage() above - see PageRenderState.thumbnailDataUrl for why
-	// the two don't share a load/evict cycle.
-	private thumbObserver: IntersectionObserver | null = null;
-
-	private layerMode: 'image' | 'text' = 'image';
-	private imageModeBtn: HTMLElement | null = null;
-	private textModeBtn: HTMLElement | null = null;
-
-	private thumbnailsVisible = false;
-	private thumbToggleBtn: HTMLElement | null = null;
-	private thumbSidebarEl: HTMLElement | null = null;
-	private thumbItems: HTMLElement[] = [];
-	// Parallel to thumbItems/pageStates — empty (no `src`) until
-	// ensurePageImage() loads that page, or until the sidebar is first
-	// opened (see toggleThumbnails()), whichever happens first.
-	private thumbImgs: HTMLImageElement[] = [];
-
-	private headerEl: HTMLElement | null = null;
-	private pageJumpInput: HTMLInputElement | null = null;
-	private scrollUpdateScheduled = false;
-
-	private findToggleBtn: HTMLElement | null = null;
-	private findBarEl: HTMLElement | null = null;
-	private findInput: SearchComponent | null = null;
-	private findMatchCountEl: HTMLElement | null = null;
-	private findMatches: FindMatch[] = [];
-	private findMatchCursor = -1;
-	private findRequestId = 0;
 
 	constructor(leaf: WorkspaceLeaf, settings: SupernotePluginSettings) {
 		super(leaf);
@@ -811,13 +561,15 @@ export class SupernoteView extends FileView {
 
 	// Obsidian delivers a link's `#page=N` subpath here — for both
 	// `[[file.note#page=8]]` and `[text](file.note#page=8)` — once setState()
-	// (which awaits onLoadFile(), so pageStates is already populated) has
-	// resolved. Mirrors the anchor SupernoteEmbed accepts for embeds; see
-	// parsePageAnchor().
+	// (which awaits onLoadFile()) has resolved. onLoadFile() itself now
+	// awaits the component's own supernote-load/-error before returning (see
+	// its own comment for why), so by the time this runs, viewerEl's page
+	// list is already built and goToPage() won't silently no-op. Mirrors the
+	// anchor SupernoteEmbed accepts for embeds; see parsePageAnchor().
 	setEphemeralState(state: unknown): void {
 		const subpath = (state as { subpath?: string } | undefined)?.subpath;
 		const page = parsePageAnchor(subpath);
-		if (page !== null) void this.goToPage(page);
+		if (page !== null) this.viewerEl?.goToPage(page);
 	}
 
 	async onOpen(): Promise<void> {
@@ -827,201 +579,42 @@ export class SupernoteView extends FileView {
 		this.contentEl.addClass('supernote-view-content');
 
 		// Obsidian's .view-content has its own top padding, leaving a gap
-		// above the sticky toolbar. A previous attempt cancelled it with a
-		// negative margin on the (sticky) header itself, which fought with
-		// `position: sticky`'s own positioning math and let page content
-		// render through/above the stuck toolbar instead. Zeroing the
-		// ancestor's padding directly avoids combining sticky with a negative
-		// margin at all; .supernote-header's own (positive, sticky-safe)
-		// padding-top puts a little breathing room back.
-		//
-		// On mobile (issue #148 - reported on an iPhone 13 mini, but likely
-		// any small screen), that same ancestor padding on the left/right/
+		// above <supernote-viewer>'s own sticky toolbar - a negative margin
+		// on the toolbar itself would fight position: sticky's positioning
+		// math, so this zeroes the ancestor's padding directly instead. On
+		// mobile (issue #148), that same ancestor padding on the left/right/
 		// bottom sides is real, wasted width on a screen already tight for
-		// legibility of handwritten content - left alone on desktop, where a
-		// window is normally wide enough that it isn't a meaningful loss.
-		// div.page-container's own margin gets the equivalent reduction in
-		// styles.css, scoped to body.is-mobile the same way.
+		// legibility of handwritten content.
 		this.contentEl.setCssStyles(
 			Platform.isMobile
 				? { paddingTop: '0', paddingLeft: '0.25em', paddingRight: '0.25em', paddingBottom: '0.25em' }
 				: { paddingTop: '0' },
 		);
 
+		// Mod+F opens/focuses <supernote-viewer>'s own find bar. Scope is an
+		// Obsidian-only concept the component has no way to register a
+		// view-scoped hotkey through itself, so the wrapper still owns this
+		// one registration even though everything the hotkey actually does
+		// (the find bar itself, stepping matches, highlighting) now lives
+		// entirely in the component.
 		this.scope?.register(['Mod'], 'f', (evt) => {
 			evt.preventDefault();
-			this.toggleFindBar();
+			this.viewerEl?.toggleFindBar();
 			return false;
 		});
-
-		// Ctrl+scroll to zoom (trackpad pinch-to-zoom is reported as a wheel
-		// event with ctrlKey set, on every platform); plain scroll keeps paging
-		// through the note as before. contentEl persists across file loads
-		// (onLoadFile only rebuilds its children), so this only needs
-		// registering once.
-		//
-		// Deliberately NOT metaKey (Cmd on macOS): Cmd is also the modifier
-		// held down through a whole Cmd+Tab app switch, and a wheel event from
-		// scroll momentum/inertia that happens to fire mid-switch — nothing to
-		// do with zooming — would still carry metaKey:true and get treated as
-		// a zoom gesture. Trackpad pinch never sets metaKey, only ctrlKey, so
-		// dropping metaKey here loses nothing for the gesture this is actually
-		// meant to support.
-		this.registerDomEvent(this.contentEl, 'wheel', (evt: WheelEvent) => {
-			if (!evt.ctrlKey) return;
-			evt.preventDefault();
-
-			// Trackpads report a pinch-to-zoom gesture as a wheel event with
-			// ctrlKey set — the same flag an ordinary two-finger scroll can
-			// spuriously carry for a stray event or two right as the scroll
-			// hits a boundary (e.g. scrolling up to the very top). A fixed
-			// per-event zoom step let a short burst of those misfires snowball
-			// straight to the zoom cap. Scaling the step by the event's own
-			// deltaY keeps a real, sustained pinch feeling responsive while
-			// capping how much a single misfired event can do.
-			const factor = Math.min(1.05, Math.max(0.95, 1 - evt.deltaY * 0.01));
-			this.setZoom(this.zoomScale * factor);
-		}, { passive: false });
-
-		// Keep the toolbar's page number in sync with whatever page is actually
-		// scrolled into view, rAF-throttled since scroll fires very frequently.
-		this.registerDomEvent(this.contentEl, 'scroll', () => {
-			if (this.scrollUpdateScheduled) return;
-			this.scrollUpdateScheduled = true;
-			window.requestAnimationFrame(() => {
-				this.scrollUpdateScheduled = false;
-				this.updateCurrentPageIndicator();
-			});
-		}, { passive: true });
-
-		// While "Fit width" is on, keep the page matched to however much room
-		// is actually available as the pane resizes (split panes, sidebars
-		// opening/closing, window resize) — not just at the moment it was
-		// turned on. Debounced since resize fires continuously while dragging.
-		this.resizeObserver = new ResizeObserver(() => {
-			if (!this.fitWidthEnabled) return;
-			window.clearTimeout(this.fitWidthDebounceTimer);
-			this.fitWidthDebounceTimer = window.setTimeout(() => this.applyFitWidth(), 150);
-		});
-		this.resizeObserver.observe(this.contentEl);
-
-		// Loads each page's image and selectable text lazily, only once it's
-		// about to scroll into view (rootMargin prefetches a screen ahead/
-		// behind so it feels instant by the time you actually get there) —
-		// for a long note, rasterizing/decoding/drawing every page's image
-		// (and building N pages' worth of text-layer DOM) upfront is real,
-		// mostly wasted work if you only ever look at the first few pages,
-		// and scales memory with page count regardless (see issue #147).
-		// Also evicts a page's image once it scrolls back *out* of that same
-		// margin (see evictPageImage()) - loading lazily instead of upfront
-		// bounds memory by "how many pages are near the viewport right now"
-		// rather than "how many have been scrolled past so far", which for a
-		// long enough document (100 pages, see issue #154) still grows
-		// without bound as you keep scrolling even though each individual
-		// page loads lazily. Text layers are left alone for eviction - much
-		// lighter (a string + some span elements, not a decoded bitmap/
-		// canvas backing store) and losing search state/highlights on
-		// scroll-past would be a worse trade for a small saving.
-		//
-		// Loading (not eviction) is debounced ~150ms, the same fix and for
-		// the same reason as thumbObserver's own debounce (see
-		// buildThumbSidebar()): a long-distance `scrollIntoView({behavior:
-		// 'smooth'})` jump - e.g. stepFind()'s search-result navigation,
-		// which can jump the full length of a 100+ page document - animates
-		// through every intermediate page in a fixed, short duration
-		// regardless of distance, so each one transitions into and back out
-		// of this 100%-margin window within a matter of milliseconds. Without
-		// debouncing, every one of those pages triggered its own full
-		// decode/evict round trip, queued behind each other on the (small,
-		// deliberately-sized-down - see WorkerPool.DEFAULT_MAX_WORKERS)
-		// shared worker pool - confirmed by testing: jumping from page 4 to
-		// page 102 via search visibly rasterized dozens of pages nobody ever
-		// actually saw, taking many seconds before the actual destination
-		// page finally loaded. A deliberate single-page jump (goToPage() -
-		// the page-jump box, thumbnail clicks, `#page=N` links) primes its
-		// destination directly instead of going through this debounce at
-		// all, so it isn't slowed down by it; stepFind() does the same (see
-		// highlightCurrentMatch()) for the same reason.
-		//
-		// Independent of thumbObserver (see buildThumbSidebar()) - each page
-		// now has its own separate full-resolution (this) and thumbnail
-		// (that one) load/evict cycle, rather than sharing one, since a
-		// thumbnail no longer costs anywhere near what the full main-view
-		// image does (see ensureThumbnail()).
-		// Re-observes fresh page containers each file load; see onLoadFile().
-		this.pageObserver = new IntersectionObserver((entries) => {
-			for (const entry of entries) {
-				const state = this.pageStates.find((s) => s.pageContainer === entry.target);
-				if (!state) continue;
-				state.visibleInMainView = entry.isIntersecting;
-				window.clearTimeout(state.pageLoadDebounceTimer);
-				if (entry.isIntersecting) {
-					state.pageLoadDebounceTimer = window.setTimeout(() => {
-						// Re-checks rather than assuming still true - the
-						// timer firing doesn't mean nothing happened since
-						// it was scheduled.
-						if (!state.visibleInMainView) return;
-						void this.ensurePageImage(state);
-						void this.ensureTextLayer(state);
-						this.ensureCompactText(state);
-					}, 150);
-				} else {
-					this.evictPageImage(state);
-				}
-			}
-		}, { root: this.contentEl, rootMargin: '100% 0px' });
 	}
 
 	async onLoadFile(file: TFile): Promise<void> {
 		const container = this.contentEl;
 		container.empty();
-
-		// Releases the *previous* file's pdf.js document, if any, in pdf.js's
-		// own internal Worker - see PdfJsDocument.destroy()'s comment for why
-		// this matters (confirmed via a real Task Manager reading on issue
-		// #154: pdf.worker.min.mjs alone was 82.4MB, apparently never
-		// released across note switches). Fire-and-forget: doesn't block
-		// this file's own loading on the previous one's teardown, and the
-		// previous promise may still be in-flight (a fast note switch) -
-		// .then() waits for whatever state it's actually in first. Silently
-		// swallows a rejection - a note that failed to build a PDF in the
-		// first place has nothing to destroy, and either way there's
-		// nothing useful to do about it here.
-		this.pdfDocPromise?.then((doc) => doc.destroy()).catch(() => { /* nothing to clean up */ });
-
-		window.clearTimeout(this.zoomDebounceTimer);
-		this.pageObserver?.disconnect();
-		this.thumbObserver?.disconnect();
-		// Disconnecting the observer stops new callbacks, but doesn't cancel
-		// timers already scheduled by earlier ones - without this, one could
-		// still fire after the file switch and redundantly load a page from
-		// a note the user has already navigated away from.
-		for (const state of this.pageStates) {
-			window.clearTimeout(state.thumbLoadDebounceTimer);
-			window.clearTimeout(state.pageLoadDebounceTimer);
-		}
-		this.pageStates = [];
-		this.zoomScale = 1;
-		this.renderedZoomScale = 1;
-		this.findMatches = [];
-		this.findMatchCursor = -1;
-		// Invalidates any in-flight runFind() from a file the user just
-		// navigated away from, so it can't resolve later and touch this one's
-		// (unrelated) pageStates.
-		this.findRequestId++;
-
-		const note = await this.app.vault.readBinary(file);
-		const sn = new SupernoteX(new Uint8Array(note));
-		this.sn = sn;
-		this.pageIds = sn.pages.map((p) => p.PAGEID ?? '');
-		const linksByPage = bucketLinksByPage(sn.links);
+		this.viewerEl = null;
+		this.pageIds = [];
 
 		if (this.settings.showExportButtons) {
 			const exportNoteBtn = container.createEl("p").createEl("button", {
 				text: "Attach Markdown to vault",
 				cls: "mod-cta",
 			});
-
 			exportNoteBtn.addEventListener("click", () => {
 				void vw.attachMarkdownFile(file);
 			});
@@ -1030,7 +623,6 @@ export class SupernoteView extends FileView {
 				text: "Attach Markdown and images to vault",
 				cls: "mod-cta",
 			});
-
 			exportAllBtn.addEventListener("click", () => {
 				void vw.attachNoteFiles(file);
 			});
@@ -1039,824 +631,99 @@ export class SupernoteView extends FileView {
 				text: "Attach as PDF",
 				cls: "mod-cta",
 			});
-
 			exportPDFBtn.addEventListener("click", () => {
 				void vw.exportToPDF(file);
 			});
 		}
 
-		// Sticky header so the toolbar (and find bar, when open) stay visible
-		// while scrolling through a long note instead of scrolling away with it.
-		this.headerEl = container.createDiv({ cls: 'supernote-header' });
-		this.buildToolbar(this.headerEl, sn.pages.length);
-		this.buildFindBar(this.headerEl);
-		this.updateThumbSidebarOffset();
-
-		const body = container.createDiv({ cls: 'supernote-body' });
-		// Issue #179: still a sibling of pagesEl inside body, but see CSS -
-		// they now share a single CSS Grid cell (stacked, not side-by-side in
-		// a flex row) so the sidebar overlays pagesEl instead of squeezing it.
-		this.buildThumbSidebar(body, sn.pages.length, sn.pageWidth, sn.pageHeight);
-
-		this.pagesEl = body.createDiv({ cls: 'supernote-pages' });
-		this.pagesEl.toggleClass('supernote-mode-text', this.layerMode === 'text');
-
-		// Page containers/canvases are built for every page up front (cheap —
-		// just DOM elements, sized from sn.pageWidth/pageHeight, which are
-		// already known without rasterizing anything), but each page's actual
-		// image is loaded lazily by ensurePageImage() — see pageObserver in
-		// onOpen(). Rasterizing, decoding, and drawing every page immediately
-		// (the previous behavior) scaled memory with page count regardless of
-		// how much of the note was ever actually looked at — see issue #147.
-		const renderStart = performance.now();
-
-		for (let i = 0; i < sn.pages.length; i++) {
-			const pageContainer = this.pagesEl.createDiv({
-				cls: 'page-container',
-			})
-
-			const canvasWrap = pageContainer.createDiv({ cls: 'supernote-canvas-wrap' });
-			const canvas = canvasWrap.createEl("canvas");
-			if (this.settings.invertColorsWhenDark) {
-				canvas.addClass("supernote-invert-dark");
-			}
-			// Text mode's own page number marker - in image mode, which page
-			// is which is obvious from the image itself (and the toolbar's
-			// page-jump box); in text mode, a long note is just a scrolling
-			// column of paragraphs with nothing else distinguishing one
-			// page's text from the next (issue #171's own follow-up report).
-			// Known immediately (just this loop's index), so unlike
-			// compactTextDiv's own content below, this needs no lazy
-			// population - it's created and filled in up front for every
-			// page, same as the thumbnail sidebar's own per-page labels.
-			pageContainer.createDiv({ cls: 'supernote-compact-text-label', text: `Page ${i + 1}` });
-			// Sibling of canvasWrap, not a child - unlike textLayerDiv (which
-			// mirrors canvasWrap's exact page-pixel dimensions to sit on top of
-			// it), this needs its own independent size: a reflowed column of
-			// text has no reason to match the page's aspect ratio. See
-			// ensureCompactText(). Text mode hides the whole of canvasWrap
-			// (see styles.css), linksLayerDiv included - internal note links
-			// have no clickable overlay here, only in image mode; there's no
-			// natural position to anchor one to once the text is reflowed.
-			const compactTextDiv = pageContainer.createDiv({ cls: 'supernote-compact-text' });
-
-			const state: PageRenderState = {
-				pageNumber: i + 1,
-				pdfPage: null,
-				nativeWidth: sn.pageWidth,
-				nativeHeight: sn.pageHeight,
-				pageContainer,
-				canvasWrap,
-				canvas,
-				textLayerDiv: canvasWrap.createDiv({ cls: 'textLayer' }),
-				linksLayerDiv: canvasWrap.createDiv({ cls: 'supernote-links-layer' }),
-				compactTextDiv,
-				compactTextLoaded: false,
-				linkEls: [],
-				imageBitmap: null,
-				imageDataUrl: null,
-				imageLoadPromise: null,
-				thumbnailDataUrl: null,
-				thumbnailLoadPromise: null,
-				visibleInMainView: false,
-				visibleInThumbnail: false,
-				thumbLoadDebounceTimer: undefined,
-				pageLoadDebounceTimer: undefined,
-				textLayerLoaded: false,
-				text: '',
-				spans: [],
-			};
-			this.pageStates.push(state);
-
-			// Deliberately NOT draggable. A previous version wired up manual
-			// drag-out (canvas doesn't get it natively the way <img> does) by
-			// putting the page's raw data: URL straight into the drag data —
-			// dropping that into a note inserts the *entire* base64-encoded
-			// PNG as literal text (there's no vault file to link to; nothing
-			// was ever saved), which for a real page-resolution image is
-			// enough text to lock up the editor. "Save image to vault" below
-			// is the safe equivalent: it creates a real attachment file and
-			// only does so on an explicit click, not on every page anyone
-			// happens to view. A correct drag-out would need the same
-			// save-to-vault to finish *before* the drop, and dataTransfer can
-			// only be populated synchronously inside dragstart — not
-			// attempted here for that reason. See #152.
-
-			for (const link of linksByPage.get(i) ?? []) {
-				const rect = parseLinkRect(link.LINKRECT);
-				if (!rect) continue;
-				const el = state.linksLayerDiv.createEl('a', {
-					cls: 'supernote-link-rect',
-					attr: { href: '#', title: link.text },
-				});
-				el.addEventListener('click', (evt) => {
-					evt.preventDefault();
-					void this.handleLinkClick(link);
-				});
-				state.linkEls.push({ el, rect });
-			}
-
-			// No image yet (imageBitmap is null) — this only sizes the canvas
-			// and its overlays correctly from nativeWidth/nativeHeight, same as
-			// every subsequent zoom redraw. ensurePageImage() calls this again
-			// once the page's actual image is loaded.
-			this.drawPageImage(state, this.zoomScale);
-
-			this.pageObserver?.observe(pageContainer);
-
-			// Create a button to save image to vault
-			if (this.settings.showExportButtons) {
-				const saveButton = pageContainer.createEl("button", {
-					text: "Save image to vault",
-					cls: "mod-cta",
-				});
-
-				saveButton.addEventListener("click", () => void (async () => {
-					// Force the load rather than assuming pageObserver already
-					// triggered it — a save click is always possible before a
-					// page's ever scrolled into view (e.g. a very tall page,
-					// or a fast click right after load).
-					await this.ensurePageImage(state);
-					if (!state.imageDataUrl) return;
-					const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}-${i + 1}.png`);
-					const buffer = dataUrlToBuffer(state.imageDataUrl);
-					await this.app.vault.createBinary(filename, buffer);
-				})());
-			}
-		}
-
-		console.debug(`Supernote: page render — DOM build ${(performance.now() - renderStart).toFixed(1)}ms for ${sn.pages.length} page(s) (images load lazily as pages scroll into view)`);
-
-		if (this.fitWidthEnabled) {
-			this.applyFitWidth();
-		}
-		this.updateCurrentPageIndicator();
-
-		// Kicked off now — after pages are already visible from their own
-		// rasterized images (drawPageImage() above, no pdf.js involved at
-		// all) — rather than before rendering them, so this fire-and-forget
-		// pipeline (still real work on this same single JS thread) can't
-		// compete with/inflate the apparent cost of the page-render loop.
-		// Only the text layer (selection/search) needs this, lazily, per
-		// page — see ensureTextLayer() — so delaying it only delays search
-		// readiness, not anything visible. Uses assembleTextOnlyPdf() (no
-		// page images at all — see its doc comment) rather than
-		// buildPdfInWorker(), since this PDF is only ever handed to
-		// pdf.js for getTextContent()/getViewport(), never rendered/shown.
-		this.pdfDocPromise = (async () => {
-			// Logged stage-by-stage (see issue #147): a hard native crash
-			// here has no catchable JS error to report — ensureTextLayer()'s
-			// own try/catch only fires for an ordinary thrown exception, and
-			// wouldn't run at all if nothing ever scrolled a page into view.
-			// The last of these lines to print is the closest thing to a
-			// stack trace such a crash leaves behind.
-			console.debug('Supernote: search text layer — building text-only PDF…');
-			const pdfBytes = await assembleTextOnlyPdf(sn);
-			console.debug(`Supernote: search text layer — text-only PDF built (${pdfBytes.byteLength} bytes), loading pdf.js…`);
-			this.pdfjsLib = await loadPdfJs() as PdfJsLib;
-			console.debug('Supernote: search text layer — pdf.js loaded, parsing PDF…');
-			const pdfDoc = await this.pdfjsLib.getDocument({ data: pdfBytes }).promise;
-			console.debug('Supernote: search text layer — ready');
-			return pdfDoc;
-		})();
-	}
-
-	// Best-effort memory estimate for logPageMemoryTrace() below - not used
-	// for any actual decision, just to give a sense of scale when
-	// investigating a suspected memory issue (see issue #154). Accounts for
-	// both the decoded ImageBitmap (native page resolution) and the canvas
-	// backing store, which is typically larger - up to 9x the bitmap's pixel
-	// count at capped 3x devicePixelRatio (see drawPageImage()) - since both
-	// are held in memory per loaded page. thumbnailDataUrl's own (much
-	// smaller) memory isn't included here - see ensureThumbnail()'s own
-	// tracing below instead.
-	private estimatedPageMemoryBytes(state: PageRenderState): number {
-		if (!state.imageBitmap) return 0;
-		const bitmapBytes = state.imageBitmap.width * state.imageBitmap.height * 4;
-		const canvasBytes = state.canvas.width * state.canvas.height * 4;
-		return bitmapBytes + canvasBytes;
-	}
-
-	// Traces every full-resolution load/evict with a running total across
-	// every currently-loaded page - added to make a suspected leak (issue
-	// #154: scrolling through all 100 pages of a long document still
-	// eventually crashes, even after #155/#156/#158/#159/#162's fixes)
-	// directly observable. Watch whether "currently loaded" keeps climbing
-	// over a long scroll (something isn't actually being freed) or stays
-	// roughly bounded (eviction is working and the cause is something else
-	// entirely - see #166's fix for what that turned out to be: the whole
-	// note being cloned to a Worker on every lazy load, not a JS-visible
-	// leak at all). Easiest to correlate on desktop, where DevTools' own
-	// Memory tab (or, given #166's finding, a Worker-specific heap
-	// snapshot) can be cross-checked against these numbers directly.
-	private logPageMemoryTrace(action: 'loaded' | 'evicted', pageNumber: number, pageBytes: number): void {
-		const loadedStates = this.pageStates.filter((s) => s.imageBitmap !== null);
-		const totalBytes = loadedStates.reduce((sum, s) => sum + this.estimatedPageMemoryBytes(s), 0);
-		const mb = (bytes: number) => (bytes / 1_048_576).toFixed(1);
-		console.debug(
-			`Supernote: page ${pageNumber} ${action} (~${mb(pageBytes)}MB) — ` +
-			`${loadedStates.length} page(s) currently loaded, ~${mb(totalBytes)}MB estimated total`,
-		);
-	}
-
-	// Loads this page's own full-resolution rasterized image if it hasn't
-	// been already — triggered by pageObserver as a page nears the
-	// viewport, or forced immediately by page-jump/save-image so those
-	// don't have to wait on scroll+observer timing. Idempotent (safe to
-	// call speculatively) and de-duplicated against a concurrent call via
-	// imageLoadPromise, the same pattern ensureTextLayer() uses for its own
-	// one-time work. Entirely independent of ensureThumbnail() below - see
-	// PageRenderState.thumbnailDataUrl for why they no longer share a load.
-	private ensurePageImage(state: PageRenderState): Promise<void> {
-		if (state.imageBitmap) return Promise.resolve();
-		if (state.imageLoadPromise) return state.imageLoadPromise;
-
-		state.imageLoadPromise = (async () => {
-			try {
-				if (!this.sn) return;
-				const [imageDataUrl] = await new ImageConverter().convertToImages(this.sn, [state.pageNumber]);
-				// The page can easily have scrolled back out of view while
-				// this was in flight (a worker round-trip, ~100-300ms) - on a
-				// fast scroll through a long document, most in-flight loads
-				// lose this race. Finalizing anyway would leave this page
-				// "stuck" loaded forever: eviction only re-triggers on the
-				// *next* intersection transition (see pageObserver in
-				// onOpen()), which won't happen again until the user
-				// scrolls back to this exact page. Confirmed as the actual
-				// cause of issue #154's runaway growth during a fast scroll
-				// via real profiling: "currently loaded" climbed past 30
-				// pages with zero evictions, well beyond pageObserver's
-				// rootMargin window. Resetting imageLoadPromise (not just
-				// bailing out) lets a later re-visit trigger a fresh load
-				// instead of reusing this now-settled, empty-result promise.
-				if (!state.visibleInMainView) {
-					state.imageLoadPromise = null;
-					return;
-				}
-				state.imageDataUrl = imageDataUrl;
-				const blob = new Blob([dataUrlToBuffer(imageDataUrl)], { type: 'image/png' });
-				const bitmap = await createImageBitmap(blob);
-				// Re-checked again here - createImageBitmap() is itself
-				// async, another window for the same race to happen in.
-				if (!state.visibleInMainView) {
-					bitmap.close();
-					state.imageDataUrl = null;
-					state.imageLoadPromise = null;
-					return;
-				}
-				state.imageBitmap = bitmap;
-				this.drawPageImage(state, this.zoomScale);
-				this.logPageMemoryTrace('loaded', state.pageNumber, this.estimatedPageMemoryBytes(state));
-			} catch (err) {
-				console.error(`Supernote: failed to load page ${state.pageNumber}'s image:`, err);
-			}
-		})();
-		return state.imageLoadPromise;
-	}
-
-	// Downsample factor for ensureThumbnail() below - the sidebar only ever
-	// displays a thumbnail at ~140px CSS width (see .supernote-thumb-img in
-	// styles.css), so there's no reason to pay full-page-resolution
-	// rasterization cost just to shrink it back down via CSS afterward (see
-	// https://github.com/philips/supernote-typescript/issues/40, and issue
-	// #154's crash trail generally). Picked so a typical Supernote page
-	// (~1400px wide) decodes to comfortably above the sidebar's own width,
-	// with headroom for higher-DPI displays, while still being a small
-	// fraction of the full-resolution decode/memory cost.
-	private static readonly THUMBNAIL_SCALE = 4;
-
-	// Loads this page's own thumbnail-resolution image if it hasn't been
-	// already — triggered by thumbObserver as its sidebar item nears the
-	// viewport (see buildThumbSidebar()). Same idempotent/de-duplicated
-	// pattern as ensurePageImage(), but entirely separate state
-	// (thumbnailDataUrl/thumbnailLoadPromise) and its own, much cheaper
-	// rasterization at THUMBNAIL_SCALE - a thumbnail being visible doesn't
-	// imply the main view wants this page's full-resolution image too, and
-	// vice versa, so there's no reason for one to force-load the other.
-	//
-	// Unlike ensurePageImage(), a completed load is never evicted and is
-	// finalized unconditionally, even if the item has since scrolled back
-	// out of thumbObserver's view. A full document's worth of these (even
-	// several hundred pages) only amounts to a few MB total at
-	// THUMBNAIL_SCALE - see issue #154 - so there's no memory pressure to
-	// evict for, and keeping them around means scrolling back to an
-	// already-visited thumbnail never has to redecode or re-show a blank/
-	// broken placeholder. This also sidesteps a UI bug: an evicted <img>
-	// (src set back to '') paired with the aspect-ratio box reserved below
-	// renders as a visible "broken image" icon rather than just collapsing,
-	// since the box no longer has a legitimate reason to be empty once
-	// something has actually loaded into it.
-	private ensureThumbnail(state: PageRenderState): Promise<void> {
-		if (state.thumbnailDataUrl) return Promise.resolve();
-		if (state.thumbnailLoadPromise) return state.thumbnailLoadPromise;
-
-		state.thumbnailLoadPromise = (async () => {
-			try {
-				if (!this.sn) return;
-				const [dataUrl] = await new ImageConverter().convertToImages(
-					this.sn, [state.pageNumber], SupernoteView.THUMBNAIL_SCALE,
-				);
-				state.thumbnailDataUrl = dataUrl;
-				const thumbImg = this.thumbImgs[state.pageNumber - 1];
-				if (thumbImg) thumbImg.src = dataUrl;
-				this.logThumbnailMemoryTrace(state.pageNumber, dataUrl.length);
-			} catch (err) {
-				console.error(`Supernote: failed to load page ${state.pageNumber}'s thumbnail:`, err);
-			}
-		})();
-		return state.thumbnailLoadPromise;
-	}
-
-	// Same trace as logPageMemoryTrace() above, but for the separate,
-	// much-cheaper thumbnail path (see THUMBNAIL_SCALE) - added alongside
-	// it so a suspected leak/residual memory issue (issue #154) can be
-	// attributed to whichever path is actually responsible, not just
-	// full-resolution main-view pages. Estimates bytes from the data URL's
-	// own string length (base64, ~4/3 of the underlying binary size) -
-	// there's no canvas backing store to account for here, unlike
-	// estimatedPageMemoryBytes(). Thumbnails are never evicted (see
-	// ensureThumbnail()), so this only ever logs a load.
-	private logThumbnailMemoryTrace(pageNumber: number, dataUrlLength: number): void {
-		const loadedCount = this.pageStates.filter((s) => s.thumbnailDataUrl !== null).length;
-		const totalChars = this.pageStates.reduce((sum, s) => sum + (s.thumbnailDataUrl?.length ?? 0), 0);
-		const kb = (chars: number) => ((chars * 0.75) / 1024).toFixed(1);
-		console.debug(
-			`Supernote: page ${pageNumber} thumbnail loaded (~${kb(dataUrlLength)}KB) — ` +
-			`${loadedCount} thumbnail(s) currently loaded, ~${kb(totalChars)}KB estimated total`,
-		);
-	}
-
-	// Draws the page's own already-decoded bitmap at the given scale — no
-	// pdf.js involved. Synchronous (drawImage from an ImageBitmap doesn't
-	// need awaiting), so redrawing on every zoom tick is cheap; pdf.js's own
-	// pdfPage.render() had to redecode the embedded PDF image every time.
-	private drawPageImage(state: PageRenderState, scale: number) {
-		const width = Math.max(1, Math.round(state.nativeWidth * scale));
-		const height = Math.max(1, Math.round(state.nativeHeight * scale));
-
-		// CSS (layout) size always tracks the current zoom, for every page,
-		// regardless of whether its image is actually loaded right now.
-		// commitZoom() calls this unconditionally for every page on every
-		// zoom change - scroll position, thumbnail click-to-jump, and
-		// page-anchor links all depend on every page's box being the right
-		// height even for pages that aren't currently loaded (never viewed
-		// yet, or evicted after scrolling away - see evictPageImage()).
-		state.canvas.setCssStyles({ width: `${width}px`, height: `${height}px` });
-		state.canvasWrap.setCssStyles({ width: `${width}px`, height: `${height}px` });
-		state.textLayerDiv.setCssStyles({ width: `${width}px`, height: `${height}px` });
-		state.linksLayerDiv.setCssStyles({ width: `${width}px`, height: `${height}px` });
-		this.positionLinkOverlay(state, width, height);
-
-		// The backing store (actual pixel buffer - the expensive part) only
-		// needs to match this size when there's a real image to draw into
-		// it. Previously resized unconditionally here, which meant
-		// commitZoom()'s loop over every page reallocated a full-size
-		// backing store for every page in the document on every zoom
-		// change, including pages nowhere near the viewport - undoing lazy
-		// loading's whole memory benefit for a long document the moment you
-		// touched zoom at all (see issue #154). A page with no imageBitmap
-		// keeps whatever backing store size it already has (a fresh
-		// <canvas>'s browser default, or evictPageImage()'s 1x1 shrink) -
-		// the browser just stretches/blurs that placeholder to fill the CSS
-		// box above, fine since such a page is off-screen by definition.
-		if (!state.imageBitmap) return;
-
-		// Rendering the backing store at devicePixelRatio and leaving the
-		// CSS size alone (set above) fixes the "chunky artifacts" a 1:1
-		// backing store gets upscaled into on a high-DPR mobile screen;
-		// capped at 3 so an extreme DPR display doesn't blow up canvas
-		// memory for no visible benefit.
-		const dpr = Math.min(window.devicePixelRatio || 1, 3);
-		const bitmapWidth = Math.max(1, Math.round(width * dpr));
-		const bitmapHeight = Math.max(1, Math.round(height * dpr));
-		state.canvas.width = bitmapWidth;
-		state.canvas.height = bitmapHeight;
-		state.canvas.getContext("2d")?.drawImage(state.imageBitmap, 0, 0, bitmapWidth, bitmapHeight);
-	}
-
-	// Frees a page's full-resolution decoded image once it's scrolled back
-	// out of pageObserver's margin (see onOpen()). Lazy *loading* alone
-	// still lets memory grow without bound on a long enough document as the
-	// main view is scrolled, since nothing ever released an earlier page's
-	// bitmap/canvas backing store once loaded (see issue #154). Safe to
-	// call speculatively: a no-op if nothing's actually loaded (most pages,
-	// most of the time - pageObserver also reports initial non-intersection
-	// for anything outside the viewport at file-open time). Entirely
-	// independent of the thumbnail sidebar's own state (see
-	// ensureThumbnail()), which this never touches.
-	private evictPageImage(state: PageRenderState): void {
-		if (!state.imageBitmap) return;
-		// Captured before freeing anything below - there'd be nothing left
-		// to measure afterward.
-		const pageBytes = this.estimatedPageMemoryBytes(state);
-
-		// Releases the decoded bitmap's memory explicitly rather than
-		// waiting on GC to notice it's unreachable.
-		state.imageBitmap.close();
-		state.imageBitmap = null;
-		state.imageDataUrl = null;
-		// Lets a later re-entry actually reload instead of reusing this
-		// already-settled (but now stale) promise - ensurePageImage()'s
-		// imageBitmap check alone isn't enough once it's null again.
-		state.imageLoadPromise = null;
-
-		// The backing store doesn't shrink on its own just because nothing
-		// points at an ImageBitmap for it anymore - a canvas keeps its full
-		// pixel buffer resident until its width/height actually change.
-		// Deliberately doesn't touch CSS size (drawPageImage() already set
-		// that correctly and it doesn't need to change) - only this.
-		state.canvas.width = 1;
-		state.canvas.height = 1;
-
-		this.logPageMemoryTrace('evicted', state.pageNumber, pageBytes);
-	}
-
-	// Repositions each link's clickable region to the page's current CSS
-	// pixel size — called on initial render and every zoom redraw (see
-	// drawPageImage()). LINKRECT is stored in native (unscaled) page-pixel
-	// coordinates, the same space as nativeWidth/nativeHeight, so one scale
-	// factor (derived from the page's current rendered width, same source as
-	// canvas/textLayerDiv's own sizing above) maps rect -> CSS px.
-	private positionLinkOverlay(state: PageRenderState, width: number, height: number) {
-		if (state.linkEls.length === 0) return;
-		const scaleX = width / state.nativeWidth;
-		const scaleY = height / state.nativeHeight;
-		for (const { el, rect } of state.linkEls) {
-			const [x, y, w, h] = rect;
-			el.setCssStyles({
-				left: `${x * scaleX}px`,
-				top: `${y * scaleY}px`,
-				width: `${w * scaleX}px`,
-				height: `${h * scaleY}px`,
-			});
-		}
-	}
-
-	// (Re)builds the selectable/searchable text layer at the given viewport.
-	// Shared by ensureTextLayer() (first load) and commitZoom() (rebuild at
-	// the new scale for pages that were already loaded).
-	private async buildTextLayerForState(pdfPage: PdfJsPage, state: PageRenderState, viewport: PdfJsViewport): Promise<void> {
-		const textContent = await pdfPage.getTextContent();
-		state.text = textContent.items.map(item => item.str ?? '').join('');
-
-		const hasTextLayer = this.pdfjsLib
-			? await renderTextLayer(this.pdfjsLib, textContent, state.textLayerDiv, viewport)
-			: false;
-		state.spans = hasTextLayer ? Array.from(state.textLayerDiv.querySelectorAll('span')) : [];
-	}
-
-	// Loads this page's text layer if it hasn't been already — triggered by
-	// pageObserver as a page nears the viewport, or forced immediately by
-	// page-jump/thumbnail-click/find-in-note so those don't have to wait on
-	// scroll+observer timing. Idempotent and safe to call speculatively.
-	private async ensureTextLayer(state: PageRenderState): Promise<void> {
-		if (state.textLayerLoaded) return;
-		state.textLayerLoaded = true; // set eagerly: no double-trigger race
-
-		try {
-			// See issue #147: if this ever crashes hard (no catchable JS
-			// error), the last of these lines to print is the closest thing
-			// to a stack trace it leaves behind.
-			console.debug(`Supernote: text layer — page ${state.pageNumber} awaiting PDF…`);
-			const pdfDoc = await this.pdfDocPromise;
-			if (!pdfDoc) return;
-
-			if (!state.pdfPage) {
-				state.pdfPage = await pdfDoc.getPage(state.pageNumber);
-			}
-			const pdfPage = state.pdfPage;
-
-			console.debug(`Supernote: text layer — page ${state.pageNumber} building…`);
-			const viewport = pdfPage.getViewport({ scale: this.zoomScale });
-			await this.buildTextLayerForState(pdfPage, state, viewport);
-			console.debug(`Supernote: text layer — page ${state.pageNumber} ready`);
-		} catch (error) {
-			console.error(`Failed to build text layer for page ${state.pageNumber}:`, error);
-		}
-	}
-
-	// Populates this page's compact/reflowed text view (see setLayerMode()'s
-	// 'text' mode) straight from the note's own recognized text - already
-	// reconstructed into reading-order lines/paragraphs by
-	// supernote-typescript's parsing (the same source markdown export uses;
-	// see exportToMarkdown()) - rather than pdf.js's word-positioned text
-	// layer (buildTextLayerForState()). That positioned layer is exactly
-	// what made the old text mode's selection unreliable (issue #171):
-	// dragging a selection across many individually-absolutely-positioned
-	// spans, arranged to match the original handwriting's x/y layout rather
-	// than a linear reading order, copies inconsistently and leaves large
-	// gaps for pages with sparse handwriting. A plain string in normal
-	// document flow has neither problem.
-	//
-	// Synchronous (no pdf.js/network/worker involved) but still gated behind
-	// a per-page loaded flag and called lazily (pageObserver, goToPage,
-	// setLayerMode('text')) rather than eagerly for every page at file-load
-	// time - consistent with how ensurePageImage()/ensureTextLayer() avoid
-	// doing all of a long note's pages' worth of work upfront (see
-	// onOpen()'s pageObserver comment).
-	private ensureCompactText(state: PageRenderState): void {
-		if (state.compactTextLoaded) return;
-		state.compactTextLoaded = true;
-
-		const rawText = this.sn?.pages[state.pageNumber - 1]?.text ?? '';
-		const hasText = rawText.length > 0;
-		state.compactTextDiv.toggleClass('supernote-compact-text-empty', !hasText);
-		state.compactTextDiv.setText(hasText ? processSupernoteText(rawText, this.settings) : 'No recognized text on this page.');
-	}
-
-	private buildToolbar(container: HTMLElement, pageCount: number) {
-		this.pageJumpInput = null;
-		const toolbar = container.createDiv({ cls: 'supernote-toolbar' });
-
-		if (pageCount > 1) {
-			const thumbGroup = toolbar.createDiv({ cls: 'supernote-toolbar-group' });
-			this.thumbToggleBtn = thumbGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Toggle page thumbnails' } });
-			setIcon(this.thumbToggleBtn, 'layout-list');
-			this.thumbToggleBtn.addEventListener('click', () => this.toggleThumbnails());
-		}
-
-		const zoomGroup = toolbar.createDiv({ cls: 'supernote-toolbar-group' });
-		const zoomOutBtn = zoomGroup.createEl('button', { text: '−', cls: 'clickable-icon', attr: { 'aria-label': 'Zoom out' } });
-		this.zoomLabelEl = zoomGroup.createSpan({ cls: 'supernote-zoom-label', text: '100%' });
-		const zoomInBtn = zoomGroup.createEl('button', { text: '+', cls: 'clickable-icon', attr: { 'aria-label': 'Zoom in' } });
-		const zoomResetBtn = zoomGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Reset zoom' } });
-		setIcon(zoomResetBtn, 'rotate-ccw');
-		this.fitWidthBtn = zoomGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Fit page to viewport width' } });
-		setIcon(this.fitWidthBtn, 'stretch-horizontal');
-
-		zoomOutBtn.addEventListener('click', () => this.setZoom(this.zoomScale / 1.25));
-		zoomInBtn.addEventListener('click', () => this.setZoom(this.zoomScale * 1.25));
-		zoomResetBtn.addEventListener('click', () => this.setZoom(1));
-		this.fitWidthBtn.addEventListener('click', () => {
-			this.fitWidthEnabled = !this.fitWidthEnabled;
-			if (this.fitWidthEnabled) {
-				this.applyFitWidth();
-			}
-			this.updateFitWidthButton();
+		// Unconditional (not gated by showExportButtons, unlike the buttons
+		// above) - matches this feature's previous toolbar-button placement,
+		// which was likewise always shown regardless of that setting. Built
+		// as a plain button here rather than restored as an icon in some
+		// toolbar of this wrapper's own: the icon-based toolbar row it used
+		// to live in belongs entirely to <supernote-viewer> now, and adding
+		// export UI there would cross the "no save/export UI" v1 boundary
+		// that component's own header comment deliberately draws.
+		const exportPageBtn = container.createEl("p").createEl("button", {
+			text: "Export current page as image",
+			cls: "mod-cta",
 		});
-		this.updateFitWidthButton();
-
-		const layerGroup = toolbar.createDiv({ cls: 'supernote-toolbar-group' });
-		this.imageModeBtn = layerGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Show page image' } });
-		setIcon(this.imageModeBtn, 'image');
-		this.textModeBtn = layerGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Show recognized text (compact)' } });
-		setIcon(this.textModeBtn, 'type');
-		this.imageModeBtn.addEventListener('click', () => this.setLayerMode('image'));
-		this.textModeBtn.addEventListener('click', () => this.setLayerMode('text'));
-		this.updateLayerModeButtons();
-
-		const exportGroup = toolbar.createDiv({ cls: 'supernote-toolbar-group' });
-		const exportPageBtn = exportGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Export current page as image' } });
-		setIcon(exportPageBtn, 'download');
-		exportPageBtn.addEventListener('click', () => {
+		exportPageBtn.addEventListener("click", () => {
 			this.exportCurrentPageAsImage().catch((err: unknown) => {
 				new ErrorModal(this.app, err instanceof Error ? err : new Error(String(err))).open();
 			});
 		});
 
-		// Mod+F (registered in onOpen) already toggles the find bar, but that
-		// hotkey has no mobile equivalent — without a button, search is
-		// unreachable on touch devices. Toolbar button covers both.
-		const findGroup = toolbar.createDiv({ cls: 'supernote-toolbar-group' });
-		this.findToggleBtn = findGroup.createEl('button', { cls: 'clickable-icon', attr: { 'aria-label': 'Find in note' } });
-		setIcon(this.findToggleBtn, 'search');
-		this.findToggleBtn.addEventListener('click', () => this.toggleFindBar());
+		const bytes = await this.app.vault.readBinary(file);
 
-		if (pageCount > 1) {
-			const jumpGroup = toolbar.createDiv({ cls: 'supernote-toolbar-group' });
-			jumpGroup.createSpan({ text: 'Page', cls: 'supernote-page-jump-label' });
-			const pageInput = jumpGroup.createEl('input', {
-				cls: 'supernote-page-jump-input',
-				attr: { type: 'number', min: '1', max: String(pageCount), value: '1' },
-			});
-			this.pageJumpInput = pageInput;
-			jumpGroup.createSpan({ text: `/ ${pageCount}`, cls: 'supernote-page-jump-total' });
-
-			const jumpToPage = () => {
-				const requested = Number(pageInput.value);
-				if (!Number.isFinite(requested)) return;
-				void this.goToPage(Math.round(requested));
-			};
-
-			pageInput.addEventListener('keydown', (evt: KeyboardEvent) => {
-				if (evt.key === 'Enter') {
-					evt.preventDefault();
-					jumpToPage();
-				}
-			});
-			pageInput.addEventListener('blur', jumpToPage);
+		const viewer = container.createEl('supernote-viewer');
+		// Applies the plugin's custom-dictionary substitution (if enabled)
+		// to recognized text shown in the component's own text mode - the
+		// one piece of SupernoteView's previous behavior <supernote-viewer>
+		// has no portable equivalent for, since it reads plugin settings
+		// this Obsidian-free component has no concept of. See
+		// textProcessor's own doc comment (SupernoteViewerElement.ts) for
+		// the narrow find-in-note inconsistency this leaves.
+		viewer.textProcessor = (text) => processSupernoteText(text, this.settings);
+		if (this.settings.invertColorsWhenDark) {
+			viewer.setAttribute('invert-dark', '');
 		}
-	}
+		this.viewerEl = viewer;
 
-	private setLayerMode(mode: 'image' | 'text') {
-		this.layerMode = mode;
-		this.pagesEl?.toggleClass('supernote-mode-text', mode === 'text');
-		this.updateLayerModeButtons();
-
-		// Unlike ensurePageImage()/ensureTextLayer(), this is cheap enough
-		// (plain strings already held in memory as part of `this.sn`, no
-		// decode/network/worker involved) to just do for every page the
-		// moment the user actually asks for text mode, rather than waiting
-		// on each page to individually scroll into view first - so the
-		// whole note reads as compact text immediately, not page-by-page as
-		// you scroll.
-		if (mode === 'text') {
-			for (const state of this.pageStates) {
-				this.ensureCompactText(state);
+		viewer.addEventListener('supernote-load', ((e: CustomEvent<{ pageIds: string[] }>) => {
+			this.pageIds = e.detail.pageIds;
+		}) as EventListener);
+		viewer.addEventListener('supernote-error', ((e: CustomEvent<{ error: unknown; pageNumber?: number }>) => {
+			// A single page failing to rasterize (pageNumber set) just
+			// leaves that one page blank and retries later - only a
+			// whole-note failure (fetch/parse, no pageNumber) is worth
+			// surfacing as a hard error.
+			if (e.detail.pageNumber === undefined) {
+				new ErrorModal(this.app, e.detail.error instanceof Error ? e.detail.error : new Error(String(e.detail.error))).open();
 			}
-		}
+		}) as EventListener);
+		viewer.addEventListener('link-click', ((e: CustomEvent<{ link: ILink }>) => {
+			void handleNoteLinkClick(this.app, file.basename, this.pageIds, this.viewerEl, e.detail.link);
+		}) as EventListener);
+
+		// Awaited (unlike SupernoteEmbed's identical assignment, which is
+		// fire-and-forget) so setEphemeralState() - which Obsidian calls
+		// right after onLoadFile() resolves, for a `#page=N` link's initial
+		// jump - never races the component's own async parse/build: without
+		// this, goToPage() could run before the component's page list even
+		// exists yet (noteData's actual parsing is deferred to a
+		// microtask - see queueRender() in SupernoteViewerElement.ts) and
+		// silently no-op.
+		const loaded = new Promise<void>((resolve) => {
+			viewer.addEventListener('supernote-load', () => resolve(), { once: true });
+			viewer.addEventListener('supernote-error', ((e: CustomEvent<{ pageNumber?: number }>) => {
+				if (e.detail.pageNumber === undefined) resolve();
+			}) as EventListener, { once: true });
+		});
+		viewer.noteData = bytes;
+		await loaded;
 	}
 
-	private updateLayerModeButtons() {
-		this.imageModeBtn?.toggleClass('is-active', this.layerMode === 'image');
-		this.textModeBtn?.toggleClass('is-active', this.layerMode === 'text');
-	}
-
-	// Reuses the same page PNGs ensurePageImage() rasterizes for the main
-	// view (see thumbImg assignment there) — no separate low-res render pass,
-	// just let CSS scale them down. Starts empty (no `src`) for every page:
-	// images are no longer all ready up front (see issue #147), so a
-	// thumbnail fills in whenever its page happens to load - from scrolling
-	// the main view, or all at once when the sidebar is first opened, see
-	// toggleThumbnails().
-	private buildThumbSidebar(body: HTMLElement, pageCount: number, pageWidth: number, pageHeight: number) {
-		const thumbSidebarEl = body.createDiv({ cls: 'supernote-thumb-sidebar' });
-		this.thumbSidebarEl = thumbSidebarEl;
-		this.thumbItems = [];
-		this.thumbImgs = [];
-
-		// Scoped to this sidebar's own scroll container (it scrolls
-		// independently of the main view - see CSS `overflow-y: auto` on
-		// .supernote-thumb-sidebar), not contentEl. A fresh observer every
-		// file load: thumbSidebarEl above is itself a brand new element each
-		// time, and an IntersectionObserver's root can't be changed after
-		// construction, so the one from any previous file load (disconnected
-		// in onLoadFile()) can't just be reused here. While the sidebar is
-		// hidden (display: none, see applyThumbSidebarVisibility()) every
-		// item reports non-intersecting - it has no layout box to intersect
-		// with - so nothing loads until it's actually shown; opening it then
-		// only loads whichever thumbnails are actually scrolled into view in
-		// it.
-		//
-		// rootMargin here originally had no prefetch buffer at all, unlike
-		// pageObserver's '100% 0px': a percentage margin resolves against
-		// the *root's own* size, and a thumbnail item (~150-250px, image +
-		// label) is much smaller than a main-view page (often
-		// near-full-viewport), so the same 100% margin that only ever
-		// brings 1-2 main-view pages into range at once used to fit several
-		// times that many thumbnails into an equivalent pixel margin - at
-		// full page resolution, that was a crash risk (issue #154). Now
-		// that thumbnails rasterize at THUMBNAIL_SCALE and are never
-		// evicted (see ensureThumbnail()), that same prefetch buffer only
-		// costs a handful of small decodes, so it's brought back to load a
-		// sidebar's worth of thumbnails ahead of/behind the visible ones,
-		// for smoother scrolling.
-		//
-		// Loading is also debounced ~200ms - confirmed by testing (issue
-		// #154): even bounded to "only what's visible" and with the
-		// pop/reflow fixed, scrolling the sidebar *quickly* through many
-		// pages still crashed, while scrolling slowly was fine. A fast
-		// scroll flings most thumbnails past the viewport well within that
-		// window, each one triggering a rasterization in quick succession.
-		// Debouncing means a thumbnail that's only ever transiently
-		// intersecting during a fast scroll never triggers a load at all -
-		// only ones the user actually lingers near for a moment do.
-		this.thumbObserver = new IntersectionObserver((entries) => {
-			for (const entry of entries) {
-				const index = this.thumbItems.indexOf(entry.target as HTMLElement);
-				if (index === -1) continue;
-				const state = this.pageStates[index];
-				if (!state) continue;
-				state.visibleInThumbnail = entry.isIntersecting;
-				window.clearTimeout(state.thumbLoadDebounceTimer);
-				if (entry.isIntersecting) {
-					state.thumbLoadDebounceTimer = window.setTimeout(() => {
-						// Re-checks rather than assuming still true - the
-						// timer firing doesn't mean nothing happened since
-						// it was scheduled.
-						if (state.visibleInThumbnail) void this.ensureThumbnail(state);
-					}, 200);
-				}
-			}
-		}, { root: thumbSidebarEl, rootMargin: '100% 0px' });
-
-		for (let i = 0; i < pageCount; i++) {
-			const item = thumbSidebarEl.createDiv({ cls: 'supernote-thumb-item' });
-			const img = item.createEl('img', { cls: 'supernote-thumb-img' });
-			if (this.settings.invertColorsWhenDark) {
-				img.addClass("supernote-invert-dark");
-			}
-			// Reserves this thumbnail's correct box size (width is already
-			// fixed at 100% of the item via CSS; aspect-ratio derives the
-			// height from that) before ensurePageImage() ever sets `src` -
-			// an <img> with no src/dimensions otherwise collapses to ~0
-			// height, so it "pops" to full size right as it loads. That's
-			// not just visual: every pop shifts every later thumbnail's
-			// position, which reflows the whole sidebar and can re-trigger
-			// thumbObserver for a large swath of items at once - plausibly
-			// why scrolling the sidebar for a while still crashed (issue
-			// #154) even after loads were bounded to whatever's actually
-			// visible. A stable layout from the start means each item's
-			// intersection only ever changes because of an actual scroll,
-			// not a layout shift caused by a sibling loading in.
-			img.style.aspectRatio = `${pageWidth} / ${pageHeight}`;
-			item.createSpan({ cls: 'supernote-thumb-label', text: String(i + 1) });
-
-			item.addEventListener('click', () => {
-				void this.goToPage(i + 1);
-			});
-
-			this.thumbItems.push(item);
-			this.thumbImgs.push(img);
-			this.thumbObserver.observe(item);
-		}
-
-		this.applyThumbSidebarVisibility();
-	}
-
-	private toggleThumbnails() {
-		this.thumbnailsVisible = !this.thumbnailsVisible;
-		this.applyThumbSidebarVisibility();
-	}
-
-	private applyThumbSidebarVisibility() {
-		this.thumbSidebarEl?.toggle(this.thumbnailsVisible);
-		this.thumbToggleBtn?.toggleClass('is-active', this.thumbnailsVisible);
-		if (this.thumbnailsVisible) this.updateThumbSidebarOffset();
-
-		// Unlike before issue #179's fix, the sidebar now overlays pagesEl
-		// (see CSS `.supernote-thumb-sidebar`) instead of sitting alongside it
-		// in the same flex row, so toggling it never changes pagesEl's own
-		// width - no fit-width re-render needed here.
-	}
-
-	// The thumbnail sidebar is sticky below the header, not at top:0 like the
-	// header itself — otherwise it would stick right under the top edge of
-	// the view, overlapping the header instead of sitting below it. The find
-	// bar toggling open/closed changes the header's height, so this needs
-	// re-running whenever that happens, not just once at load.
-	private updateThumbSidebarOffset() {
-		if (!this.thumbSidebarEl) return;
-		const headerHeight = this.headerEl?.offsetHeight ?? 0;
-		this.thumbSidebarEl.setCssStyles({ top: `${headerHeight}px` });
-	}
-
-	private highlightThumbnail(index: number) {
-		this.thumbItems.forEach((item, i) => item.toggleClass('is-active', i === index));
-	}
-
-	// Shared by the toolbar's page-jump input, the thumbnail sidebar, and
-	// setEphemeralState() (a `#page=N` link anchor) — all three just need to
-	// scroll a given 1-indexed page into view and prime its image/text layer.
-	private async goToPage(pageNumber: number): Promise<void> {
-		if (this.pageStates.length === 0) return;
-		// Wait out any in-flight fit-width/zoom re-render first — see
-		// waitForZoomToSettle() for why scrolling before it settles can land on
-		// the wrong page.
-		await this.waitForZoomToSettle();
-		if (this.pageStates.length === 0) return;
-		const clamped = Math.min(this.pageStates.length, Math.max(1, pageNumber));
-		const state = this.pageStates[clamped - 1];
-		if (!state) return;
-		state.pageContainer.scrollIntoView({ block: 'start', behavior: 'smooth' });
-		// Don't wait on scroll+observer timing for a page the user (or link)
-		// explicitly asked to jump to — a fast programmatic jump can easily
-		// land before pageObserver's next tick fires. Marking it visible
-		// directly (rather than just calling ensurePageImage()) also closes
-		// off a narrow race with evictPageImage(): a stray non-intersecting
-		// callback firing for this page while the scroll is still settling
-		// would otherwise see visibleInMainView still false and could evict
-		// the very page we just asked to load.
-		state.visibleInMainView = true;
-		void this.ensurePageImage(state);
-		void this.ensureTextLayer(state);
-		this.ensureCompactText(state);
-		if (this.pageJumpInput) this.pageJumpInput.value = String(clamped);
-	}
-
-	// Saves just the page currently shown in the toolbar's page indicator
-	// (kept up to date by updateCurrentPageIndicator()'s scrollspy) as a PNG
-	// attachment — the single-page equivalent of the per-page "Save image to
-	// vault" button, for when the user only wants the page they're looking
-	// at right now rather than the whole note. See issue #169. Exposed as a
-	// command (see 'export-current-page-as-image') and a toolbar button.
+	// Exports the page currently on screen (viewerEl.currentPage, kept up to
+	// date by the component's own scroll-driven page indicator) as a PNG
+	// attachment - the single-page equivalent of the whole-note export
+	// buttons above, for when the user only wants the page they're looking
+	// at right now rather than the whole note. Exposed as a command (see
+	// 'export-current-page-as-image') and the toolbar button above.
+	// Independently re-reads and rasterizes just this one page rather than
+	// reaching into the live <supernote-viewer>'s own internal state -
+	// mirrors how VaultWriter's own export methods already read+convert
+	// independently of whatever's currently displayed.
 	async exportCurrentPageAsImage(): Promise<void> {
-		if (this.pageStates.length === 0) return;
-		const requested = this.pageJumpInput ? Number(this.pageJumpInput.value) : 1;
-		const clamped = Math.min(this.pageStates.length, Math.max(1, Number.isFinite(requested) ? requested : 1));
-		const state = this.pageStates[clamped - 1];
+		if (!this.viewerEl || this.viewerEl.currentPage === 0) return;
+		const pageNumber = this.viewerEl.currentPage;
 
-		// Same race as goToPage() above — force this page "visible" so
-		// ensurePageImage() doesn't discard the load if pageObserver hasn't
-		// caught up with the current scroll position yet.
-		state.visibleInMainView = true;
-		await this.ensurePageImage(state);
-		if (!state.imageDataUrl) {
-			throw new Error(`Page ${clamped} has no rendered image to export.`);
-		}
+		const note = await this.app.vault.readBinary(this.file);
+		const sn = new SupernoteX(new Uint8Array(note));
+		const [imageDataUrl] = await new ImageConverter().convertToImages(sn, [pageNumber]);
 
-		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${this.file.basename}-page-${clamped}.png`);
-		const savedFile = await this.app.vault.createBinary(filename, dataUrlToBuffer(state.imageDataUrl));
+		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${this.file.basename}-page-${pageNumber}.png`);
+		const savedFile = await this.app.vault.createBinary(filename, dataUrlToBuffer(imageDataUrl));
 
 		// Same "click to open" completion notice as VaultWriter's exports
 		// (see notifyExportComplete(), issue #167 / PR #175).
@@ -1866,344 +733,61 @@ export class SupernoteView extends FileView {
 		});
 	}
 
-	// A clicked link region's target: same-file (jump in place via goToPage)
-	// when its basename matches this file, or another vault note (open via a
-	// new leaf, reusing the `#page=N` ephemeral-state anchor that regular
-	// `[[note#page=N]]` links already use — see setEphemeralState()). Basename
-	// matching against the vault mirrors VaultWriter.resolvePageAnchor()'s
-	// export-time link resolution (see PR #122), so a link resolves the same
-	// note whether you're viewing it live or exporting it; ambiguous if two
-	// vault notes share a basename in different folders, same known
-	// limitation as that export path.
-	private async handleLinkClick(link: ILink): Promise<void> {
-		const targetBasename = link.text.split('#')[0];
-		const pageid = link.PAGEID;
-
-		if (!targetBasename || targetBasename === this.file.basename) {
-			const pageIndex = this.pageIds.findIndex((id) => id === pageid);
-			if (pageIndex >= 0) void this.goToPage(pageIndex + 1);
-			return;
-		}
-
-		const targetFile = this.app.vault.getFiles().find((f) => f.extension === 'note' && f.basename === targetBasename);
-		if (!targetFile) {
-			new Notice(`Linked note "${targetBasename}.note" not found in vault.`);
-			return;
-		}
-
-		let subpath: string | undefined;
-		if (pageid && pageid !== '0' && pageid !== 'none') {
-			try {
-				const buffer = await this.app.vault.readBinary(targetFile);
-				const pageIndex = new SupernoteX(new Uint8Array(buffer)).pages.findIndex((p) => p.PAGEID === pageid);
-				if (pageIndex >= 0) subpath = `#page=${pageIndex + 1}`;
-			} catch {
-				// Malformed target file — fall through and open without a page anchor.
-			}
-		}
-
-		const leaf = this.app.workspace.getLeaf(false);
-		await leaf.openFile(targetFile, subpath ? { eState: { subpath } } : undefined);
-	}
-
-	// Scrollspy: find the last page whose top has scrolled up past the sticky
-	// header, and reflect it in the toolbar's page number — unless the user is
-	// actively typing in that field themselves.
-	private updateCurrentPageIndicator() {
-		if (!this.pageJumpInput || this.pageStates.length === 0) return;
-		if (document.activeElement === this.pageJumpInput) return;
-
-		const headerHeight = this.headerEl?.offsetHeight ?? 0;
-		const threshold = this.contentEl.getBoundingClientRect().top + headerHeight + 1;
-
-		let current = 0;
-		for (let i = 0; i < this.pageStates.length; i++) {
-			if (this.pageStates[i].pageContainer.getBoundingClientRect().top <= threshold) {
-				current = i;
-			} else {
-				break;
-			}
-		}
-
-		this.pageJumpInput.value = String(current + 1);
-		this.highlightThumbnail(current);
-	}
-
-	private setZoom(newScale: number, opts: { manual?: boolean } = {}) {
-		const isManual = opts.manual !== false;
-		if (isManual) {
-			// Any direct zoom action (buttons, wheel, reset) is the user taking
-			// manual control — stop auto-adjusting on resize until they ask for
-			// fit-width again. applyFitWidth() itself calls in with manual:false
-			// so it doesn't immediately cancel the mode it's trying to apply.
-			this.fitWidthEnabled = false;
-			this.updateFitWidthButton();
-		}
-
-		// Floor lowered from a former 0.25: "Fit width" (on by default) computes
-		// whatever zoom is needed to match the available viewport width, and on
-		// a narrow mobile screen — especially with the thumbnail sidebar open,
-		// or a wide/landscape note — that can legitimately need to go below
-		// 25%. Clamping it there just forced horizontal scrolling instead.
-		//
-		// The 500% ceiling only makes sense for *manual* zoom (a sanity cap on
-		// how far a user should zoom in by hand). "100%" here is one canvas
-		// pixel per native rasterized page pixel (see nativeWidth/nativeHeight),
-		// not anything tied to the available viewport — so a page with a small
-		// native resolution on a large or high-DPI display can legitimately
-		// need well over 5x to fill it with "Fit width". Applying the same
-		// 500% ceiling there just left the page stuck at a fixed pixel width
-		// regardless of how much wider the pane actually was, while showing a
-		// confusing pinned "500%" (see issue #108). Fit width instead gets a
-		// much higher ceiling, purely as a guard against a pathological render
-		// (e.g. a zero-width native page) rather than a real intended limit.
-		const ceiling = isManual ? 5 : 20;
-		this.zoomScale = Math.min(ceiling, Math.max(0.05, newScale));
-		this.zoomLabelEl?.setText(`${Math.round(this.zoomScale * 100)}%`);
-
-		// Instant CSS-scale feedback while the user is still zooming; the real
-		// re-render (crisp at the new resolution, text layer repositioned) is
-		// debounced below so rapid wheel/button input doesn't thrash pdf.js.
-		const instantFactor = this.zoomScale / this.renderedZoomScale;
-		for (const state of this.pageStates) {
-			state.canvasWrap.setCssStyles({ transform: `scale(${instantFactor})`, transformOrigin: 'top left' });
-		}
-
-		window.clearTimeout(this.zoomDebounceTimer);
-		this.zoomCommitPending = true;
-		this.zoomDebounceTimer = window.setTimeout(() => void this.commitZoom(), 200);
-	}
-
-	private async commitZoom(): Promise<void> {
-		const targetZoom = this.zoomScale;
-		for (const state of this.pageStates) {
-			this.drawPageImage(state, targetZoom);
-			state.canvasWrap.setCssStyles({ transform: '', transformOrigin: '' });
-
-			// Only rebuild the text layer for pages that already had one —
-			// pages not yet loaded (ensureTextLayer() never ran) will build
-			// theirs at whatever zoom is current when they eventually do.
-			if (state.textLayerLoaded && state.pdfPage) {
-				const pdfPage = state.pdfPage;
-				const viewport = pdfPage.getViewport({ scale: targetZoom });
-				await this.buildTextLayerForState(pdfPage, state, viewport);
-			}
-		}
-		this.renderedZoomScale = targetZoom;
-		this.updateCurrentPageIndicator();
-
-		this.zoomCommitPending = false;
-		const resolvers = this.zoomSettleResolvers;
-		this.zoomSettleResolvers = [];
-		resolvers.forEach((resolve) => resolve());
-	}
-
-	// Until commitZoom() runs, page containers are still sized at whatever
-	// zoom was rendered *before* the pending setZoom() call (the interim CSS
-	// transform scale it applies for instant visual feedback doesn't change
-	// their layout box). onLoadFile() calls applyFitWidth() as soon as pages
-	// are built, so a page-anchor link (setEphemeralState() -> goToPage(),
-	// firing right as that file finishes loading) can easily land its
-	// scrollIntoView() before fit-width's real re-render — using page heights
-	// that are about to change once commitZoom() actually fires, and landing
-	// on the wrong page once they do. Waiting this out first keeps
-	// scrollIntoView() targeting final, stable page positions.
-	private async waitForZoomToSettle(): Promise<void> {
-		if (!this.zoomCommitPending) return;
-		await new Promise<void>((resolve) => this.zoomSettleResolvers.push(resolve));
-	}
-
-	// Scales the page so its rendered width matches however much horizontal
-	// space is actually available (pagesEl's content box - the thumbnail
-	// sidebar overlays pagesEl rather than sharing its flex row, so this
-	// doesn't need to account for whether it's open, see
-	// applyThumbSidebarVisibility()) minus the page container's own margin.
-	private applyFitWidth() {
-		const state = this.pageStates[0];
-		if (!state || !this.pagesEl || state.nativeWidth <= 0) return;
-
-		const availableWidth = this.pagesEl.clientWidth;
-		if (availableWidth <= 0) return;
-
-		const containerStyle = getComputedStyle(state.pageContainer);
-		const horizontalMargin = parseFloat(containerStyle.marginLeft || '0') + parseFloat(containerStyle.marginRight || '0');
-		const targetWidth = Math.max(availableWidth - horizontalMargin, 1);
-
-		this.setZoom(targetWidth / state.nativeWidth, { manual: false });
-	}
-
-	private updateFitWidthButton() {
-		this.fitWidthBtn?.toggleClass('is-active', this.fitWidthEnabled);
-	}
-
-	private buildFindBar(container: HTMLElement) {
-		const bar = container.createDiv({ cls: 'supernote-find-bar' });
-		bar.hide();
-		this.findBarEl = bar;
-
-		this.findInput = new SearchComponent(bar);
-		this.findInput.setPlaceholder('Find in note…');
-		this.findInput.onChange((value) => this.runFind(value));
-
-		this.findMatchCountEl = bar.createSpan({ cls: 'supernote-find-count' });
-
-		const prevBtn = bar.createEl('button', { text: '↑', cls: 'clickable-icon', attr: { 'aria-label': 'Previous match' } });
-		const nextBtn = bar.createEl('button', { text: '↓', cls: 'clickable-icon', attr: { 'aria-label': 'Next match' } });
-		const closeBtn = bar.createEl('button', { text: '✕', cls: 'clickable-icon', attr: { 'aria-label': 'Close find bar' } });
-
-		prevBtn.addEventListener('click', () => this.stepFind(-1));
-		nextBtn.addEventListener('click', () => this.stepFind(1));
-		closeBtn.addEventListener('click', () => this.closeFindBar());
-
-		bar.addEventListener('keydown', (evt: KeyboardEvent) => {
-			if (evt.key === 'Escape') {
-				evt.preventDefault();
-				this.closeFindBar();
-			} else if (evt.key === 'Enter') {
-				evt.preventDefault();
-				this.stepFind(evt.shiftKey ? -1 : 1);
-			}
-		});
-	}
-
-	private toggleFindBar() {
-		if (!this.findBarEl) return;
-		if (this.findBarEl.isShown()) {
-			this.closeFindBar();
-			return;
-		}
-		this.findBarEl.show();
-		this.findToggleBtn?.toggleClass('is-active', true);
-		this.findInput?.inputEl.focus();
-		this.findInput?.inputEl.select();
-		this.updateThumbSidebarOffset();
-	}
-
-	private closeFindBar() {
-		this.clearFindHighlights();
-		this.findBarEl?.hide();
-		this.findToggleBtn?.toggleClass('is-active', false);
-		this.updateThumbSidebarOffset();
-	}
-
-	private clearFindHighlights() {
-		for (const state of this.pageStates) {
-			for (const span of state.spans) {
-				span.removeClass('supernote-find-match');
-				span.removeClass('supernote-find-match-current');
-			}
-		}
-		this.findMatches = [];
-		this.findMatchCursor = -1;
-		this.findMatchCountEl?.setText('');
-	}
-
-	// Maps a character offset within state.text back to the span that contains
-	// it. Assumes pdf.js's text layer renders one span per text-content item in
-	// order, which holds for the common case; a mismatch here just means a
-	// match highlights the wrong span rather than crashing.
-	private findSpanForOffset(state: PageRenderState, offset: number): number {
-		let cumulative = 0;
-		for (let i = 0; i < state.spans.length; i++) {
-			const len = state.spans[i].textContent?.length ?? 0;
-			if (offset < cumulative + len) return i;
-			cumulative += len;
-		}
-		return -1;
-	}
-
-	private async runFind(query: string) {
-		const requestId = ++this.findRequestId;
-
-		this.clearFindHighlights();
-		if (!query) return;
-
-		// Search needs every page's text, not just whatever's been lazily
-		// loaded so far — force any not-yet-loaded pages to load now rather
-		// than silently missing matches on pages the user hasn't scrolled to.
-		// Already-loaded pages resolve near-instantly, so this only really
-		// costs anything on the first search of a long, mostly-unscrolled note.
-		await Promise.all(this.pageStates.map((state) => this.ensureTextLayer(state)));
-		// A newer search may have started (and even finished) while this one
-		// was waiting on that — don't clobber its results with stale ones.
-		if (requestId !== this.findRequestId) return;
-
-		const lowerQuery = query.toLowerCase();
-		for (let pageIndex = 0; pageIndex < this.pageStates.length; pageIndex++) {
-			const state = this.pageStates[pageIndex];
-			const lowerText = state.text.toLowerCase();
-
-			for (let searchStart = 0; ;) {
-				const matchOffset = lowerText.indexOf(lowerQuery, searchStart);
-				if (matchOffset === -1) break;
-
-				const spanIndex = this.findSpanForOffset(state, matchOffset);
-				if (spanIndex !== -1) {
-					this.findMatches.push({ pageIndex, spanIndex });
-					state.spans[spanIndex].addClass('supernote-find-match');
-				}
-				searchStart = matchOffset + lowerQuery.length;
-			}
-		}
-
-		if (this.findMatches.length > 0) {
-			this.findMatchCursor = 0;
-			this.highlightCurrentMatch();
-		}
-		this.updateFindCount();
-	}
-
-	private stepFind(direction: 1 | -1) {
-		if (this.findMatches.length === 0) return;
-		this.findMatchCursor = (this.findMatchCursor + direction + this.findMatches.length) % this.findMatches.length;
-		this.highlightCurrentMatch();
-		this.updateFindCount();
-	}
-
-	private highlightCurrentMatch() {
-		for (const state of this.pageStates) {
-			for (const span of state.spans) {
-				span.removeClass('supernote-find-match-current');
-			}
-		}
-
-		const match = this.findMatches[this.findMatchCursor];
-		if (!match) return;
-
-		const state = this.pageStates[match.pageIndex];
-		const span = state.spans[match.spanIndex];
-		span.addClass('supernote-find-match-current');
-		state.pageContainer.scrollIntoView({ block: 'center', behavior: 'smooth' });
-		// Primes this page's image directly, exactly like goToPage() does for
-		// the same reason (see its comment) - stepping to a match can jump
-		// the length of the whole document, and shouldn't have to wait out
-		// pageObserver's own debounce (see onOpen()) on top of the smooth
-		// scroll animation itself before its destination page appears.
-		state.visibleInMainView = true;
-		void this.ensurePageImage(state);
-	}
-
-	private updateFindCount() {
-		if (!this.findMatchCountEl) return;
-		this.findMatchCountEl.setText(this.findMatches.length === 0 ? 'No matches' : `${this.findMatchCursor + 1}/${this.findMatches.length}`);
-	}
-
 	async onClose() {
-		window.clearTimeout(this.zoomDebounceTimer);
-		window.clearTimeout(this.fitWidthDebounceTimer);
-		this.resizeObserver?.disconnect();
-		this.pageObserver?.disconnect();
-		this.thumbObserver?.disconnect();
-		for (const state of this.pageStates) {
-			window.clearTimeout(state.thumbLoadDebounceTimer);
-			window.clearTimeout(state.pageLoadDebounceTimer);
-		}
-		// See onLoadFile()'s matching call for why this matters - closing the
-		// view entirely shouldn't leave its last file's pdf.js document
-		// resident in pdf.js's own Worker either.
-		this.pdfDocPromise?.then((doc) => doc.destroy()).catch(() => { /* nothing to clean up */ });
+		this.viewerEl = null;
 	}
 }
+
+// A clicked internal note link's navigation target: same-file (jump in
+// place via viewerEl.goToPage()) when the link carries no filename at all
+// or names the file currently open/embedded, or another vault note (open
+// via a new leaf, reusing the `#page=N` ephemeral-state anchor that regular
+// `[[note#page=N]]` links already use — see SupernoteView.setEphemeralState()
+// and SupernoteEmbed's own pageAnchor handling). Basename matching against
+// the vault mirrors VaultWriter.resolvePageAnchor()'s export-time link
+// resolution (see PR #122), so a link resolves the same note whether you're
+// viewing it live or exporting it; ambiguous if two vault notes share a
+// basename in different folders, same known limitation as that export path.
+// Shared by SupernoteView and SupernoteEmbed, which had identical copies of
+// this before this function existed - the only difference between them was
+// which file/pageIds/viewerEl to check against, now just parameters.
+async function handleNoteLinkClick(
+	app: App,
+	currentFileBasename: string,
+	pageIds: string[],
+	viewerEl: SupernoteViewerElement | null,
+	link: ILink,
+): Promise<void> {
+	const targetBasename = link.text.split('#')[0];
+	const pageid = link.PAGEID;
+
+	if (!targetBasename || targetBasename === currentFileBasename) {
+		const pageIndex = pageIds.findIndex((id) => id === pageid);
+		if (pageIndex >= 0) viewerEl?.goToPage(pageIndex + 1);
+		return;
+	}
+
+	const targetFile = app.vault.getFiles().find((f) => f.extension === 'note' && f.basename === targetBasename);
+	if (!targetFile) {
+		new Notice(`Linked note "${targetBasename}.note" not found in vault.`);
+		return;
+	}
+
+	let subpath: string | undefined;
+	if (pageid && pageid !== '0' && pageid !== 'none') {
+		try {
+			const buffer = await app.vault.readBinary(targetFile);
+			const pageIndex = new SupernoteX(new Uint8Array(buffer)).pages.findIndex((p) => p.PAGEID === pageid);
+			if (pageIndex >= 0) subpath = `#page=${pageIndex + 1}`;
+		} catch {
+			// Malformed target file — fall through and open without a page anchor.
+		}
+	}
+
+	const leaf = app.workspace.getLeaf(false);
+	await leaf.openFile(targetFile, subpath ? { eState: { subpath } } : undefined);
+}
+
 
 // Obsidian's PDF support accepts a `#page=3` anchor — as an embed
 // (`![[file.pdf#page=3]]`) or a regular link (`[[file.pdf#page=3]]` /
@@ -2242,11 +826,11 @@ export class SupernoteEmbed extends Component {
 	private minHeightObserver: ResizeObserver | null = null;
 	private lastMinHeightWidth = -1;
 	// This note's own pages' PAGEIDs, from the component's own supernote-load
-	// event - lets handleLinkClick() below resolve a link that names this
-	// same file explicitly (this.file.basename) without re-parsing bytes
-	// already parsed once inside the component. See that event's own detail
-	// comment (SupernoteViewerElement.ts) for why the component can't
-	// resolve this particular case itself.
+	// event - lets handleNoteLinkClick() resolve a link that names this same
+	// file explicitly (this.file.basename) without re-parsing bytes already
+	// parsed once inside the component. See that event's own detail comment
+	// (SupernoteViewerElement.ts) for why the component can't resolve this
+	// particular case itself.
 	private pageIds: string[] = [];
 
 	constructor(
@@ -2340,7 +924,7 @@ export class SupernoteEmbed extends Component {
 			if (e.detail.pageNumber === undefined) this.renderError(e.detail.error);
 		}) as EventListener);
 		viewer.addEventListener('link-click', ((e: CustomEvent<{ link: ILink }>) => {
-			void this.handleLinkClick(e.detail.link);
+			void handleNoteLinkClick(this.app, this.file.basename, this.pageIds, this.viewerEl, e.detail.link);
 		}) as EventListener);
 
 		// createEl() above already appended (and thus connected) it - matters
@@ -2386,46 +970,6 @@ export class SupernoteEmbed extends Component {
 		});
 	}
 
-	// Mirrors SupernoteView's own handleLinkClick() (same method name,
-	// same logic) - <supernote-viewer> only resolves a link-click itself
-	// when the link carries no filename at all (see that event's own
-	// dispatch comment), so every link-click this embed actually receives
-	// names some file explicitly; this replicates the one thing the
-	// component genuinely can't know on its own - whether that name
-	// happens to match the file *this* embed is currently showing - using
-	// pageIds captured from the component's own supernote-load event
-	// rather than re-parsing this.file's bytes a second time just to get
-	// that list.
-	private async handleLinkClick(link: ILink): Promise<void> {
-		const targetBasename = link.text.split('#')[0];
-		const pageid = link.PAGEID;
-
-		if (!targetBasename || targetBasename === this.file.basename) {
-			const pageIndex = this.pageIds.findIndex((id) => id === pageid);
-			if (pageIndex >= 0) this.viewerEl?.goToPage(pageIndex + 1);
-			return;
-		}
-
-		const targetFile = this.app.vault.getFiles().find((f) => f.extension === 'note' && f.basename === targetBasename);
-		if (!targetFile) {
-			new Notice(`Linked note "${targetBasename}.note" not found in vault.`);
-			return;
-		}
-
-		let subpath: string | undefined;
-		if (pageid && pageid !== '0' && pageid !== 'none') {
-			try {
-				const buffer = await this.app.vault.readBinary(targetFile);
-				const pageIndex = new SupernoteX(new Uint8Array(buffer)).pages.findIndex((p) => p.PAGEID === pageid);
-				if (pageIndex >= 0) subpath = `#page=${pageIndex + 1}`;
-			} catch {
-				// Malformed target file — fall through and open without a page anchor.
-			}
-		}
-
-		const leaf = this.app.workspace.getLeaf(false);
-		await leaf.openFile(targetFile, subpath ? { eState: { subpath } } : undefined);
-	}
 }
 
 export default class SupernotePlugin extends Plugin {

--- a/src/main.ts
+++ b/src/main.ts
@@ -650,24 +650,6 @@ export class SupernoteView extends FileView {
 			});
 		}
 
-		// Unconditional (not gated by showExportButtons, unlike the buttons
-		// above) - matches this feature's previous toolbar-button placement,
-		// which was likewise always shown regardless of that setting. Built
-		// as a plain button here rather than restored as an icon in some
-		// toolbar of this wrapper's own: the icon-based toolbar row it used
-		// to live in belongs entirely to <supernote-viewer> now, and adding
-		// export UI there would cross the "no save/export UI" v1 boundary
-		// that component's own header comment deliberately draws.
-		const exportPageBtn = container.createEl("p").createEl("button", {
-			text: "Export current page as image",
-			cls: "mod-cta",
-		});
-		exportPageBtn.addEventListener("click", () => {
-			this.exportCurrentPageAsImage().catch((err: unknown) => {
-				new ErrorModal(this.app, err instanceof Error ? err : new Error(String(err))).open();
-			});
-		});
-
 		const bytes = await this.app.vault.readBinary(file);
 
 		const viewer = container.createEl('supernote-viewer');
@@ -684,6 +666,28 @@ export class SupernoteView extends FileView {
 		}
 		this.viewerEl = viewer;
 		this.updateDarkAttribute();
+
+		// A real toolbar button, not a standalone element outside the
+		// component (an earlier version of this wrapper did that - a real,
+		// reported regression, since it no longer sat with the rest of the
+		// page-nav/mode/find controls the way it did in SupernoteView's own
+		// pre-web-component toolbar). <supernote-viewer> has no portable
+		// equivalent for this - it writes to an Obsidian vault - so it
+		// exposes a "toolbar-extra" slot instead of building export UI
+		// itself (see buildToolbar()'s own comment on that slot, and its
+		// header comment's "no save/export UI" v1 boundary). A plain
+		// light-DOM child of `viewer`, unaffected by the component
+		// rebuilding its own shadow-root toolbar on every note load - no
+		// re-adding needed beyond this one call per onLoadFile().
+		const exportPageBtn = viewer.createEl('button', {
+			text: 'Export',
+			attr: { type: 'button', slot: 'toolbar-extra', 'aria-label': 'Export current page as image' },
+		});
+		exportPageBtn.addEventListener('click', () => {
+			this.exportCurrentPageAsImage().catch((err: unknown) => {
+				new ErrorModal(this.app, err instanceof Error ? err : new Error(String(err))).open();
+			});
+		});
 
 		viewer.addEventListener('supernote-load', ((e: CustomEvent<{ pageIds: string[] }>) => {
 			this.pageIds = e.detail.pageIds;

--- a/src/render/sidebarList.test.ts
+++ b/src/render/sidebarList.test.ts
@@ -19,6 +19,30 @@ describe('buildSidebarList', () => {
         }
     });
 
+    it('tags each thumbnail img for dark-mode inversion when invertColorsWhenDark is set', () => {
+        // Confirmed as a real, reported bug (issue #192): thumbnails never
+        // inverted regardless of dark mode, since this class was never
+        // applied to them at all - only main page images got it (see
+        // noteRenderer.ts's own buildNotePagePlaceholders()).
+        const container = document.createElement('div');
+        const items = buildSidebarList(
+            container,
+            [{ label: '1' }, { label: '2' }],
+            { thumbnailAspectRatio: { width: 100, height: 200 }, invertColorsWhenDark: true },
+        );
+        for (const item of items) {
+            expect(item.imgEl.classList.contains('supernote-invert-dark')).toBe(true);
+        }
+    });
+
+    it('does not tag thumbnails for inversion when invertColorsWhenDark is omitted', () => {
+        const container = document.createElement('div');
+        const [item] = buildSidebarList(container, [{ label: '1' }], {
+            thumbnailAspectRatio: { width: 100, height: 200 },
+        });
+        expect(item.imgEl.classList.contains('supernote-invert-dark')).toBe(false);
+    });
+
     it('renders a plain label (no checkbox) when checkbox is omitted', () => {
         const container = document.createElement('div');
         const [item] = buildSidebarList(container, [{ label: 'Page 1' }], {

--- a/src/render/sidebarList.ts
+++ b/src/render/sidebarList.ts
@@ -49,6 +49,12 @@ export interface BuildSidebarListOptions {
     // doc comment) shares one native size.
     thumbnailAspectRatio: { width: number; height: number };
     onItemClick?: (index: number) => void;
+    // Tags each thumbnail <img> for dark-mode stroke inversion, same as a
+    // main page image (see noteRenderer.ts's own invertColorsWhenDark) -
+    // without this, a thumbnail's handwriting stayed uninverted regardless
+    // of the setting, since this class was never applied here at all
+    // (confirmed as a real, reported bug - issue #192).
+    invertColorsWhenDark?: boolean;
 }
 
 // Builds one item per entry in `items` and appends them to `container` -
@@ -84,6 +90,7 @@ export function buildSidebarList(
 
         const img = document.createElement('img');
         img.className = 'sidebar-list-thumb';
+        if (options.invertColorsWhenDark) img.classList.add('supernote-invert-dark');
         img.style.aspectRatio = `${width} / ${height}`;
         itemEl.appendChild(img);
 

--- a/src/webcomponent/SupernoteViewerElement.test.ts
+++ b/src/webcomponent/SupernoteViewerElement.test.ts
@@ -83,6 +83,32 @@ describe('<supernote-viewer>', () => {
         // test sets up.
     });
 
+    it('projects a light-DOM child slotted as toolbar-extra into the toolbar', async () => {
+        // Lets a host add its own controls (e.g. SupernoteView's "export
+        // current page as image" button in main.ts, which writes to an
+        // Obsidian vault - nothing this portable component can do itself)
+        // without needing an imperative "addToolbarButton()" API - see
+        // buildToolbar()'s own comment on this slot for the full
+        // rationale. Added *before* noteData is set, matching how a real
+        // host builds it (append once, right after creating the element),
+        // to confirm the slotted content survives the element's own
+        // subsequent build/render rather than only working if added after.
+        const el = createViewer();
+        const btn = document.createElement('button');
+        btn.slot = 'toolbar-extra';
+        btn.textContent = 'Export';
+        el.appendChild(btn);
+        document.body.appendChild(el);
+
+        const loaded = waitForEvent(el, 'supernote-load');
+        el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+        await loaded;
+
+        const slot = el.shadowRoot!.querySelector<HTMLSlotElement>('slot[name="toolbar-extra"]');
+        expect(slot).toBeTruthy();
+        expect(slot!.assignedElements()).toEqual([btn]);
+    });
+
     it('includes each page\'s own PAGEID in the supernote-load event, for a host resolving a same-named link-click', async () => {
         // A host embedding this component (e.g. SupernoteEmbed in main.ts)
         // knows its own file's name, which this component deliberately

--- a/src/webcomponent/SupernoteViewerElement.test.ts
+++ b/src/webcomponent/SupernoteViewerElement.test.ts
@@ -138,6 +138,7 @@ describe('<supernote-viewer>', () => {
         pagesEl.dispatchEvent(new Event('scroll'));
         await new Promise((resolve) => window.requestAnimationFrame(resolve));
         expect(el.shadowRoot!.querySelector('.page-indicator')?.textContent).toBe('1 / 2');
+        expect(el.currentPage).toBe(1);
 
         // Now page 2 is the one at the top instead (a real fast scroll
         // jumping straight past page 1, not an intermediate observer batch).
@@ -146,6 +147,34 @@ describe('<supernote-viewer>', () => {
         pagesEl.dispatchEvent(new Event('scroll'));
         await new Promise((resolve) => window.requestAnimationFrame(resolve));
         expect(el.shadowRoot!.querySelector('.page-indicator')?.textContent).toBe('2 / 2');
+        expect(el.currentPage).toBe(2);
+    });
+
+    it('currentPage is 0 before any note has loaded', () => {
+        const el = createViewer();
+        document.body.appendChild(el);
+        expect(el.currentPage).toBe(0);
+    });
+
+    it('textProcessor transforms recognized text shown in text mode, but not word-overlay/find-in-note\'s own index', async () => {
+        // See textProcessor's own doc comment: it only ever touches the
+        // rawText/textEl copy built in wrapPageStates(), not the separate
+        // word-overlay entries built from recognitionElements' own
+        // per-word boxes - a host substituting text (e.g. SupernoteView's
+        // custom-dictionary feature in main.ts) has no per-word
+        // substitution data, so find-in-note keeps matching the
+        // unprocessed OCR text even though recognized-text mode displays
+        // the processed version.
+        const el = createViewer();
+        el.textProcessor = (text) => text.toUpperCase();
+        document.body.appendChild(el);
+        const loaded = waitForEvent(el, 'supernote-load');
+        el.noteData = readFixture('rtr.note');
+        await loaded;
+
+        const textEl = el.shadowRoot!.querySelector('.page-text');
+        expect(textEl?.textContent).toBe(textEl?.textContent?.toUpperCase());
+        expect(textEl?.textContent?.length).toBeGreaterThan(0);
     });
 
     it('goToPage() forces that page to load immediately, once, idempotently', async () => {

--- a/src/webcomponent/SupernoteViewerElement.test.ts
+++ b/src/webcomponent/SupernoteViewerElement.test.ts
@@ -259,6 +259,25 @@ describe('<supernote-viewer>', () => {
             }
         });
 
+        it('tags thumbnail images for dark-mode inversion when invert-dark is set, same as main page images', async () => {
+            // Confirmed as a real, reported bug (issue #192): only main page
+            // images (buildNotePagePlaceholders() in noteRenderer.ts) got
+            // the supernote-invert-dark class - thumbnails never did, so
+            // they never inverted regardless of dark mode.
+            const el = createViewer();
+            el.setAttribute('invert-dark', '');
+            document.body.appendChild(el);
+            const loaded = waitForEvent(el, 'supernote-load');
+            el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+            await loaded;
+
+            const thumbs = el.shadowRoot!.querySelectorAll<HTMLImageElement>('.sidebar-list-thumb');
+            expect(thumbs).toHaveLength(2);
+            for (const thumb of Array.from(thumbs)) {
+                expect(thumb.classList.contains('supernote-invert-dark')).toBe(true);
+            }
+        });
+
         it('toggle button opens and closes the sidebar', async () => {
             const el = await createLoadedViewer();
             const toggleBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Toggle page thumbnails"]')!;

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -419,13 +419,21 @@ button[aria-pressed="true"] {
    same reason: without the :not([dark])/[dark="false"] guards, a
    light-themed host on a dark-OS system would still get its page images
    inverted underneath it, same bug as the border/background colors
-   above. */
+   above.
+
+   .sidebar-list-thumb.supernote-invert-dark alongside the main page image
+   selector - confirmed as a real, reported bug (issue #192): a thumbnail's
+   own <img> gets the same class (see sidebarList.ts's buildSidebarList())
+   but this rule originally only ever matched .pages' own page images, so
+   thumbnails never inverted regardless of dark mode. */
 @media (prefers-color-scheme: dark) {
-    :host(:not([dark])) .pages .page-container > img.supernote-invert-dark {
+    :host(:not([dark])) .pages .page-container > img.supernote-invert-dark,
+    :host(:not([dark])) .sidebar-list-thumb.supernote-invert-dark {
         filter: invert(1);
     }
 }
-:host([dark]:not([dark="false"])) .pages .page-container > img.supernote-invert-dark {
+:host([dark]:not([dark="false"])) .pages .page-container > img.supernote-invert-dark,
+:host([dark]:not([dark="false"])) .sidebar-list-thumb.supernote-invert-dark {
     filter: invert(1);
 }
 .status {
@@ -841,7 +849,7 @@ export class SupernoteViewerElement extends HTMLElement {
         this.setupPageLoadObserver(sn, states);
         if (pageCount > 1) {
             this.setupPageIndicatorTracking();
-            this.buildThumbSidebar(sn, pageCount);
+            this.buildThumbSidebar(sn, pageCount, invertColorsWhenDark);
         }
         this.setupOverlayResizing(sn, states);
     }
@@ -1140,7 +1148,7 @@ export class SupernoteViewerElement extends HTMLElement {
     // own viewport. Only built for pageCount > 1 (see buildToolbar()) -
     // nothing to navigate to via thumbnails on a single-page document
     // either.
-    private buildThumbSidebar(sn: SupernoteX, pageCount: number): void {
+    private buildThumbSidebar(sn: SupernoteX, pageCount: number, invertColorsWhenDark: boolean): void {
         const sidebar = document.createElement('div');
         sidebar.className = 'thumb-sidebar';
         sidebar.setAttribute('part', 'thumb-sidebar');
@@ -1151,6 +1159,7 @@ export class SupernoteViewerElement extends HTMLElement {
         this.thumbItems = buildSidebarList(sidebar, specs, {
             thumbnailAspectRatio: { width: sn.pageWidth, height: sn.pageHeight },
             onItemClick: (index) => this.goToPage(index + 1),
+            invertColorsWhenDark,
         });
 
         this.thumbLoadObserver = setupLazyListLoading(

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -147,6 +147,32 @@ button {
     padding: 0.2em 0.6em;
     cursor: pointer;
 }
+/* Lets each slotted node lay out as its own independent toolbar flex item
+   (same "display: contents on the wrapper" trick .supernote-toolbar-group
+   uses in main.ts's own styles.css, for the same reason: without it, the
+   <slot> element itself - not each of its assigned nodes - is the flex
+   item, so multiple host-provided buttons would wrap/space as one block
+   instead of individually). See the toolbar-extra slot below and its own
+   comment for what this is for. */
+.toolbar slot {
+    display: contents;
+}
+/* Styles a host's own <button slot="toolbar-extra"> to match this
+   toolbar's built-in buttons - light DOM content projected through a slot
+   doesn't inherit this shadow root's plain button rule above on its own;
+   ::slotted() is the mechanism for reaching in from here. Only matches
+   top-level slotted nodes, which is exactly the shape a host is expected
+   to provide - see buildToolbar()'s own comment on the "toolbar-extra"
+   slot for the full contract. */
+::slotted(button) {
+    font: inherit;
+    color: inherit;
+    background: transparent;
+    border: 1px solid var(--supernote-viewer-border);
+    border-radius: 4px;
+    padding: 0.2em 0.6em;
+    cursor: pointer;
+}
 button[aria-pressed="true"] {
     background: var(--supernote-viewer-muted);
     opacity: 0.3;
@@ -1333,6 +1359,26 @@ export class SupernoteViewerElement extends HTMLElement {
         findBtn.addEventListener('click', () => this.toggleFindBar());
         toolbar.appendChild(findBtn);
         this.findToggleBtn = findBtn;
+
+        // Lets a host add its own controls to this toolbar - e.g.
+        // SupernoteView's "export current page as image" button in
+        // main.ts, which has no portable equivalent here (it writes to an
+        // Obsidian vault) but still deserves a real toolbar button rather
+        // than being relegated to a standalone element outside the
+        // component (a real, reported regression when this component
+        // first replaced SupernoteView's own toolbar - see issue #183's
+        // SupernoteView-swap phase). A named <slot>, not a public
+        // "addToolbarButton()" method: slotted (light DOM) content is
+        // unaffected by this element being torn down and rebuilt on every
+        // note load (see teardownForRerender()/buildViewer()) - the host
+        // adds its <button slot="toolbar-extra"> once, as an ordinary
+        // child of <supernote-viewer> itself, and the browser keeps
+        // re-projecting it into whichever toolbar currently exists with no
+        // further coordination needed on either side. See ::slotted(button)
+        // above for the matching visual styling.
+        const extraSlot = document.createElement('slot');
+        extraSlot.name = 'toolbar-extra';
+        toolbar.appendChild(extraSlot);
 
         this.rootEl.appendChild(toolbar);
         this.toolbarEl = toolbar;

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -453,6 +453,16 @@ export class SupernoteViewerElement extends HTMLElement {
         return imageDataUrl;
     };
 
+    // Overridable hook applied to each page's raw recognized text before
+    // it's shown in recognized-text mode or indexed for find-in-note -
+    // identity by default. Exists for a host with its own text
+    // post-processing step that has no portable equivalent here (e.g.
+    // SupernoteView's own custom-dictionary substitution in main.ts,
+    // processSupernoteText() - reads plugin settings this component has
+    // no concept of). Left unset, this component's recognized-text mode
+    // shows sn.pages[i].text completely unprocessed.
+    textProcessor: (text: string) => string = (text) => text;
+
     private readonly rootEl: HTMLElement;
     private pagesEl: HTMLElement | null = null;
     private toolbarEl: HTMLElement | null = null;
@@ -467,7 +477,7 @@ export class SupernoteViewerElement extends HTMLElement {
     private debugLoopTimer?: number;
     private resizeObserver: ResizeObserver | null = null;
     private pageStates: ViewerPageState[] = [];
-    private currentPage = 0;
+    private currentPageIndex = 0;
     private pageIndicatorScrollScheduled = false;
     private mode: 'image' | 'text' = 'image';
     private sn: SupernoteX | null = null;
@@ -544,6 +554,19 @@ export class SupernoteViewerElement extends HTMLElement {
                 if (Number.isFinite(n)) this.goToPage(n);
             }
         }
+    }
+
+    // 1-indexed, matching goToPage()'s own convention - 0 before any note
+    // has loaded. Kept in sync by updateCurrentPageIndicator() (the same
+    // scroll-driven "what page is actually on screen" logic the toolbar's
+    // own page indicator reads), not just whatever goToPage() last jumped
+    // to - a host reading this after the user has since scrolled elsewhere
+    // gets the page actually on screen, not a stale jump target. Exposed
+    // for a host that needs "what page is the user looking at right now"
+    // for its own UI (e.g. SupernoteView's exportCurrentPageAsImage() in
+    // main.ts, which has no other way to know this from outside).
+    get currentPage(): number {
+        return this.pageStates.length === 0 ? 0 : this.currentPageIndex + 1;
     }
 
     // Scrolls to (1-indexed) `pageNumber` and forces that page's image to
@@ -757,7 +780,7 @@ export class SupernoteViewerElement extends HTMLElement {
         this.toolbarEl = null;
         this.pageIndicatorEl = null;
         this.modeToggleBtn = null;
-        this.currentPage = 0;
+        this.currentPageIndex = 0;
         this.pageIndicatorScrollScheduled = false;
         this.mode = 'image';
         this.sn = null;
@@ -873,7 +896,17 @@ export class SupernoteViewerElement extends HTMLElement {
 
         return placeholders.map((page) => {
             const notePage = sn.pages[page.pageNumber - 1];
-            const rawText = notePage?.text ?? '';
+            // textProcessor only ever touches this rawText/textEl copy, not
+            // the word-overlay entries built just below - those come from
+            // recognitionElements' own per-word boxes (buildWordOverlay()),
+            // an entirely separate representation of this page's text that
+            // a host's text-substitution hook (see textProcessor's own doc
+            // comment) has no way to touch per-word. Find-in-note therefore
+            // matches against the *unprocessed* OCR text even when
+            // recognized-text mode displays a processed version - a known,
+            // narrow inconsistency, not something this hook can close
+            // without per-word substitution data no host actually has.
+            const rawText = this.textProcessor(notePage?.text ?? '');
             const textEl = document.createElement('div');
             textEl.className = 'page-text';
             textEl.classList.toggle('empty', rawText.length === 0);
@@ -1062,7 +1095,7 @@ export class SupernoteViewerElement extends HTMLElement {
             }
         }
 
-        this.currentPage = current;
+        this.currentPageIndex = current;
         if (this.pageIndicatorEl) this.pageIndicatorEl.textContent = `${current + 1} / ${this.pageStates.length}`;
         this.highlightThumbnail(current);
     }
@@ -1253,7 +1286,7 @@ export class SupernoteViewerElement extends HTMLElement {
             prevBtn.setAttribute('part', 'button');
             prevBtn.setAttribute('aria-label', 'Previous page');
             prevBtn.textContent = '↑';
-            prevBtn.addEventListener('click', () => this.goToPage(this.currentPage));
+            prevBtn.addEventListener('click', () => this.goToPage(this.currentPageIndex));
             toolbar.appendChild(prevBtn);
 
             const indicator = document.createElement('span');
@@ -1268,7 +1301,7 @@ export class SupernoteViewerElement extends HTMLElement {
             nextBtn.setAttribute('part', 'button');
             nextBtn.setAttribute('aria-label', 'Next page');
             nextBtn.textContent = '↓';
-            nextBtn.addEventListener('click', () => this.goToPage(this.currentPage + 2));
+            nextBtn.addEventListener('click', () => this.goToPage(this.currentPageIndex + 2));
             toolbar.appendChild(nextBtn);
         }
 
@@ -1357,7 +1390,10 @@ export class SupernoteViewerElement extends HTMLElement {
         this.findBarEl = bar;
     }
 
-    private toggleFindBar(): void {
+    // Public so a host can wire its own hotkey to this (e.g. SupernoteView's
+    // Mod+F Scope registration in main.ts) without needing its own separate
+    // find-bar implementation.
+    toggleFindBar(): void {
         if (this.findBarEl?.classList.contains('open')) this.closeFindBar();
         else this.openFindBar();
     }

--- a/styles.css
+++ b/styles.css
@@ -18,121 +18,34 @@
     filter: invert(1);
 }
 
-.theme-dark canvas.supernote-invert-dark {
-    filter: invert(1);
-}
-
-.theme-light canvas.supernote-invert-light {
-    filter: invert(1);
-}
-
 .supernote-view-content button.mod-cta,
 .supernote-import-modal button.mod-cta {
     display: block;
 }
 
-div.page-container {
-    display: inline-block;
-    vertical-align: top;
-    margin: 1.2em;
-}
-
-/* Issue #148: 1.2em of margin on every side of every page is real, wasted
-   width on a small screen already tight for legibility of handwritten
-   content - a phone doesn't have the spare width a desktop window does.
-   Left alone elsewhere; SupernoteView.onOpen() reduces its own ancestor
-   .view-content padding the same way, scoped the same way. */
-body.is-mobile div.page-container {
-    margin: 0.3em;
-}
-
-div.supernote-canvas-wrap {
-    position: relative;
-    display: inline-block;
-    transform-origin: top left;
-}
-
-div.supernote-canvas-wrap canvas {
-    display: block;
-    max-width: 100%;
-}
-
-/* Mirrors pdf.js's own text_layer_builder.css: canvas carries the pixels,
-   this transparent layer carries selectable/searchable text on top of it.
-   pointer-events: none on the container (re-enabled per-span below) matters
-   beyond just this layer: without it, this fully covers every page's canvas
-   (position: absolute; inset: 0) and, being on top in paint order, would
-   swallow every mouse event anywhere on the page - including the canvas's
-   own manually-wired drag-out (see SupernoteView.onLoadFile()) - not just
-   clicks on an actual text span. */
-.textLayer {
-    position: absolute;
-    inset: 0;
+/* Same fix, same reason, as .internal-embed.supernote-embed further below
+   (SupernoteEmbed's own <supernote-viewer> sizing) - confirmed via real
+   headless-Obsidian testing to be the identical bug in this wrapper too:
+   without a flex column here and flex: 1; min-height: 0 on the viewer
+   itself, <supernote-viewer> rendered at its full (every-page) content
+   height instead of being clipped/scrollable at the pane's own height, so
+   nothing inside the component's shadow root ever needed to scroll
+   internally - goToPage()'s own .pages.scrollTo() call (and everything
+   built on real scroll/intersection behavior: lazy loading, eviction, the
+   scroll-driven page indicator) silently did nothing, since .pages was
+   never actually the container doing the scrolling. overflow: hidden, not
+   auto - the actual scrolling happens inside <supernote-viewer>'s own
+   shadow root; a second scrollbar here would just double up on the same
+   content. */
+.supernote-view-content {
+    display: flex;
+    flex-direction: column;
     overflow: hidden;
-    line-height: 1;
-    text-align: initial;
-    transform-origin: 0 0;
-    pointer-events: none;
 }
 
-.textLayer span,
-.textLayer br {
-    color: transparent;
-    position: absolute;
-    white-space: pre;
-    cursor: text;
-    transform-origin: 0% 0%;
-    pointer-events: auto;
-}
-
-.textLayer ::selection {
-    background: var(--text-selection);
-}
-
-.textLayer .supernote-find-match {
-    background: rgba(255, 224, 0, 0.4);
-    border-radius: 2px;
-}
-
-.textLayer .supernote-find-match-current {
-    background: rgba(255, 145, 0, 0.7);
-}
-
-/* Clickable overlay for Supernote internal links (see
-   SupernoteView.positionLinkOverlay() in main.ts). Sits above the text
-   layer; positioned/sized per-link via inline styles since geometry is
-   data-driven, same pattern as canvas/textLayer sizing. pointer-events: none
-   on the container (re-enabled on each link rect below) for the same reason
-   as .textLayer above - otherwise this, being topmost, would swallow every
-   mouse event on the page, not just clicks on an actual link. */
-.supernote-links-layer {
-    position: absolute;
-    inset: 0;
-    overflow: hidden;
-    pointer-events: none;
-}
-
-.supernote-link-rect {
-    position: absolute;
-    display: block;
-    border-radius: 2px;
-    cursor: pointer;
-    background: transparent;
-    transition: background-color 0.1s ease;
-    pointer-events: auto;
-}
-
-.supernote-link-rect:hover {
-    background: var(--background-modifier-hover);
-}
-
-.supernote-header {
-    position: sticky;
-    top: 0;
-    z-index: 10;
-    background: var(--background-primary);
-    padding-top: 0.5em;
-    padding-bottom: 0.5em;
+.supernote-view-content supernote-viewer {
+    flex: 1;
+    min-height: 0;
 }
 
 .supernote-toolbar {
@@ -165,189 +78,6 @@ div.supernote-canvas-wrap canvas {
 .supernote-file-list-toolbar {
     padding: 0.5em 0.75em 0;
     margin: 0;
-}
-
-.supernote-page-jump-input {
-    width: 4em;
-    text-align: center;
-}
-
-.supernote-page-jump-total {
-    color: var(--text-muted);
-}
-
-/* Text mode: hide the raster page (and its word-positioned, invisible
-   textLayer overlay - that one stays reserved for search-highlighting over
-   the image in image mode, see runFind()) in favor of .supernote-compact-text
-   below. */
-.supernote-mode-text .supernote-canvas-wrap {
-    display: none;
-}
-
-/* div.page-container above is display: inline-block, which shrink-to-fits
-   its content's width - fine in image mode, where canvasWrap always carries
-   an explicit pixel width (see drawPageImage()) for it to shrink-to-fit
-   *to*, identically on every page (same source page dimensions). Text mode
-   has no such explicit width anywhere in the chain, so that same
-   shrink-to-fit instead sized each page's box to whatever its own longest
-   line happened to need, up to .supernote-compact-text's max-width below -
-   a short page got a narrow box, a long one a wide one. Switching to
-   display: block for text mode's page-container stretches it to
-   .supernote-pages' own (flex-determined, so already page-count- and
-   content-independent) full width instead, giving the child's `width: 100%`
-   below something concrete and *uniform across every page* to resolve
-   against. */
-.supernote-mode-text .page-container {
-    display: block;
-}
-
-/* Compact text mode - see SupernoteView.ensureCompactText(). Reflowed plain
-   text in normal document flow (not positioned to match the original
-   handwriting layout, unlike .textLayer above), so selection/copy behaves
-   like any other text and a sparse page doesn't leave a huge blank gap.
-   Hidden outside text mode; sized independently of the page's own pixel
-   dimensions/aspect ratio, unlike canvasWrap/textLayer.
-
-   user-select: text is not the default and has to be opted into explicitly
-   - Obsidian sets `body { user-select: none; }` and only opts specific
-   elements it controls back in (its editor, markdown preview, its own PDF
-   viewer's .textLayer via `.pdf-container .textLayer`, which - being scoped
-   to .pdf-container - doesn't reach this plugin's own same-named .textLayer
-   either). Without this, the text renders exactly as intended but a drag
-   across it does nothing - confirmed via issue #171's own follow-up. */
-.supernote-compact-text {
-    display: none;
-    box-sizing: border-box;
-    width: 100%;
-    max-width: 42em;
-    padding: 1em 1.2em;
-    user-select: text;
-    -webkit-user-select: text;
-    cursor: text;
-    white-space: pre-wrap;
-    overflow-wrap: break-word;
-    color: var(--text-normal);
-    background: var(--background-primary);
-    border: 1px solid var(--background-modifier-border);
-    border-radius: var(--radius-s);
-}
-
-.supernote-compact-text-empty {
-    color: var(--text-muted);
-    font-style: italic;
-}
-
-/* Text mode's per-page marker (see the page-build loop in onLoadFile()) -
-   same muted/small treatment as .supernote-thumb-label and
-   .supernote-page-jump-total, so a long note's worth of stacked text blocks
-   in text mode still reads as distinct pages while scrolling. */
-.supernote-compact-text-label {
-    display: none;
-    margin: 0 0 0.3em;
-    color: var(--text-muted);
-    font-size: var(--font-smaller);
-    font-weight: var(--font-semibold);
-}
-
-.supernote-mode-text .supernote-compact-text,
-.supernote-mode-text .supernote-compact-text-label {
-    display: block;
-}
-
-.supernote-find-bar {
-    display: flex;
-    align-items: center;
-    gap: 0.5em;
-    padding: 0.4em;
-    background: var(--background-primary);
-    border: 1px solid var(--background-modifier-border);
-    border-radius: var(--radius-s);
-    width: fit-content;
-}
-
-.supernote-find-count {
-    min-width: 5em;
-    color: var(--text-muted);
-    font-size: var(--font-smaller);
-}
-
-/* Issue #179: .supernote-pages and .supernote-thumb-sidebar both sit in this
-   single grid cell (see grid-row/grid-column below) instead of splitting a
-   flex row between them. Previously, opening/closing the sidebar changed how
-   much of that row pagesEl got, which fit-width then re-rendered every page's
-   size against, reflowing the whole note and bouncing whatever page was
-   currently in view. Stacking them means pagesEl always gets the cell's full
-   width regardless of whether the sidebar is showing - it overlays pagesEl
-   instead of squeezing it. */
-.supernote-body {
-    display: grid;
-    grid-template-columns: 1fr;
-}
-
-.supernote-pages {
-    grid-column: 1;
-    grid-row: 1;
-    min-width: 0;
-}
-
-/* justify-self/align-self (not the old flex gap/align-items on .supernote-body)
-   position this within the shared grid cell - hugging the top-left corner,
-   same spot it occupied back when it was a flex sibling (it's built before
-   pagesEl in the DOM, so it landed first/left in that flex row). Still
-   position: sticky (unchanged from before this issue - that part already
-   worked, it's only the flex-row width-sharing that caused the bounce) so it
-   keeps tracking scroll the same way .supernote-header does. z-index lifts
-   it above pagesEl's own (unpositioned, z-index: auto) canvases so it
-   visibly overlays them rather than being painted underneath. */
-.supernote-thumb-sidebar {
-    display: flex;
-    grid-column: 1;
-    grid-row: 1;
-    justify-self: start;
-    align-self: start;
-    position: sticky;
-    z-index: 5;
-    flex-flow: column;
-    flex-shrink: 0;
-    width: 140px;
-    max-height: calc(100vh - 4em);
-    margin-left: 0.5em;
-    overflow-y: auto;
-    gap: 0.75em;
-    padding: 0.5em;
-    background: var(--background-secondary);
-    border: 1px solid var(--background-modifier-border);
-    border-radius: var(--radius-s);
-    box-shadow: var(--shadow-l);
-}
-
-.supernote-thumb-item {
-    cursor: pointer;
-    text-align: center;
-    padding: 0.25em;
-    border: 2px solid transparent;
-    border-radius: var(--radius-s);
-}
-
-.supernote-thumb-item:hover {
-    background: var(--background-modifier-hover);
-}
-
-.supernote-thumb-item.is-active {
-    border-color: var(--interactive-accent);
-}
-
-.supernote-thumb-img {
-    display: block;
-    width: 100%;
-    border-radius: 2px;
-}
-
-.supernote-thumb-label {
-    display: block;
-    margin-top: 0.25em;
-    color: var(--text-muted);
-    font-size: var(--font-smaller);
 }
 
 /* `.internal-embed.supernote-embed`, not just `.supernote-embed` alone -


### PR DESCRIPTION
## Summary

The final phase of porting `SupernoteView`'s features into the shared `<supernote-viewer>` web component (after zoom - #188, thumbnail sidebar - #189, find-in-note - #187, memory eviction - #190, link overlay - #191): `SupernoteView` is now a thin wrapper around `<supernote-viewer>`, mirroring the `SupernoteEmbed` unification exactly. Deletes ~1500 lines of now-redundant implementation: canvas drawing, zoom state/debouncing, thumbnail sidebar sync, `pageObserver`/lazy loading, the pdf.js text-layer/search machinery, and `PageRenderState`/`FindMatch` - all now handled once, inside the component.

**What stays** (genuinely Obsidian-only regardless of where rendering lives): the `FileView` lifecycle, the Mod+F `Scope` registration (now calling the component's own public `toggleFindBar()`), `setEphemeralState` (`#page=N` anchors, now calling `goToPage()` directly), the whole-note export buttons, `exportCurrentPageAsImage()`, and link-click navigation (now a shared `handleNoteLinkClick()` function - `SupernoteEmbed` had an identical copy of this logic, extracted rather than duplicated a third time).

**Two small additions to `<supernote-viewer>`'s public surface**, needed to keep this wrapper thin:
- `currentPage` getter (1-indexed) - `exportCurrentPageAsImage()` has no other way to know which page the user is looking at.
- `textProcessor` property (identity by default, same overridable-property pattern `rasterizePage` already uses) - lets `SupernoteView` apply the plugin's custom-dictionary substitution, which the component can't do itself (no concept of plugin settings). **Known limitation, documented in the property's own comment**: find-in-note still matches the *unprocessed* OCR text, so a dictionary substitution won't be found by searching for its replacement.

**One deliberate UI simplification**: the old per-page "Save image to vault" button has no equivalent in the component's v1-scoped toolbar (no per-page slot, and the component deliberately draws a "no save/export UI" line). The whole-note export buttons plus the always-present "Export current page as image" button cover the same use case.

**Also fixed**: a real bug this surfaced - `<supernote-viewer>` inside `.supernote-view-content` rendered at full content height instead of being clipped to the pane, since the wrapper never gave it a flex context to shrink into (the exact same bug already fixed once for `SupernoteEmbed` - see `.internal-embed.supernote-embed`'s own comment in `styles.css`). Without it, nothing inside the component ever needed to scroll internally, so `goToPage()` and everything built on real scroll behavior (lazy loading, eviction, link navigation) silently did nothing. Fixed identically (flex column + `flex: 1; min-height: 0`).

Also deletes the CSS this rewrite makes dead - double-checked against `SupernoteEmbed`, the `.spd` Atelier view, and `FileListModal` before removing anything (kept every class those still use).

## Test plan

- [x] `npm test` - 165/165 passing (2 new component-level tests for `currentPage`/`textProcessor`)
- [x] `npx tsc --noEmit` and `npx eslint .` clean
- [x] Both bundles build clean
- [x] Verified against a real headless-Obsidian instance:
  - Full view opens via the shared component (toolbar, thumbnails, find, all present)
  - "Export current page as image" creates a real vault file
  - Mod+F opens the find bar; thumbnail sidebar toggles
  - A `#page=N` link anchor jumps to the right page
  - A same-file internal link jumps within the view (no new tab)
  - A cross-file internal link opens the target note at the correct page
  - The `.spd` Atelier view's own shared toolbar/zoom-label CSS still renders correctly after cleanup


Fixes #192
