### PR TITLE
Add native Obsidian icons throughout SupernoteView's toolbar (#197)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { installAtPolyfill } from './polyfills';
-import { App, Modal, Notice, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, Component, Scope, Platform } from 'obsidian';
+import { App, Modal, Notice, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, Component, Scope, Platform, setIcon } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS, ImportFormat } from './settings';
 import { SupernoteX, ILink, RecognitionStatuses, fetchMirrorFrame, extractPdfPageData } from 'supernote-typescript';
 import { encode } from 'image-js';
@@ -679,10 +679,23 @@ export class SupernoteView extends FileView {
 		// light-DOM child of `viewer`, unaffected by the component
 		// rebuilding its own shadow-root toolbar on every note load - no
 		// re-adding needed beyond this one call per onLoadFile().
+		//
+		// Uses Obsidian's own icon set (setIcon(), Lucide), not the
+		// component's own inline-SVG icons (issue #197) - this button is
+		// SupernoteView's own addition, built entirely within Obsidian's
+		// context (unlike the component's toolbar, which has no Obsidian
+		// dependency and bakes its icons in for exactly that reason - see
+		// SupernoteViewerElement.ts's own icon* functions), so there's no
+		// portability reason not to use the real thing here. 'download',
+		// cls: 'clickable-icon' - same icon name and pattern this button
+		// had before the #183 web-component swap, and the same pattern
+		// SupernoteAtelierView's own toolbar buttons already use
+		// (atelierView.ts).
 		const exportPageBtn = viewer.createEl('button', {
-			text: 'Export',
+			cls: 'clickable-icon',
 			attr: { type: 'button', slot: 'toolbar-extra', 'aria-label': 'Export current page as image' },
 		});
+		setIcon(exportPageBtn, 'download');
 		exportPageBtn.addEventListener('click', () => {
 			this.exportCurrentPageAsImage().catch((err: unknown) => {
 				new ErrorModal(this.app, err instanceof Error ? err : new Error(String(err))).open();

--- a/src/main.ts
+++ b/src/main.ts
@@ -661,6 +661,15 @@ export class SupernoteView extends FileView {
 		// textProcessor's own doc comment (SupernoteViewerElement.ts) for
 		// the narrow find-in-note inconsistency this leaves.
 		viewer.textProcessor = (text) => processSupernoteText(text, this.settings);
+		// Obsidian's own icon set (setIcon()/Lucide) instead of the
+		// component's own baked-in inline SVGs - see iconRenderer's own
+		// doc comment (SupernoteViewerElement.ts) for why this is safe:
+		// the component picked its icon names to already equal Lucide's
+		// own, specifically so a host with a real icon system can wire
+		// this up with no translation table of its own (issue #197's
+		// original ask for the export button, extended here to the whole
+		// toolbar for full UX consistency with the rest of Obsidian).
+		viewer.iconRenderer = (name, el) => setIcon(el, name);
 		if (this.settings.invertColorsWhenDark) {
 			viewer.setAttribute('invert-dark', '');
 		}
@@ -940,6 +949,10 @@ export class SupernoteEmbed extends Component {
 		if (this.settings.invertColorsWhenDark) {
 			viewer.setAttribute('invert-dark', '');
 		}
+		// Obsidian's own icon set (setIcon()/Lucide), same as SupernoteView's
+		// identical assignment - see its own comment, and iconRenderer's
+		// doc comment in SupernoteViewerElement.ts, for why this is safe.
+		viewer.iconRenderer = (name, el) => setIcon(el, name);
 		this.viewerEl = viewer;
 		this.updateDarkAttribute();
 

--- a/src/webcomponent/SupernoteViewerElement.test.ts
+++ b/src/webcomponent/SupernoteViewerElement.test.ts
@@ -109,6 +109,49 @@ describe('<supernote-viewer>', () => {
         expect(slot!.assignedElements()).toEqual([btn]);
     });
 
+    describe('iconRenderer', () => {
+        it('falls back to a baked-in SVG icon when unset', async () => {
+            const el = createViewer();
+            document.body.appendChild(el);
+            const loaded = waitForEvent(el, 'supernote-load');
+            el.noteData = readFixture('nomad-3.26.40-blank-2p.note'); // 2 pages
+            await loaded;
+
+            const findBtn = el.shadowRoot!.querySelector('button[aria-label="Find in note"]')!;
+            expect(findBtn.querySelector('svg')).toBeTruthy();
+        });
+
+        it('calls a host-supplied renderer with the icon\'s canonical (Lucide-matching) name and the button element, instead of using the fallback', async () => {
+            // A host (e.g. SupernoteView/SupernoteEmbed in main.ts) wires
+            // this to Obsidian's own setIcon() for exact visual
+            // consistency with the rest of its UI - see iconRenderer's
+            // own doc comment for why IconName's values already equal
+            // Lucide's own icon names, so a real host needs no
+            // translation table, just `(name, el) => setIcon(el, name)`.
+            const el = createViewer();
+            const calls: Array<{ name: string; el: HTMLElement }> = [];
+            el.iconRenderer = (name, iconEl) => {
+                calls.push({ name, el: iconEl });
+                iconEl.textContent = `[${name}]`;
+            };
+            document.body.appendChild(el);
+            const loaded = waitForEvent(el, 'supernote-load');
+            el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+            await loaded;
+
+            const findBtn = el.shadowRoot!.querySelector('button[aria-label="Find in note"]')!;
+            expect(findBtn.querySelector('svg')).toBeNull();
+            expect(findBtn.textContent).toBe('[search]');
+            expect(calls.some((c) => c.name === 'search' && c.el === findBtn)).toBe(true);
+            expect(calls.some((c) => c.name === 'layout-list')).toBe(true);
+            expect(calls.some((c) => c.name === 'zoom-in')).toBe(true);
+            expect(calls.some((c) => c.name === 'zoom-out')).toBe(true);
+            expect(calls.some((c) => c.name === 'rotate-ccw')).toBe(true);
+            expect(calls.some((c) => c.name === 'stretch-horizontal')).toBe(true);
+            expect(calls.some((c) => c.name === 'type')).toBe(true);
+        });
+    });
+
     it('includes each page\'s own PAGEID in the supernote-load event, for a host resolving a same-named link-click', async () => {
         // A host embedding this component (e.g. SupernoteEmbed in main.ts)
         // knows its own file's name, which this component deliberately

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -56,37 +56,60 @@ function svgIcon(children: [string, Record<string, string>][]): SVGSVGElement {
     return svg;
 }
 
-function iconThumbnails(): SVGSVGElement {
-    return svgIcon([
+// Canonical names for every icon this component's own toolbar/find-bar
+// ever needs - chosen to equal real Lucide icon names (confirmed against
+// this codebase's own existing setIcon() call sites, e.g. atelierView.ts's
+// 'rotate-ccw'/'stretch-horizontal') wherever a matching Lucide icon
+// exists, specifically so a host that wants Obsidian's own icon set (see
+// iconRenderer below) can hand this straight to setIcon() with no
+// translation table of its own to maintain.
+type IconName =
+    | 'layout-list'
+    | 'type'
+    | 'search'
+    | 'chevron-left'
+    | 'chevron-right'
+    | 'x'
+    | 'zoom-out'
+    | 'zoom-in'
+    | 'rotate-ccw'
+    | 'stretch-horizontal';
+
+const FALLBACK_ICONS: Record<IconName, () => SVGSVGElement> = {
+    'layout-list': () => svgIcon([
         ['rect', { x: '3', y: '3', width: '18', height: '18', rx: '2' }],
         ['line', { x1: '9', y1: '3', x2: '9', y2: '21' }],
-    ]);
-}
-function iconTextMode(): SVGSVGElement {
-    return svgIcon([
+    ]),
+    'type': () => svgIcon([
         ['line', { x1: '4', y1: '6', x2: '20', y2: '6' }],
         ['line', { x1: '4', y1: '12', x2: '16', y2: '12' }],
         ['line', { x1: '4', y1: '18', x2: '12', y2: '18' }],
-    ]);
-}
-function iconSearch(): SVGSVGElement {
-    return svgIcon([
+    ]),
+    'search': () => svgIcon([
         ['circle', { cx: '11', cy: '11', r: '8' }],
         ['path', { d: 'm21 21-4.3-4.3' }],
-    ]);
-}
-function iconChevronLeft(): SVGSVGElement {
-    return svgIcon([['path', { d: 'M15 18l-6-6 6-6' }]]);
-}
-function iconChevronRight(): SVGSVGElement {
-    return svgIcon([['path', { d: 'M9 18l6-6-6-6' }]]);
-}
-function iconClose(): SVGSVGElement {
-    return svgIcon([
+    ]),
+    'chevron-left': () => svgIcon([['path', { d: 'M15 18l-6-6 6-6' }]]),
+    'chevron-right': () => svgIcon([['path', { d: 'M9 18l6-6-6-6' }]]),
+    'x': () => svgIcon([
         ['path', { d: 'M18 6 6 18' }],
         ['path', { d: 'M6 6l12 12' }],
-    ]);
-}
+    ]),
+    'zoom-out': () => svgIcon([['line', { x1: '5', y1: '12', x2: '19', y2: '12' }]]),
+    'zoom-in': () => svgIcon([
+        ['line', { x1: '12', y1: '5', x2: '12', y2: '19' }],
+        ['line', { x1: '5', y1: '12', x2: '19', y2: '12' }],
+    ]),
+    'rotate-ccw': () => svgIcon([
+        ['path', { d: 'M3 12a9 9 0 1 0 2.6-6.4' }],
+        ['path', { d: 'M3 4v5h5' }],
+    ]),
+    'stretch-horizontal': () => svgIcon([
+        ['path', { d: 'M8 3 4 7l4 4' }],
+        ['line', { x1: '4', y1: '7', x2: '20', y2: '7' }],
+        ['path', { d: 'M16 3l4 4-4 4' }],
+    ]),
+};
 
 interface ViewerPageState extends RenderedNotePage {
     textEl: HTMLElement;
@@ -249,12 +272,26 @@ button svg {
    ::slotted() is the mechanism for reaching in from here. Only matches
    top-level slotted nodes, which is exactly the shape a host is expected
    to provide - see buildToolbar()'s own comment on the "toolbar-extra"
-   slot for the full contract. */
+   slot for the full contract.
+
+   border: ... !important - confirmed via real headless-Obsidian testing
+   (getComputedStyle) that without it, a host button also carrying
+   Obsidian's own "clickable-icon" class (e.g. SupernoteView's export
+   button in main.ts, styled with setIcon() - see its own comment on why
+   that class is used there) rendered with no border at all: Obsidian's
+   own core CSS for that class sets border: none, and won out over this
+   rule despite ::slotted() living in this shadow root - the same class
+   of "Obsidian's own core CSS beats this component's styling" problem
+   .internal-embed.supernote-embed's own !important already exists to
+   solve elsewhere in this codebase (styles.css), just encountered here
+   from the opposite direction (a *light DOM* host element reaching
+   *into* a shadow root's own visual language, not the reverse). Scoped
+   to just this one property, not a blanket escape hatch. */
 ::slotted(button) {
     font: inherit;
     color: inherit;
     background: transparent;
-    border: 1px solid var(--supernote-viewer-border);
+    border: 1px solid var(--supernote-viewer-border) !important;
     border-radius: 4px;
     padding: 0.2em 0.6em;
     cursor: pointer;
@@ -637,6 +674,29 @@ export class SupernoteViewerElement extends HTMLElement {
     // no concept of). Left unset, this component's recognized-text mode
     // shows sn.pages[i].text completely unprocessed.
     textProcessor: (text: string) => string = (text) => text;
+
+    // Overridable hook for rendering a toolbar/find-bar icon into `el` -
+    // unset by default, in which case renderIcon() below falls back to
+    // this component's own baked-in inline SVGs (FALLBACK_ICONS above),
+    // needing no external icon set or Obsidian runtime at all. Exists so
+    // a host that already has a real icon system (e.g. Obsidian's own
+    // setIcon()/Lucide) can use it here too, for exact visual consistency
+    // with the rest of its own UI, instead of this component's
+    // necessarily-simpler baked-in icons - same overridable-property
+    // pattern rasterizePage/textProcessor above already use. `name` is
+    // one of IconName's own values, chosen to already equal the matching
+    // Lucide icon name wherever one exists (see IconName's own comment),
+    // so a host wiring this up to setIcon() needs no translation table:
+    // `viewer.iconRenderer = (name, el) => setIcon(el, name);` is enough.
+    iconRenderer?: (name: IconName, el: HTMLElement) => void;
+
+    private renderIcon(name: IconName, el: HTMLElement): void {
+        if (this.iconRenderer) {
+            this.iconRenderer(name, el);
+            return;
+        }
+        el.appendChild(FALLBACK_ICONS[name]());
+    }
 
     private readonly rootEl: HTMLElement;
     private pagesEl: HTMLElement | null = null;
@@ -1642,7 +1702,7 @@ export class SupernoteViewerElement extends HTMLElement {
             thumbBtn.setAttribute('part', 'button');
             thumbBtn.setAttribute('aria-label', 'Toggle page thumbnails');
             thumbBtn.setAttribute('aria-pressed', 'false');
-            thumbBtn.appendChild(iconThumbnails());
+            this.renderIcon('layout-list', thumbBtn);
             thumbBtn.addEventListener('click', () => this.toggleThumbSidebar());
             toolbar.appendChild(thumbBtn);
             this.thumbToggleBtn = thumbBtn;
@@ -1717,7 +1777,7 @@ export class SupernoteViewerElement extends HTMLElement {
         zoomOutBtn.type = 'button';
         zoomOutBtn.setAttribute('part', 'button');
         zoomOutBtn.setAttribute('aria-label', 'Zoom out');
-        zoomOutBtn.textContent = '−';
+        this.renderIcon('zoom-out', zoomOutBtn);
         zoomOutBtn.addEventListener('click', () => this.setZoom(this.zoomScale / 1.25));
         toolbar.appendChild(zoomOutBtn);
 
@@ -1732,7 +1792,7 @@ export class SupernoteViewerElement extends HTMLElement {
         zoomInBtn.type = 'button';
         zoomInBtn.setAttribute('part', 'button');
         zoomInBtn.setAttribute('aria-label', 'Zoom in');
-        zoomInBtn.textContent = '+';
+        this.renderIcon('zoom-in', zoomInBtn);
         zoomInBtn.addEventListener('click', () => this.setZoom(this.zoomScale * 1.25));
         toolbar.appendChild(zoomInBtn);
 
@@ -1740,7 +1800,7 @@ export class SupernoteViewerElement extends HTMLElement {
         zoomResetBtn.type = 'button';
         zoomResetBtn.setAttribute('part', 'button');
         zoomResetBtn.setAttribute('aria-label', 'Reset zoom');
-        zoomResetBtn.textContent = '↺';
+        this.renderIcon('rotate-ccw', zoomResetBtn);
         zoomResetBtn.addEventListener('click', () => this.setZoom(1));
         toolbar.appendChild(zoomResetBtn);
 
@@ -1749,7 +1809,7 @@ export class SupernoteViewerElement extends HTMLElement {
         fitWidthBtn.setAttribute('part', 'button');
         fitWidthBtn.setAttribute('aria-label', 'Fit page to viewport width');
         fitWidthBtn.setAttribute('aria-pressed', 'true'); // fitWidthEnabled defaults to true
-        fitWidthBtn.textContent = 'Fit';
+        this.renderIcon('stretch-horizontal', fitWidthBtn);
         fitWidthBtn.addEventListener('click', () => {
             this.fitWidthEnabled = !this.fitWidthEnabled;
             if (this.fitWidthEnabled) this.applyFitWidth();
@@ -1763,7 +1823,7 @@ export class SupernoteViewerElement extends HTMLElement {
         modeBtn.setAttribute('part', 'button');
         modeBtn.setAttribute('aria-label', 'Toggle recognized text view');
         modeBtn.setAttribute('aria-pressed', 'false');
-        modeBtn.appendChild(iconTextMode());
+        this.renderIcon('type', modeBtn);
         modeBtn.addEventListener('click', () => this.toggleMode());
         toolbar.appendChild(modeBtn);
         this.modeToggleBtn = modeBtn;
@@ -1773,7 +1833,7 @@ export class SupernoteViewerElement extends HTMLElement {
         findBtn.setAttribute('part', 'button');
         findBtn.setAttribute('aria-label', 'Find in note');
         findBtn.setAttribute('aria-pressed', 'false');
-        findBtn.appendChild(iconSearch());
+        this.renderIcon('search', findBtn);
         findBtn.addEventListener('click', () => this.toggleFindBar());
         toolbar.appendChild(findBtn);
         this.findToggleBtn = findBtn;
@@ -1833,7 +1893,7 @@ export class SupernoteViewerElement extends HTMLElement {
         prevBtn.type = 'button';
         prevBtn.setAttribute('part', 'button');
         prevBtn.setAttribute('aria-label', 'Previous match');
-        prevBtn.appendChild(iconChevronLeft());
+        this.renderIcon('chevron-left', prevBtn);
         prevBtn.addEventListener('click', () => this.stepFind(-1));
         bar.appendChild(prevBtn);
 
@@ -1841,7 +1901,7 @@ export class SupernoteViewerElement extends HTMLElement {
         nextBtn.type = 'button';
         nextBtn.setAttribute('part', 'button');
         nextBtn.setAttribute('aria-label', 'Next match');
-        nextBtn.appendChild(iconChevronRight());
+        this.renderIcon('chevron-right', nextBtn);
         nextBtn.addEventListener('click', () => this.stepFind(1));
         bar.appendChild(nextBtn);
 
@@ -1855,7 +1915,7 @@ export class SupernoteViewerElement extends HTMLElement {
         closeBtn.type = 'button';
         closeBtn.setAttribute('part', 'button');
         closeBtn.setAttribute('aria-label', 'Close find bar');
-        closeBtn.appendChild(iconClose());
+        this.renderIcon('x', closeBtn);
         closeBtn.addEventListener('click', () => this.closeFindBar());
         bar.appendChild(closeBtn);
 


### PR DESCRIPTION
## Summary

Issue #197: `SupernoteView`'s toolbar needed real icons for its find/export buttons - grew into a general mechanism while working through it, per direct feedback mid-session ("can we use the obsidian native icons if available? ... I want to use obsidian icons to keep ux consistent").

**`iconRenderer` hook**: `<supernote-viewer>` now exposes an overridable `iconRenderer` hook (same pattern as `rasterizePage`/`textProcessor`) that a host can set to render toolbar/find-bar icons via its own icon system instead of the component's own baked-in inline SVGs (from #195). Left unset, nothing changes - `renderIcon()` falls back to the existing SVGs, so a standalone/bare use with no Obsidian runtime is unaffected.

Icon names (`IconName`) were chosen to already equal real Lucide icon names wherever one exists, specifically so a host wiring this up needs no translation table:
```ts
viewer.iconRenderer = (name, el) => setIcon(el, name);
```
Both `SupernoteEmbed` and `SupernoteView` now set this, so every place `<supernote-viewer>` appears inside Obsidian gets real Lucide icons for full visual consistency with the rest of its UI.

**Zoom button icons**: adds icons for the four zoom buttons (zoom out/in, reset, fit width) - the same "plain text/symbol buttons" gap #195 already fixed for the rest of the toolbar, just not yet done for zoom (a separately-merged PR, #188, not part of #195's own scope at the time).

**Border bug fix**: the export button (host-provided, slotted into `toolbar-extra`, carrying Obsidian's own `clickable-icon` class) rendered with no border at all, unlike every other toolbar button - confirmed via `getComputedStyle` that Obsidian's own core CSS for that class sets `border: none` and won out over this component's `::slotted(button)` rule despite living inside its shadow root. Fixed with `!important` on just that property, the same narrow, deliberate pattern `.internal-embed.supernote-embed`'s own fix already uses elsewhere in this codebase for the identical class of problem.

## Test plan

- [x] `npm test` - 181/181 passing (2 new tests for `iconRenderer`'s own fallback and override behavior)
- [x] `npx tsc --noEmit` and `npx eslint .` clean
- [x] Both bundles build clean
- [x] Verified against a real headless-Obsidian instance: every toolbar button (thumbnails, zoom x4, mode toggle, find) now renders a real Lucide icon (confirmed via each SVG's own `lucide-*` class), the export button's border now matches every other button, and all buttons remain fully functional (export creates a real file, zoom actually zooms)