### PR TITLE
Fix multi-word find highlighting + text selection in SupernoteView (#199)

### DIFF
--- a/src/render/wordOverlay.test.ts
+++ b/src/render/wordOverlay.test.ts
@@ -133,6 +133,42 @@ describe('buildWordSearchText', () => {
         const { entryAt } = buildWordSearchText([]);
         expect(entryAt(0)).toBeUndefined();
     });
+
+    describe('entriesInRange', () => {
+        it('returns every entry a multi-word range overlaps, not just the one at its start', () => {
+            // Confirmed as a real, reported bug (issue #199): a caller that
+            // only ever looked up entryAt(range.start) - the shape
+            // runFind() used before this function existed - silently
+            // dropped every word after the first one a multi-word match
+            // spanned, e.g. only "With" out of a "With enough" match.
+            const container = document.createElement('div');
+            const page = fakePage([
+                {
+                    label: 'With enough space',
+                    type: 'Text',
+                    words: [
+                        { label: 'With', 'bounding-box': { x: 0, y: 0, width: 1, height: 1 } },
+                        { label: ' ' },
+                        { label: 'enough', 'bounding-box': { x: 0, y: 0, width: 1, height: 1 } },
+                        { label: ' ' },
+                        { label: 'space', 'bounding-box': { x: 0, y: 0, width: 1, height: 1 } },
+                    ],
+                },
+            ]);
+            const entries = buildWordOverlay(page, container, 1);
+            const { text, entriesInRange } = buildWordSearchText(entries);
+            expect(text).toBe('With enough space');
+
+            // "With enough" spans [0, 11).
+            const spanned = entriesInRange(0, 11);
+            expect(spanned.map((e) => e.label)).toEqual(['With', ' ', 'enough']);
+        });
+
+        it('returns an empty array for a range with no overlap', () => {
+            const { entriesInRange } = buildWordSearchText([]);
+            expect(entriesInRange(0, 5)).toEqual([]);
+        });
+    });
 });
 
 describe('repositionWordOverlay', () => {

--- a/src/render/wordOverlay.ts
+++ b/src/render/wordOverlay.ts
@@ -143,7 +143,11 @@ export function buildWordOverlay(page: IPage, container: HTMLElement, pageNumber
 // '\n'), individual whitespace/punctuation characters between words are
 // already present as their own boxless word entries in real recognition
 // data, so adding another separator here would double them up.
-export function buildWordSearchText(entries: WordOverlayEntry[]): { text: string; entryAt: (offset: number) => WordOverlayEntry | undefined } {
+export function buildWordSearchText(entries: WordOverlayEntry[]): {
+    text: string;
+    entryAt: (offset: number) => WordOverlayEntry | undefined;
+    entriesInRange: (start: number, end: number) => WordOverlayEntry[];
+} {
     let text = '';
     const ranges: { start: number; end: number; entry: WordOverlayEntry }[] = [];
 
@@ -158,7 +162,20 @@ export function buildWordSearchText(entries: WordOverlayEntry[]): { text: string
         return found?.entry;
     };
 
-    return { text, entryAt };
+    // Every entry a *multi-word* match's own [start, end) range overlaps,
+    // not just the single word at its start offset - entryAt() alone only
+    // ever finds the first word a match begins in, which is enough to
+    // scroll to, but silently drops every word after it from the caller's
+    // own view of "what did this match cover" (confirmed as a real,
+    // reported bug: a two-word search only highlighted its first word in
+    // image mode, since the caller was highlighting entryAt(match.start)
+    // alone). Half-open interval overlap (r.start < end && r.end > start),
+    // matching this module's own [start, end) convention throughout.
+    const entriesInRange = (start: number, end: number): WordOverlayEntry[] => {
+        return ranges.filter((r) => r.start < end && r.end > start).map((r) => r.entry);
+    };
+
+    return { text, entryAt, entriesInRange };
 }
 
 // Repositions every word span in `entries` to match the page's *currently

--- a/src/webcomponent/SupernoteViewerElement.test.ts
+++ b/src/webcomponent/SupernoteViewerElement.test.ts
@@ -849,6 +849,42 @@ describe('<supernote-viewer>', () => {
             expect(el.shadowRoot!.querySelector('.find-count')?.textContent).toBe('No results');
         });
 
+        it('a multi-word query highlights every word it spans, not just the first (issue #199)', async () => {
+            // Confirmed as a real, reported bug: searching "with enough"
+            // (present once in this fixture, in "With enough space a new
+            // paragraph") correctly reported "1 / 1" but only ever
+            // highlighted "With" - the first word in the match, via
+            // entryAt(match.start) alone - leaving "enough" unhighlighted
+            // even though the match genuinely spans both words. Works
+            // correctly in recognized-text mode already (a single <mark>
+            // wraps the whole [start, end) range there, not one span per
+            // word), which is why this was image-mode-only.
+            const el = await createLoadedViewer();
+            el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Find in note"]')!.click();
+            const input = el.shadowRoot!.querySelector<HTMLInputElement>('.find-bar input')!;
+
+            input.value = 'with enough';
+            input.dispatchEvent(new Event('input'));
+
+            expect(el.shadowRoot!.querySelector('.find-count')?.textContent).toBe('1 / 1');
+            const current = Array.from(el.shadowRoot!.querySelectorAll('.word-overlay-match-current'));
+            expect(current.map((s) => s.textContent)).toEqual(['With', 'enough']);
+        });
+
+        it('clears every word\'s highlight from a multi-word match, not just the first', async () => {
+            const el = await createLoadedViewer();
+            el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Find in note"]')!.click();
+            const input = el.shadowRoot!.querySelector<HTMLInputElement>('.find-bar input')!;
+
+            input.value = 'with enough';
+            input.dispatchEvent(new Event('input'));
+            expect(el.shadowRoot!.querySelectorAll('.word-overlay-match')).toHaveLength(2);
+
+            input.value = 'zzzznotfound';
+            input.dispatchEvent(new Event('input'));
+            expect(el.shadowRoot!.querySelectorAll('.word-overlay-match, .word-overlay-match-current')).toHaveLength(0);
+        });
+
         it('highlights matches with <mark> in recognized-text mode too', async () => {
             // Image-mode's word-overlay spans have nothing sensible to
             // overlay in text mode (the image is hidden entirely, and the

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -134,16 +134,26 @@ interface FindMatch {
     start: number;
     end: number;
     // The overlay span for the word the match started in - used for
-    // image-mode highlighting/scrolling. Always non-null (see runFind()):
-    // a match whose start landed on a boxless word is discarded rather than
-    // kept with a null entry, since text mode's <mark> highlighting still
-    // needs a real word to point to for image-mode's own highlight.
+    // image-mode scrolling (jump to where the match begins). Always
+    // non-null (see runFind()): a match whose start landed on a boxless
+    // word is discarded rather than kept with a null entry, since text
+    // mode's <mark> highlighting still needs a real word to point to for
+    // image-mode's own highlight.
     entry: WordOverlayEntry;
+    // Every overlay span the match's own [start, end) range overlaps, not
+    // just `entry` above - a multi-word match needs every word it covers
+    // highlighted, not only the one it starts in. Always includes `entry`
+    // itself (its own range overlaps [start, end) by definition). Confirmed
+    // as a real, reported bug: a two-word search previously only
+    // highlighted its first word in image mode, since only `entry` (via
+    // entryAt(start)) was ever marked.
+    entries: WordOverlayEntry[];
 }
 
 interface PageSearchEntry {
     lower: string;
     entryAt: (offset: number) => WordOverlayEntry | undefined;
+    entriesInRange: (start: number, end: number) => WordOverlayEntry[];
 }
 
 const STYLE = `
@@ -584,6 +594,18 @@ button[aria-pressed="true"] {
 .pages.mode-text .page-container {
     width: min(40em, 100%) !important;
 }
+/* user-select: text is not the default and has to be opted into
+   explicitly - Obsidian sets body { user-select: none; } and only opts
+   specific elements it controls back in (its editor, markdown preview,
+   its own PDF viewer's .textLayer). This element had never carried its
+   own explicit override at all (a real, reported regression: SupernoteView
+   in main.ts had it, via the compact-text-mode feature's own pre-#183
+   .supernote-compact-text rule, but it wasn't ported over when that mode
+   was rebuilt here) - it only happened to look selectable in an embed,
+   which inherits user-select: text from Obsidian's own markdown-preview
+   ancestor; SupernoteView's own .view-content is a different kind of view
+   entirely, with nothing re-enabling it, so text there inherited the
+   global default (none) instead. Confirmed via issue #199. */
 .pages .page-container > .page-text {
     display: none;
     white-space: pre-wrap;
@@ -592,6 +614,9 @@ button[aria-pressed="true"] {
     border-radius: 4px;
     max-width: 40em;
     box-sizing: border-box;
+    user-select: text;
+    -webkit-user-select: text;
+    cursor: text;
 }
 .pages.mode-text .page-container > .page-text {
     display: block;
@@ -1094,8 +1119,8 @@ export class SupernoteViewerElement extends HTMLElement {
         const states = this.wrapPageStates(sn, placeholders);
         this.pageStates = states;
         this.pageSearchIndex = states.map((state) => {
-            const { text, entryAt } = buildWordSearchText(state.wordEntries);
-            return { lower: text.toLowerCase(), entryAt };
+            const { text, entryAt, entriesInRange } = buildWordSearchText(state.wordEntries);
+            return { lower: text.toLowerCase(), entryAt, entriesInRange };
         });
 
         this.setupPageLoadObserver(sn, states);
@@ -1967,7 +1992,7 @@ export class SupernoteViewerElement extends HTMLElement {
         const q = query.trim().toLowerCase();
         if (q.length > 0) {
             for (let pageIndex = 0; pageIndex < this.pageSearchIndex.length; pageIndex++) {
-                const { lower, entryAt } = this.pageSearchIndex[pageIndex];
+                const { lower, entryAt, entriesInRange } = this.pageSearchIndex[pageIndex];
                 let from = 0;
                 for (;;) {
                     const idx = lower.indexOf(q, from);
@@ -1983,10 +2008,20 @@ export class SupernoteViewerElement extends HTMLElement {
                     // mode's <mark> highlighting only needs the offsets,
                     // but keeping one rule for what counts as a match, in
                     // both modes, is simpler than two).
-                    if (entry?.el) this.findMatches.push({ pageIndex, start: idx, end, entry });
+                    if (entry?.el) {
+                        // Every word the match spans, not just the one it
+                        // starts in - see FindMatch.entries' own comment.
+                        // Filtered to entries with a real span: a boxless
+                        // one (e.g. the space between two matched words)
+                        // has no element to add a highlight class to.
+                        const entries = entriesInRange(idx, end).filter((e) => e.el);
+                        this.findMatches.push({ pageIndex, start: idx, end, entry, entries });
+                    }
                 }
             }
-            for (const match of this.findMatches) match.entry.el!.classList.add('word-overlay-match');
+            for (const match of this.findMatches) {
+                for (const entry of match.entries) entry.el!.classList.add('word-overlay-match');
+            }
         }
 
         if (this.findMatches.length > 0) this.stepFind(1);
@@ -2004,13 +2039,14 @@ export class SupernoteViewerElement extends HTMLElement {
     private stepFind(delta: number): void {
         if (this.findMatches.length === 0) return;
 
-        this.findMatches[this.findMatchIndex]?.entry.el?.classList.remove('word-overlay-match-current');
+        const previous = this.findMatches[this.findMatchIndex];
+        if (previous) for (const entry of previous.entries) entry.el?.classList.remove('word-overlay-match-current');
 
         const n = this.findMatches.length;
         this.findMatchIndex = ((this.findMatchIndex + delta) % n + n) % n;
 
         const match = this.findMatches[this.findMatchIndex];
-        match.entry.el?.classList.add('word-overlay-match-current');
+        for (const entry of match.entries) entry.el?.classList.add('word-overlay-match-current');
         this.updateFindCount();
         this.renderPageTextHighlights();
         this.scrollToMatch(match);
@@ -2107,7 +2143,7 @@ export class SupernoteViewerElement extends HTMLElement {
 
     private clearFindHighlights(): void {
         for (const match of this.findMatches) {
-            match.entry.el?.classList.remove('word-overlay-match', 'word-overlay-match-current');
+            for (const entry of match.entries) entry.el?.classList.remove('word-overlay-match', 'word-overlay-match-current');
         }
     }
 


### PR DESCRIPTION
## Summary

Issue #199, both checkboxes:

**1. Multi-word find-in-note query only highlighted the first word it matched.** Confirmed against the real fixture: searching "with enough" in `rtr.note` correctly reported "1 / 1" (the match itself was found correctly) but only "With" ever got a `word-overlay-match`/`-current` class in image mode - "enough" stayed unhighlighted even though the match genuinely spanned both words. Recognized-text mode was never affected (a single `<mark>` wraps the whole range there, not one span per word), matching the report ("This does work in the compact text mode").

Root cause: `runFind()`'s highlighting (and `stepFind()`'s current-match toggle, and `clearFindHighlights()`) only ever touched `entryAt(match.start)` - the single word entry at the match's own starting offset - never anything after it.

Fixed by adding `entriesInRange(start, end)` to `buildWordSearchText()` (`wordOverlay.ts`) - returns every entry a range overlaps, not just the one at a single offset - and storing all of a match's own overlapping entries (`FindMatch.entries`) alongside the existing single `entry` (kept, still used for scrolling). All three highlighting call sites now iterate `match.entries`.

**2. Text wasn't selectable in `SupernoteView`'s recognized-text mode** (an embed showing the same content selected fine). `.page-text` had no `user-select` rule of its own at all - `SupernoteView`'s pre-#183 compact-text-mode feature had one, but it was never carried over when this mode was rebuilt for the shared component. It only ever looked selectable in an embed because embeds live inside Obsidian's own markdown-preview content, which already re-enables `user-select: text`; `SupernoteView`'s own `.view-content` is a different kind of view entirely, with nothing re-enabling it. Fixed by giving `.page-text` its own explicit `user-select: text` rule, matching the original.

## Test plan

- [x] `npm test` - 185/185 passing (4 new tests)
- [x] `npx tsc --noEmit` and `npx eslint .` clean
- [x] Both bundles build clean
- [x] Verified against real headless-Obsidian instances:
  - Searching "with enough" in the real `rtr.note` fixture now highlights both "With" and "enough" together (confirmed visually - orange highlight over both words in the actual handwriting)
  - Text in `SupernoteView`'s recognized-text mode is now genuinely drag-selectable (confirmed via a real mouse drag gesture producing an actual browser selection, not just a computed-style check)