### PR TITLE
Opt <supernote-viewer> out of Obsidian's mobile navigation gestures (#204)

### DIFF
--- a/src/webcomponent/SupernoteViewerElement.test.ts
+++ b/src/webcomponent/SupernoteViewerElement.test.ts
@@ -874,6 +874,74 @@ describe('<supernote-viewer>', () => {
         });
     });
 
+    describe('Obsidian host gesture opt-out (issue #204)', () => {
+        async function createLoadedViewer() {
+            const el = createViewer();
+            document.body.appendChild(el);
+            const loaded = waitForEvent(el, 'supernote-load');
+            el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+            await loaded;
+            return el;
+        }
+
+        function touchstart(target: HTMLElement) {
+            const touch = new Touch({ identifier: 1, target, clientX: 0, clientY: 0 });
+            target.dispatchEvent(new TouchEvent('touchstart', { touches: [touch], cancelable: true }));
+        }
+
+        it('sets data-ignore-swipe when scrolled below the top (blocks the palette-pull gesture)', async () => {
+            const el = await createLoadedViewer();
+            const rootEl = el.shadowRoot!.querySelector('.root') as HTMLElement;
+            const pagesEl = el.shadowRoot!.querySelector('.pages') as HTMLElement;
+            Object.defineProperty(pagesEl, 'scrollTop', { value: 500, configurable: true });
+
+            touchstart(rootEl);
+
+            expect(rootEl.dataset.ignoreSwipe).toBe('true');
+        });
+
+        it('clears data-ignore-swipe when at the very top and not horizontally scrollable', async () => {
+            const el = await createLoadedViewer();
+            const rootEl = el.shadowRoot!.querySelector('.root') as HTMLElement;
+            const pagesEl = el.shadowRoot!.querySelector('.pages') as HTMLElement;
+            Object.defineProperty(pagesEl, 'scrollTop', { value: 0, configurable: true });
+            Object.defineProperty(pagesEl, 'scrollWidth', { value: 400, configurable: true });
+            Object.defineProperty(pagesEl, 'clientWidth', { value: 400, configurable: true });
+
+            touchstart(rootEl);
+
+            expect(rootEl.hasAttribute('data-ignore-swipe')).toBe(false);
+        });
+
+        it('sets data-ignore-swipe when horizontally scrollable and not at an edge (blocks the sidebar-swipe gesture)', async () => {
+            const el = await createLoadedViewer();
+            const rootEl = el.shadowRoot!.querySelector('.root') as HTMLElement;
+            const pagesEl = el.shadowRoot!.querySelector('.pages') as HTMLElement;
+            Object.defineProperty(pagesEl, 'scrollTop', { value: 0, configurable: true });
+            Object.defineProperty(pagesEl, 'scrollWidth', { value: 1000, configurable: true });
+            Object.defineProperty(pagesEl, 'clientWidth', { value: 400, configurable: true });
+            Object.defineProperty(pagesEl, 'scrollLeft', { value: 300, configurable: true });
+
+            touchstart(rootEl);
+
+            expect(rootEl.dataset.ignoreSwipe).toBe('true');
+        });
+
+        it('sets data-ignore-swipe for horizontal overflow regardless of scroll position (no single "edge" - a sidebar swipe can go either way)', async () => {
+            const el = await createLoadedViewer();
+            const rootEl = el.shadowRoot!.querySelector('.root') as HTMLElement;
+            const pagesEl = el.shadowRoot!.querySelector('.pages') as HTMLElement;
+            Object.defineProperty(pagesEl, 'scrollTop', { value: 0, configurable: true });
+            Object.defineProperty(pagesEl, 'scrollWidth', { value: 1000, configurable: true });
+            Object.defineProperty(pagesEl, 'clientWidth', { value: 400, configurable: true });
+            Object.defineProperty(pagesEl, 'scrollLeft', { value: 0, configurable: true }); // at the left edge
+
+            touchstart(rootEl);
+
+            expect(rootEl.dataset.ignoreSwipe).toBe('true');
+        });
+    });
+
     describe('find in note', () => {
         async function createLoadedViewer() {
             const el = createViewer();

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -812,6 +812,8 @@ export class SupernoteViewerElement extends HTMLElement {
         this.rootEl.className = 'root';
         this.rootEl.setAttribute('part', 'root');
         shadow.appendChild(this.rootEl);
+
+        this.setupHostGestureOptOut();
     }
 
     // Raw note bytes, as an alternative to the `src` URL attribute - for
@@ -1703,6 +1705,16 @@ export class SupernoteViewerElement extends HTMLElement {
         this.pagesEl.addEventListener('touchcancel', endPinch);
     }
 
+    // Blocks the scroll-boundary "rubber band" bounce itself (the CSS/
+    // native overscroll animation) - a real, worthwhile fix for old WebKit
+    // in its own right (see this method's own comment), but NOT what
+    // actually stops Obsidian's own gesture recognizer from firing: that
+    // one lives entirely in Obsidian's own JS (see
+    // setupHostGestureOptOut() below, added for issue #204 after this fix
+    // alone turned out not to be enough - confirmed by testing directly,
+    // and by reading Obsidian's own app.js) and pays no attention to
+    // whether a touchmove's default was prevented at all.
+    //
     // Blocks the scroll-boundary "rubber band" that would otherwise chain
     // a pull gesture out to whatever's outside this element (issue #202):
     // inside Obsidian's mobile app shell, continuing to pull up past
@@ -1740,6 +1752,84 @@ export class SupernoteViewerElement extends HTMLElement {
             // otherwise rubber-band/chain outward.
             if ((atTop && deltaY > 0) || (atBottom && deltaY < 0)) evt.preventDefault();
         }, { passive: false });
+    }
+
+    // Opts this whole component out of Obsidian's own mobile navigation
+    // gestures - pull-down-to-open-command-palette and swipe-to-open-
+    // sidebar (issue #204, reported as still broken even after
+    // setupScrollBoundaryContainment() above) - confirmed by reading
+    // Obsidian's own app.js: both gestures are recognized by one shared
+    // generic swipe-detector registered on the whole workspace container,
+    // which walks a touch's ancestor chain via plain DOM `.parentElement`
+    // to decide whether some scrollable container already has room to
+    // consume the gesture instead (and if so, backs off - this is exactly
+    // how its own PDF viewer avoids the problem, since a PDF's scrollable
+    // container sits in the ordinary light DOM where that walk works
+    // fine). That walk cannot see past a shadow root at all -
+    // `Node.parentElement` (unlike `.parentNode`) is null for a shadow
+    // root's own top-level children once there's nowhere left to go
+    // *within* the shadow tree - so it can never discover that .pages,
+    // sitting inside *this* shadow root, is scrollable, and treats every
+    // drag here as a navigation gesture regardless of whether there's
+    // genuinely anything left to scroll.
+    //
+    // Obsidian's core does honor one specific escape hatch for exactly
+    // this situation: a touch's target chain (walked via `.parentNode`,
+    // which - unlike `.parentElement` - does keep ascending correctly up
+    // to a shadow root's own boundary) carrying a truthy
+    // `dataset.ignoreSwipe` anywhere along it makes the gesture recognizer
+    // bail out entirely for that touch, before it ever looks at
+    // scrollability at all. Toggled fresh on every touchstart (not left
+    // permanently on) so this only opts out while .pages genuinely still
+    // has relevant scroll room - once it doesn't, the attribute is cleared
+    // and Obsidian's own gesture takes over exactly as it would for its
+    // own exhausted PDF viewer (e.g. the command palette pull activating
+    // only once you've reached the first page).
+    private setupHostGestureOptOut(): void {
+        this.rootEl.addEventListener('touchstart', () => {
+            const pagesEl = this.pagesEl;
+            // A pull-down-to-open-palette gesture only ever needs
+            // *upward* scroll room (there's nowhere to "pull down into" -
+            // pulling down at the very top is the whole point of that
+            // gesture) - scrollTop > 0 means there's still a page above
+            // what's currently visible, so a downward drag here should
+            // just be an ordinary scroll up through the document, not a
+            // navigation gesture.
+            const blocksPalettePull = !!pagesEl && pagesEl.scrollTop > 0;
+            // A left/right swipe-to-open-sidebar gesture can go either
+            // direction, unlike the palette pull above (always downward) -
+            // so unlike scrollTop, there's no single "the only edge that
+            // matters" position to check here. Blocking any time .pages
+            // has *some* horizontal overflow at all, regardless of exactly
+            // where within it, is the simple, defensible line: relevant
+            // only once zoomed in past the point .pages overflows
+            // horizontally (see setZoom()) - in the far more common
+            // un-zoomed case scrollWidth shouldn't exceed clientWidth at
+            // all, so this shouldn't block the sidebar swipe needlessly,
+            // matching the reported "not in pdf view IF the pdf view is
+            // scrollable" framing exactly. A flat 50px tolerance, not a
+            // bare > 0 comparison - confirmed via real headless-Obsidian
+            // testing that .pages' own padding (see its CSS) alone leaves
+            // a real ~28px scrollWidth/clientWidth gap even at ordinary,
+            // un-zoomed fit-width sizing, which would otherwise trip this
+            // check on every single note and permanently block the
+            // sidebar swipe regardless of actual zoom level. 50px clears
+            // that gap with real margin while staying far below any
+            // genuinely zoomed-in overflow (hundreds of pixels once zoomed
+            // in far enough to matter).
+            const blocksSidebarSwipe = !!pagesEl && pagesEl.scrollWidth > pagesEl.clientWidth + 50;
+            // Obsidian's own check (see this method's own doc comment) is
+            // a plain truthiness test on `dataset.ignoreSwipe`, not an
+            // `!== undefined`/presence check - `toggleAttribute()` sets an
+            // *empty*-string attribute value when true, which reads back
+            // as `""` (falsy!) through `dataset`, silently defeating the
+            // whole opt-out. A real, literal "true" string is required -
+            // confirmed directly against Obsidian's own app.js, which sets
+            // exactly this same literal string on its own swipe-exempt
+            // elements (e.g. its range-slider input).
+            if (blocksPalettePull || blocksSidebarSwipe) this.rootEl.setAttribute('data-ignore-swipe', 'true');
+            else this.rootEl.removeAttribute('data-ignore-swipe');
+        }, { passive: true });
     }
 
     // While "Fit width" is on, keeps every page matched to however much


### PR DESCRIPTION
Addresses both checkboxes of #204.

## Checkbox 1: mobile navigation gestures misfiring during scroll
PR #203 fixed the CSS-level scroll-boundary rubber-band, but the actual report in #204 is that Obsidian's own navigation gestures (pull-down-to-open-command-palette, swipe-to-open-sidebar) still fire during ordinary scrolling. Reading Obsidian's own `app.js` directly confirmed why: both gestures are driven by one shared swipe-detector registered on the whole workspace container. It walks a touch's ancestor chain via plain `.parentElement` to check whether some scrollable container already has room to consume the gesture instead (exactly how its own PDF viewer avoids this problem - a PDF's scrollable container sits in ordinary light DOM, where that walk works fine). That walk can never see past a shadow root boundary, so it could never discover `.pages` (inside `<supernote-viewer>`'s own shadow root) is scrollable at all, and treated every drag here as a navigation gesture regardless of whether there was anything left to scroll.

Obsidian's core does honor one escape hatch for exactly this: a touch target carrying a truthy `dataset.ignoreSwipe` (checked via `.parentNode`, which - unlike `.parentElement` - does correctly ascend up to a shadow root's own boundary) makes the gesture recognizer bail out entirely for that touch. This PR toggles that attribute fresh on every `touchstart`, based on `.pages`' current scroll state - not left permanently on, so Obsidian's own gesture still takes over once there's genuinely nothing left to scroll, matching its own PDF viewer's "only once you've reached the first page" behavior described in the issue.

## Checkbox 2: search highlights inaccurate
Turned out to have nothing to do with mobile/Safari at all - reproduced identically in a plain desktop headless Chromium with no Obsidian involved, once loading a real A5X-family note (`a5x-2.14.28.note`) rather than the `rtr.note` fixture used everywhere else in this project's tests.

Root cause: `RECOGNITION_COORDINATE_SCALE` (`11.9`) was never a universal constant - it's specific to a 1920px-wide reference page (the Manta-family device; `SupernoteX`'s own `header.APPLY_EQUIPMENT === 'N5'` check special-cases to pageWidth 1920/pageHeight 2560, and every other device - including the far more common A5X family - defaults to 1404x1872). Applying the same fixed 11.9 to a narrower page overscales every box, and since the error is multiplicative (scales with each word's own native y), it's barely visible on the first line and lands a highlight on completely blank paper five lines down - exactly matching the original report ("highlighting a full page or more below where the word strokes are").

Confirmed empirically, not just by formula: rasterized a real A5X note, cropped the exact pixel region the old code computed for known words ("Subject", "Test", "Let", "been", "instance"), and compared against a scale proportional to pageWidth (`scale = pageWidth * 11.9 / 1920`) - the proportional formula lines up with the actual ink on every line; the fixed 11.9 drifts further off with each one. Also verified the reverse case: `rtr.note`'s own multi-line recognition element (three lines within one element) aligns perfectly at 11.9, ruling out a general multi-line-element bug and confirming this is specifically about `pageWidth`.

`buildWordOverlay()` now takes the note's own `pageWidth` and derives the scale from it instead of a hardcoded constant.

## Test plan
- [x] Unit tests: gesture opt-out attribute sets/clears correctly across mid-document/at-rest/zoomed-in states; recognized-word positioning tests for both the 1920px reference case and the narrower (1404px, A5X) case, including a real fixture-based regression test against `a5x-2.14.28.note`
- [x] Verified live against a real headless Obsidian instance: gesture opt-out attribute toggles correctly under real touch input in all three scroll scenarios; recognized-word highlight for "instance" (5 lines down a real A5X note, previously landing on completely blank paper) now lands exactly on the word
- [ ] `app.isMobile` is false in this desktop headless environment, so Obsidian's own gesture recognizer (gated on that flag) never actually attaches here - I could not observe the full end-to-end "command palette doesn't open" behavior, only that the escape-hatch attribute itself is set/cleared correctly at the right moments. Real mobile confirmation would need someone with that hardware.