### PR TITLE
Fix recognized-word highlight position for non-Manta devices (#204)

### DIFF
--- a/src/render/wordOverlay.test.ts
+++ b/src/render/wordOverlay.test.ts
@@ -25,7 +25,7 @@ describe('buildWordOverlay', () => {
         ]);
         const container = document.createElement('div');
 
-        const entries = buildWordOverlay(page, container, 1);
+        const entries = buildWordOverlay(page, container, 1, 1920);
 
         expect(entries).toHaveLength(1);
         expect(entries[0].label).toBe('Real');
@@ -35,18 +35,38 @@ describe('buildWordOverlay', () => {
         expect(entries[0].el!.textContent).toBe('Real');
     });
 
-    it('scales native bounding-box units by RECOGNITION_COORDINATE_SCALE (11.9)', () => {
+    it('scales native bounding-box units by 11.9 at the 1920px reference page width', () => {
         const page = fakePage([
             { label: 'x', type: 'Text', words: [{ label: 'x', 'bounding-box': { x: 10, y: 20, width: 30, height: 40 } }] },
         ]);
         const container = document.createElement('div');
 
-        const [entry] = buildWordOverlay(page, container, 1);
+        const [entry] = buildWordOverlay(page, container, 1, 1920);
 
         expect(entry.nativeX).toBeCloseTo(10 * 11.9);
         expect(entry.nativeY).toBeCloseTo(20 * 11.9);
         expect(entry.nativeWidth).toBeCloseTo(30 * 11.9);
         expect(entry.nativeHeight).toBeCloseTo(40 * 11.9);
+    });
+
+    it('scales proportionally to pageWidth, not a fixed 11.9, for narrower (non-Manta) devices (issue #204)', () => {
+        // Real, reported bug: notes from the far more common non-Manta
+        // device family (pageWidth 1404, e.g. an A5X) used the same fixed
+        // 11.9 scale tuned for Manta's 1920px-wide pages, landing
+        // recognized-word highlights increasingly far below the actual
+        // pen strokes the further down the page a word sat - confirmed by
+        // cropping the actual rendered page image at both the old and
+        // corrected positions against a real A5X note fixture.
+        const page = fakePage([
+            { label: 'x', type: 'Text', words: [{ label: 'x', 'bounding-box': { x: 10, y: 20, width: 30, height: 40 } }] },
+        ]);
+        const container = document.createElement('div');
+
+        const [entry] = buildWordOverlay(page, container, 1, 1404);
+
+        const expectedScale = (1404 * 11.9) / 1920;
+        expect(entry.nativeX).toBeCloseTo(10 * expectedScale);
+        expect(entry.nativeY).toBeCloseTo(20 * expectedScale);
     });
 
     it('keeps a word without a bounding box as a null-el entry rather than dropping it', () => {
@@ -62,7 +82,7 @@ describe('buildWordOverlay', () => {
         ]);
         const container = document.createElement('div');
 
-        const entries = buildWordOverlay(page, container, 1);
+        const entries = buildWordOverlay(page, container, 1, 1920);
 
         expect(entries.map((e) => e.label)).toEqual(['paragraph', ' ', 'test']);
         expect(entries[1].el).toBeNull();
@@ -75,7 +95,7 @@ describe('buildWordOverlay', () => {
         ]);
         const container = document.createElement('div');
 
-        expect(buildWordOverlay(page, container, 1)).toHaveLength(0);
+        expect(buildWordOverlay(page, container, 1, 1920)).toHaveLength(0);
     });
 });
 
@@ -93,7 +113,7 @@ describe('buildWordSearchText', () => {
                 ],
             },
         ]);
-        const entries = buildWordOverlay(page, container, 1);
+        const entries = buildWordOverlay(page, container, 1, 1920);
 
         const { text } = buildWordSearchText(entries);
 
@@ -113,7 +133,7 @@ describe('buildWordSearchText', () => {
                 ],
             },
         ]);
-        const entries = buildWordOverlay(page, container, 1);
+        const entries = buildWordOverlay(page, container, 1, 1920);
 
         const { text, entryAt } = buildWordSearchText(entries);
         expect(text).toBe('Real time');
@@ -155,7 +175,7 @@ describe('buildWordSearchText', () => {
                     ],
                 },
             ]);
-            const entries = buildWordOverlay(page, container, 1);
+            const entries = buildWordOverlay(page, container, 1, 1920);
             const { text, entriesInRange } = buildWordSearchText(entries);
             expect(text).toBe('With enough space');
 
@@ -175,7 +195,7 @@ describe('repositionWordOverlay', () => {
     it('scales native rects into the currently rendered CSS pixel size', () => {
         const container = document.createElement('div');
         const page = fakePage([{ label: 'x', type: 'Text', words: [{ label: 'x', 'bounding-box': { x: 10, y: 10, width: 10, height: 10 } }] }]);
-        const entries = buildWordOverlay(page, container, 1);
+        const entries = buildWordOverlay(page, container, 1, 1920);
         // native x/y/w/h are all 10 * 11.9 = 119
 
         repositionWordOverlay(entries, 238, 238, 238, 238); // rendered == native -> scale 1
@@ -206,7 +226,7 @@ describe('against a real .note fixture', () => {
         const page = sn.pages[0];
         const container = document.createElement('div');
 
-        const entries = buildWordOverlay(page, container, 1);
+        const entries = buildWordOverlay(page, container, 1, sn.pageWidth);
         expect(entries.length).toBeGreaterThan(0);
 
         const boxed = entries.filter((e) => e.el !== null);
@@ -240,9 +260,34 @@ describe('against a real .note fixture', () => {
         const page = sn.pages[0];
         const container = document.createElement('div');
 
-        const entries = buildWordOverlay(page, container, 1);
+        const entries = buildWordOverlay(page, container, 1, sn.pageWidth);
         const { text } = buildWordSearchText(entries);
 
         expect(text).toBe(page.text);
+    });
+
+    it('positions "Subject" within its own line on a real narrower (non-Manta, pageWidth 1404) note (issue #204)', () => {
+        // rtr.note above is a Manta-family capture (pageWidth 1920, where
+        // the 11.9 reference scale applies directly) - this fixture is the
+        // far more common non-Manta case (pageWidth 1404, e.g. an A5X)
+        // that exposed the bug: pixel-cropping the actual rendered page
+        // confirmed "Subject" (the note's first recognized word) should
+        // land at native y ~114-115 (13.224 native units * the correct
+        // ~8.70 scale for this pageWidth), not ~157 (the same native units
+        // * the wrong, Manta-tuned 11.9) - a difference that compounds
+        // with every line further down the page.
+        const a5xPath = path.join(import.meta.dirname, '..', '..', 'supernote-typescript', 'tests', 'input', 'a5x-2.14.28.note');
+        const buffer = fs.readFileSync(a5xPath);
+        const sn = new SupernoteX(new Uint8Array(buffer));
+        const page = sn.pages[0];
+        const container = document.createElement('div');
+
+        expect(sn.pageWidth).toBe(1404);
+        const entries = buildWordOverlay(page, container, 1, sn.pageWidth);
+        const subject = entries.find((e) => e.label === 'Subject');
+
+        expect(subject).toBeDefined();
+        const expectedScale = (1404 * 11.9) / 1920;
+        expect(subject!.nativeY).toBeCloseTo(13.224001 * expectedScale, 0);
     });
 });

--- a/src/render/wordOverlay.ts
+++ b/src/render/wordOverlay.ts
@@ -40,14 +40,31 @@ export interface WordOverlayEntry {
     nativeHeight: number;
 }
 
-// Empirically-verified constant used by Supernote's own recognition format:
-// recognized word bounding boxes are stored in raster-pixel units divided by
-// this factor. Mirrors supernote-typescript/src/pdf.ts's own copy of the
-// same constant (used there to embed these same words as invisible PDF
-// text) - duplicated rather than imported since supernote-typescript
-// doesn't currently export it as a standalone helper. If it's ever wrong,
-// fix both copies.
-const RECOGNITION_COORDINATE_SCALE = 11.9;
+// Recognized word bounding boxes are stored in raster-pixel units divided by
+// a scale factor - NOT a universal constant, confirmed via real device
+// files: 11.9 (this constant's own long-standing value, and
+// supernote-typescript/src/pdf.ts's identical copy - see that constant's
+// own comment) only holds for notes from Manta-family devices
+// (SupernoteX's own `header.APPLY_EQUIPMENT === 'N5'` check, pageWidth
+// 1920) - real-world testing against an A5X-family note (pageWidth 1404,
+// the *default* for every device other than Manta) found recognized-word
+// highlights landing up to a full page-height below the actual pen
+// strokes (issue #204's second checkbox), the error compounding with
+// distance down the page in exactly the way a wrong *multiplicative*
+// factor would, not a fixed offset.
+//
+// Cropping the actual rendered page image at the position each formula
+// predicts (not just eyeballing) confirmed the fix directly: 11.9 is
+// exactly right for a 1920px-wide page and only that page width -
+// scaling it down by the same ratio the actual page is narrower than
+// 1920 lines every word up tightly again on a 1404-wide (A5X) page.
+// I.e. the true constant is a *reference page width*, not a scale
+// factor: recognition coordinates are defined against a fixed
+// 1920/11.9 ≈ 161.34-unit-wide canvas, and need dividing by whatever
+// fraction of 1920px this particular note's own page actually is.
+function recognitionCoordinateScale(pageWidth: number): number {
+    return (pageWidth * 11.9) / 1920;
+}
 
 // Some recognition environments produce mojibake-looking labels that are
 // actually correctly-encoded UTF-8 bytes misinterpreted as Latin-1
@@ -87,9 +104,15 @@ function decodeRecognitionLabel(label: string): string {
 // buildWordSearchText), so silently skipping them here would make that
 // reconstruction lose spacing information a caller has no other way to
 // recover.
-export function buildWordOverlay(page: IPage, container: HTMLElement, pageNumber: number): WordOverlayEntry[] {
+export function buildWordOverlay(
+    page: IPage,
+    container: HTMLElement,
+    pageNumber: number,
+    pageWidth: number,
+): WordOverlayEntry[] {
     const entries: WordOverlayEntry[] = [];
     const textElements = page.recognitionElements.filter((element) => element.type === 'Text');
+    const scale = recognitionCoordinateScale(pageWidth);
 
     for (let elementIndex = 0; elementIndex < textElements.length; elementIndex++) {
         for (const word of textElements[elementIndex].words) {
@@ -112,10 +135,10 @@ export function buildWordOverlay(page: IPage, container: HTMLElement, pageNumber
                 pageNumber,
                 label,
                 el: span,
-                nativeX: box.x * RECOGNITION_COORDINATE_SCALE,
-                nativeY: box.y * RECOGNITION_COORDINATE_SCALE,
-                nativeWidth: box.width * RECOGNITION_COORDINATE_SCALE,
-                nativeHeight: box.height * RECOGNITION_COORDINATE_SCALE,
+                nativeX: box.x * scale,
+                nativeY: box.y * scale,
+                nativeWidth: box.width * scale,
+                nativeHeight: box.height * scale,
             });
         }
 

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -1245,7 +1245,7 @@ export class SupernoteViewerElement extends HTMLElement {
             // overlay is built and correctly positioned" a plain invariant
             // rather than something a caller needs to check the render mode
             // to reason about.
-            const wordEntries = notePage ? buildWordOverlay(notePage, page.containerEl, page.pageNumber) : [];
+            const wordEntries = notePage ? buildWordOverlay(notePage, page.containerEl, page.pageNumber, sn.pageWidth) : [];
 
             const linkEntries = buildLinkOverlay(linksByPage.get(page.pageNumber - 1) ?? [], page.containerEl);
             for (const entry of linkEntries) {


### PR DESCRIPTION
Addresses the second checkbox of #204 ("search highlights are not accurate on mobile"), which was left unresolved by #205 (merged before this fix was ready).

## Summary
Turned out to have nothing to do with mobile/Safari at all - reproduced identically in a plain desktop headless Chromium with no Obsidian involved, once loading a real A5X-family note (`a5x-2.14.28.note`) rather than the `rtr.note` fixture used everywhere else in this project's tests.

Root cause: `RECOGNITION_COORDINATE_SCALE` (`11.9`) was never a universal constant - it's specific to a 1920px-wide reference page (the Manta-family device; `SupernoteX`'s own `header.APPLY_EQUIPMENT === 'N5'` check special-cases to pageWidth 1920/pageHeight 2560, and every other device - including the far more common A5X family - defaults to 1404x1872). Applying the same fixed 11.9 to a narrower page overscales every box, and since the error is multiplicative (scales with each word's own native y), it's barely visible on the first line and lands a highlight on completely blank paper five lines down - exactly matching the original report ("highlighting a full page or more below where the word strokes are").

Confirmed empirically, not just by formula: rasterized a real A5X note, cropped the exact pixel region the old code computed for known words ("Subject", "Test", "Let", "been", "instance"), and compared against a scale proportional to pageWidth (`scale = pageWidth * 11.9 / 1920`) - the proportional formula lines up with the actual ink on every line; the fixed 11.9 drifts further off with each one. Also verified the reverse case: `rtr.note`'s own multi-line recognition element (three lines within one element) aligns perfectly at 11.9, ruling out a general multi-line-element bug and confirming this is specifically about `pageWidth`.

`buildWordOverlay()` now takes the note's own `pageWidth` and derives the scale from it instead of a hardcoded constant.

## Test plan
- [x] Unit tests for both the 1920px reference case and the narrower (1404px, A5X) case, including a real fixture-based regression test against `a5x-2.14.28.note`
- [x] Verified live against a real headless Obsidian instance: recognized-word highlight for "instance" (5 lines down a real A5X note, previously landing on completely blank paper) now lands exactly on the word
- [x] Full suite (196 tests), typecheck, and lint all pass