### PR TITLE
Fix gesture opt-out attribute placement: host, not shadow-internal (#204)

### DIFF
--- a/src/webcomponent/SupernoteViewerElement.test.ts
+++ b/src/webcomponent/SupernoteViewerElement.test.ts
@@ -889,6 +889,16 @@ describe('<supernote-viewer>', () => {
             target.dispatchEvent(new TouchEvent('touchstart', { touches: [touch], cancelable: true }));
         }
 
+        // The attribute belongs on the *host* element (`el` - what
+        // Obsidian's own retargeted event.target/targetNode actually
+        // resolves to from outside this shadow root), not `.root` inside
+        // the shadow root - see setupHostGestureOptOut()'s own doc comment
+        // for why the first version of this fix, checked here instead,
+        // passed every one of these tests yet still did nothing on a real
+        // device. The touchstart is still dispatched on `.root` (the
+        // listener itself lives there, and the touch still bubbles to it
+        // within the same shadow tree) - only the assertion target changed.
+
         it('sets data-ignore-swipe when scrolled below the top (blocks the palette-pull gesture)', async () => {
             const el = await createLoadedViewer();
             const rootEl = el.shadowRoot!.querySelector('.root') as HTMLElement;
@@ -897,7 +907,7 @@ describe('<supernote-viewer>', () => {
 
             touchstart(rootEl);
 
-            expect(rootEl.dataset.ignoreSwipe).toBe('true');
+            expect(el.dataset.ignoreSwipe).toBe('true');
         });
 
         it('clears data-ignore-swipe when at the very top and not horizontally scrollable', async () => {
@@ -910,7 +920,7 @@ describe('<supernote-viewer>', () => {
 
             touchstart(rootEl);
 
-            expect(rootEl.hasAttribute('data-ignore-swipe')).toBe(false);
+            expect(el.hasAttribute('data-ignore-swipe')).toBe(false);
         });
 
         it('sets data-ignore-swipe when horizontally scrollable and not at an edge (blocks the sidebar-swipe gesture)', async () => {
@@ -924,7 +934,7 @@ describe('<supernote-viewer>', () => {
 
             touchstart(rootEl);
 
-            expect(rootEl.dataset.ignoreSwipe).toBe('true');
+            expect(el.dataset.ignoreSwipe).toBe('true');
         });
 
         it('sets data-ignore-swipe for horizontal overflow regardless of scroll position (no single "edge" - a sidebar swipe can go either way)', async () => {
@@ -938,8 +948,22 @@ describe('<supernote-viewer>', () => {
 
             touchstart(rootEl);
 
-            expect(rootEl.dataset.ignoreSwipe).toBe('true');
+            expect(el.dataset.ignoreSwipe).toBe('true');
         });
+
+        // A test asserting the actual cross-shadow-boundary retargeting
+        // Obsidian's own listener depends on (dispatch inside the shadow
+        // root with composed: true, observe event.target from a listener
+        // on `document`, expect it to resolve to `el`) was tried here and
+        // dropped: happy-dom does not implement shadow DOM event
+        // retargeting at all (confirmed directly - a bare
+        // Event/EventTarget retargeting check against a minimal shadow
+        // host/inner-node pair, with no supernote-viewer involved at all,
+        // still failed), so it could never pass here regardless of
+        // whether the underlying fix is correct. The real-browser
+        // (Playwright/Chromium) verification for this fix lives in this
+        // session's own history, not as an automated test - happy-dom
+        // genuinely cannot exercise this specific DOM behavior.
     });
 
     describe('find in note', () => {

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -1756,16 +1756,16 @@ export class SupernoteViewerElement extends HTMLElement {
 
     // Opts this whole component out of Obsidian's own mobile navigation
     // gestures - pull-down-to-open-command-palette and swipe-to-open-
-    // sidebar (issue #204, reported as still broken even after
-    // setupScrollBoundaryContainment() above) - confirmed by reading
-    // Obsidian's own app.js: both gestures are recognized by one shared
-    // generic swipe-detector registered on the whole workspace container,
-    // which walks a touch's ancestor chain via plain DOM `.parentElement`
-    // to decide whether some scrollable container already has room to
-    // consume the gesture instead (and if so, backs off - this is exactly
-    // how its own PDF viewer avoids the problem, since a PDF's scrollable
-    // container sits in the ordinary light DOM where that walk works
-    // fine). That walk cannot see past a shadow root at all -
+    // sidebar (issue #204, reported as still broken on a real device even
+    // after this method's own first attempt - see below) - confirmed by
+    // reading Obsidian's own app.js: both gestures are recognized by one
+    // shared generic swipe-detector registered on the whole workspace
+    // container, which walks a touch's ancestor chain via plain DOM
+    // `.parentElement` to decide whether some scrollable container already
+    // has room to consume the gesture instead (and if so, backs off - this
+    // is exactly how its own PDF viewer avoids the problem, since a PDF's
+    // scrollable container sits in the ordinary light DOM where that walk
+    // works fine). That walk cannot see past a shadow root at all -
     // `Node.parentElement` (unlike `.parentNode`) is null for a shadow
     // root's own top-level children once there's nowhere left to go
     // *within* the shadow tree - so it can never discover that .pages,
@@ -1774,17 +1774,37 @@ export class SupernoteViewerElement extends HTMLElement {
     // genuinely anything left to scroll.
     //
     // Obsidian's core does honor one specific escape hatch for exactly
-    // this situation: a touch's target chain (walked via `.parentNode`,
-    // which - unlike `.parentElement` - does keep ascending correctly up
-    // to a shadow root's own boundary) carrying a truthy
+    // this situation: a touch's target chain carrying a truthy
     // `dataset.ignoreSwipe` anywhere along it makes the gesture recognizer
     // bail out entirely for that touch, before it ever looks at
-    // scrollability at all. Toggled fresh on every touchstart (not left
-    // permanently on) so this only opts out while .pages genuinely still
-    // has relevant scroll room - once it doesn't, the attribute is cleared
-    // and Obsidian's own gesture takes over exactly as it would for its
-    // own exhausted PDF viewer (e.g. the command palette pull activating
-    // only once you've reached the first page).
+    // scrollability at all. The chain it walks, though, starts at
+    // `event.targetNode` - confirmed, by extracting and reading Obsidian's
+    // own bundle directly, to be nothing more than a bare alias for
+    // `event.target` (defined once, in a small `enhance.js` bootstrap file
+    // shipped alongside app.js: `Object.defineProperty(UIEvent.prototype,
+    // "targetNode", {get: function(){return this.target}})`) - and
+    // `event.target`, for a touch that originates *inside* a shadow root,
+    // is retargeted (standard DOM behavior, for encapsulation) to the
+    // shadow *host* element for any listener sitting outside that root,
+    // exactly Obsidian's workspace-level listener here. This method's own
+    // first attempt set the attribute on `this.rootEl` - inside the shadow
+    // root - which the resulting `.parentNode` walk, starting from the
+    // *retargeted* (light-DOM, outside-the-shadow-root) node, can never
+    // reach at all: confirmed as the reason the first fix passed every
+    // test written against this component's own internals yet still did
+    // nothing on a real device, since nothing in that testing ever
+    // exercised a touch's target crossing back out through the shadow
+    // boundary the way Obsidian's own listener actually observes it. The
+    // attribute has to live on `this` (the shadow *host*, i.e. this
+    // element itself) - the one node every retargeted `event.target`
+    // still resolves to correctly - not anywhere inside the shadow root.
+    //
+    // Toggled fresh on every touchstart (not left permanently on) so this
+    // only opts out while .pages genuinely still has relevant scroll room
+    // - once it doesn't, the attribute is cleared and Obsidian's own
+    // gesture takes over exactly as it would for its own exhausted PDF
+    // viewer (e.g. the command palette pull activating only once you've
+    // reached the first page).
     private setupHostGestureOptOut(): void {
         this.rootEl.addEventListener('touchstart', () => {
             const pagesEl = this.pagesEl;
@@ -1827,8 +1847,13 @@ export class SupernoteViewerElement extends HTMLElement {
             // confirmed directly against Obsidian's own app.js, which sets
             // exactly this same literal string on its own swipe-exempt
             // elements (e.g. its range-slider input).
-            if (blocksPalettePull || blocksSidebarSwipe) this.rootEl.setAttribute('data-ignore-swipe', 'true');
-            else this.rootEl.removeAttribute('data-ignore-swipe');
+            //
+            // Set on `this` (the shadow host), not `this.rootEl` (inside
+            // the shadow root) - see this method's own doc comment for why
+            // the latter is invisible to Obsidian's own retargeted-target
+            // traversal.
+            if (blocksPalettePull || blocksSidebarSwipe) this.setAttribute('data-ignore-swipe', 'true');
+            else this.removeAttribute('data-ignore-swipe');
         }, { passive: true });
     }
 


### PR DESCRIPTION
Fixes a real bug in PR #205's gesture opt-out, reported by @philips as not working on a real iOS 26 device (iPhone 13) even though it passed every test at the time.

## Root cause
Extracted Obsidian's own app bundle (`obsidian.asar`) to trace this precisely. Obsidian's gesture recognizer reads a touch's target via `event.targetNode`, which a small bootstrap file (`enhance.js`) defines as nothing more than a bare alias:

```js
Object.defineProperty(UIEvent.prototype, "targetNode", { get: function() { return this.target } })
```

`event.target`, for a touch that originates *inside* a shadow root, gets **retargeted** to the shadow *host* element for any listener sitting *outside* that root - standard DOM behavior, for encapsulation. Obsidian's gesture recognizer is registered on the whole workspace container, entirely outside `<supernote-viewer>`'s shadow root - so when it walks `event.targetNode.parentNode` looking for `dataset.ignoreSwipe`, it starts at the *retargeted* node (`<supernote-viewer>` itself) and walks up through the light DOM. It never descends into the shadow root, so it never saw the attribute the previous fix set on `this.rootEl` (which lives inside the shadow root).

This also explains why the original fix passed every test: those tests only checked the attribute from *inside* the same shadow-root context, which never exercises the actual cross-boundary traversal Obsidian's own listener performs. `emulateMobile(true)` on desktop doesn't help debug this either, since `td.isMobile` gates whether Obsidian's listener even attaches at all, independent of this bug.

## Fix
Moved the attribute from `this.rootEl` to `this` (the custom element itself - the shadow host) - the one node a retargeted `event.target` still resolves to correctly.

## Test plan
- [x] Updated existing unit tests to check the attribute on the host element instead of the shadow-internal `.root`
- [x] Confirmed directly in a real Chromium DOM (not just this project's own happy-dom test suite, which doesn't implement shadow DOM event retargeting at all - confirmed that gap directly too): dispatching a composed touchstart deep inside the shadow root and observing it from a listener on `document` - mimicking exactly how Obsidian's own listener sees it - shows `dataset.ignoreSwipe` as `"true"` with this fix, `undefined` with the old placement
- [ ] Still can't verify the full end-to-end "command palette doesn't open" on a real device myself - would appreciate confirmation once this merges