### PR TITLE
Attempt: Range-header workaround for screen-mirror capture on mobile (#186)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1136,13 +1136,9 @@ export default class SupernotePlugin extends Plugin {
 					// its own. fetchMirrorFrameViaRange works around that with a Range
 					// header asking the device for just a bounded slice of the stream;
 					// see its own comment for what happens if the device ignores it.
-					//
-					// TEMPORARY (issue #186 testing): forced to always take the Range
-					// path, even on desktop, so it can be exercised against a real
-					// device from desktop instead of a mobile build. Revert to
-					// `Platform.isMobile ? ... : ...` once the Range approach is
-					// confirmed to work against real hardware.
-					const image = await fetchMirrorFrameViaRange(this.settings.directConnectIP);
+					const image = Platform.isMobile
+						? await fetchMirrorFrameViaRange(this.settings.directConnectIP)
+						: await fetchMirrorFrame(`${this.settings.directConnectIP}:8080`);
 
 					const file = await this.app.vault.createBinary(filename, encode(image).buffer as ArrayBuffer);
 					const path = this.app.workspace.activeEditor?.file?.path;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1136,9 +1136,13 @@ export default class SupernotePlugin extends Plugin {
 					// its own. fetchMirrorFrameViaRange works around that with a Range
 					// header asking the device for just a bounded slice of the stream;
 					// see its own comment for what happens if the device ignores it.
-					const image = Platform.isMobile
-						? await fetchMirrorFrameViaRange(this.settings.directConnectIP)
-						: await fetchMirrorFrame(`${this.settings.directConnectIP}:8080`);
+					//
+					// TEMPORARY (issue #186 testing): forced to always take the Range
+					// path, even on desktop, so it can be exercised against a real
+					// device from desktop instead of a mobile build. Revert to
+					// `Platform.isMobile ? ... : ...` once the Range approach is
+					// confirmed to work against real hardware.
+					const image = await fetchMirrorFrameViaRange(this.settings.directConnectIP);
 
 					const file = await this.app.vault.createBinary(filename, encode(image).buffer as ArrayBuffer);
 					const path = this.app.workspace.activeEditor?.file?.path;

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { ErrorModal } from './ErrorModal';
 import { PdfBuildWorkerMessage, PdfBuildWorkerResponse } from './pdfBuild.worker';
 import PdfBuildWorker from 'pdfBuild.worker';
 import { ImageConverter, terminateSharedWorkerPool } from './render/imageConverter';
+import { fetchMirrorFrameViaRange } from './mirrorFetch';
 // Side-effect import: registers <supernote-viewer> (customElements.define)
 // - see SupernoteEmbed below, which is now a thin wrapper around it rather
 // than its own separate rendering implementation.
@@ -1116,23 +1117,6 @@ export default class SupernotePlugin extends Plugin {
 			id: 'insert-screen-mirror-image',
 			name: 'Insert a screen mirroring image as attachment',
 			editorCallback: async (editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
-				// Screen mirroring is an indefinitely-open multipart MJPEG stream read
-				// with a raw `fetch()` + ReadableStream reader (see fetchMirrorFrame in
-				// supernote-typescript). Mobile Obsidian runs in a WKWebView, which
-				// blocks cross-origin fetch() to a plain-HTTP LAN device, and
-				// Obsidian's mobile-safe `requestUrl` alternative can't substitute here
-				// because it only resolves once the whole response body finishes -
-				// which for this stream never happens. Fail fast with an actionable
-				// message instead of attempting (and mysteriously failing) the request.
-				if (Platform.isMobile) {
-					new ErrorModal(this.app, new Error(
-						"Screen mirroring insert isn't supported on Obsidian mobile: it needs a continuous network "
-						+ "stream that mobile's WebView can't read. Use \"Browse and Access\" to insert a file "
-						+ "instead, or run this command on desktop."
-					)).open();
-					return;
-				}
-
 				// generate a unique filename for the mirror based on the current note path
 				const ts = generateTimestamp();
 				const f = this.app.workspace.activeEditor?.file?.basename || '';
@@ -1142,7 +1126,19 @@ export default class SupernotePlugin extends Plugin {
 					if (this.settings.directConnectIP.length == 0) {
 						throw new Error("IP is unset, please set in Supernote plugin settings")
 					}
-					const image = await fetchMirrorFrame(`${this.settings.directConnectIP}:8080`);
+					// Screen mirroring is normally an indefinitely-open multipart MJPEG
+					// stream read with a raw `fetch()` + ReadableStream reader (see
+					// fetchMirrorFrame in supernote-typescript). Mobile Obsidian runs in
+					// a WKWebView, which blocks cross-origin fetch() to a plain-HTTP LAN
+					// device, and Obsidian's mobile-safe `requestUrl` alternative can't
+					// substitute directly because it only resolves once the whole
+					// response body finishes - which for this stream never happens on
+					// its own. fetchMirrorFrameViaRange works around that with a Range
+					// header asking the device for just a bounded slice of the stream;
+					// see its own comment for what happens if the device ignores it.
+					const image = Platform.isMobile
+						? await fetchMirrorFrameViaRange(this.settings.directConnectIP)
+						: await fetchMirrorFrame(`${this.settings.directConnectIP}:8080`);
 
 					const file = await this.app.vault.createBinary(filename, encode(image).buffer as ArrayBuffer);
 					const path = this.app.workspace.activeEditor?.file?.path;

--- a/src/mirrorFetch.test.ts
+++ b/src/mirrorFetch.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { requestUrl } from 'obsidian';
+import { fetchMirrorFrameViaRange, MIRROR_RANGE_BYTES, MIRROR_TIMEOUT_MS } from './mirrorFetch';
+
+vi.mock('obsidian', () => ({
+	requestUrl: vi.fn(),
+}));
+
+vi.mock('supernote-typescript', () => ({
+	extractMjpegFrame: vi.fn(),
+}));
+
+// mirrorFetch.ts calls window.setTimeout/clearTimeout; vitest's default node
+// environment has no `window`, so alias it to the global timer functions.
+vi.stubGlobal('window', globalThis);
+
+function mockResponse(overrides: Partial<Awaited<ReturnType<typeof requestUrl>>> = {}) {
+	return {
+		status: 206,
+		headers: { 'Content-Type': 'multipart/x-mixed-replace; boundary=--BOUNDARY' },
+		arrayBuffer: new ArrayBuffer(0),
+		json: undefined,
+		text: '',
+		...overrides,
+	};
+}
+
+describe('fetchMirrorFrameViaRange', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+		vi.useRealTimers();
+	});
+
+	it('requests a bounded Range and returns the decoded frame', async () => {
+		const { extractMjpegFrame } = await import('supernote-typescript');
+		const fakeImage = { width: 1 } as never;
+		vi.mocked(extractMjpegFrame).mockReturnValue(fakeImage);
+		vi.mocked(requestUrl).mockResolvedValue(mockResponse());
+
+		const image = await fetchMirrorFrameViaRange('192.168.1.50');
+
+		expect(image).toBe(fakeImage);
+		expect(requestUrl).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: 'http://192.168.1.50:8080/screencast.mjpeg',
+				throw: false,
+				headers: { Range: `bytes=0-${MIRROR_RANGE_BYTES - 1}` },
+			}),
+		);
+	});
+
+	it('accepts a plain 200 response, not just 206 Partial Content', async () => {
+		const { extractMjpegFrame } = await import('supernote-typescript');
+		const fakeImage = { width: 1 } as never;
+		vi.mocked(extractMjpegFrame).mockReturnValue(fakeImage);
+		vi.mocked(requestUrl).mockResolvedValue(mockResponse({ status: 200 }));
+
+		await expect(fetchMirrorFrameViaRange('192.168.1.50')).resolves.toBe(fakeImage);
+	});
+
+	it('throws when no complete JPEG frame is found within the ranged bytes', async () => {
+		const { extractMjpegFrame } = await import('supernote-typescript');
+		vi.mocked(extractMjpegFrame).mockReturnValue(null);
+		vi.mocked(requestUrl).mockResolvedValue(mockResponse());
+
+		await expect(fetchMirrorFrameViaRange('192.168.1.50')).rejects.toThrow(
+			/didn't find a complete JPEG frame/,
+		);
+	});
+
+	it('throws on an unexpected status code', async () => {
+		vi.mocked(requestUrl).mockResolvedValue(mockResponse({ status: 404 }));
+
+		await expect(fetchMirrorFrameViaRange('192.168.1.50')).rejects.toThrow(
+			"Supernote's screen-mirror server returned status 404.",
+		);
+	});
+
+	it('reports an unreachable device distinctly from a timeout', async () => {
+		vi.mocked(requestUrl).mockRejectedValue(new Error('net::ERR_CONNECTION_REFUSED'));
+
+		await expect(fetchMirrorFrameViaRange('192.168.1.50')).rejects.toThrow(
+			'Could not reach Supernote at 192.168.1.50 (net::ERR_CONNECTION_REFUSED).',
+		);
+	});
+
+	describe('with fake timers', () => {
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+
+		it('gives up if the device ignores Range and keeps streaming past the timeout', async () => {
+			const pending = new Promise(() => { /* never resolves */ });
+			vi.mocked(requestUrl).mockReturnValue(Object.assign(pending, {
+				arrayBuffer: pending.then(() => new ArrayBuffer(0)),
+				json: pending.then(() => undefined),
+				text: pending.then(() => ''),
+			}) as ReturnType<typeof requestUrl>);
+
+			const assertion = expect(fetchMirrorFrameViaRange('192.168.1.50')).rejects.toThrow(
+				/doesn't appear to support partial \(Range\) requests/,
+			);
+			await vi.advanceTimersByTimeAsync(MIRROR_TIMEOUT_MS);
+			await assertion;
+		});
+	});
+});

--- a/src/mirrorFetch.ts
+++ b/src/mirrorFetch.ts
@@ -1,0 +1,75 @@
+import { requestUrl } from 'obsidian';
+import { extractMjpegFrame } from 'supernote-typescript';
+import type { Image } from 'image-js';
+
+// http://IP:8080/screencast.mjpeg is an indefinitely-open multipart MJPEG
+// stream (see fetchMirrorFrame in supernote-typescript) that only a raw
+// fetch() + ReadableStream reader can consume incrementally. That's
+// unavailable on Obsidian mobile's WKWebView (blocks cross-origin fetch to a
+// plain-HTTP LAN device) and unusable via requestUrl, which only resolves
+// once a response fully completes - something this stream never does on its
+// own.
+//
+// Instead, ask for just a bounded slice of the stream with a Range header.
+// If the Supernote's mirror server honors it, it returns a bounded 206 (or
+// closes the connection anyway at that many bytes) - something requestUrl
+// CAN resolve - and that's normally enough to contain one full JPEG frame.
+// If the server ignores Range and just keeps streaming past it, the timeout
+// below aborts the wait instead of hanging indefinitely; the underlying
+// native request may keep running, but nothing keeps waiting on it.
+export const MIRROR_RANGE_BYTES = 2 * 1024 * 1024;
+export const MIRROR_TIMEOUT_MS = 8000;
+
+function headerValue(headers: Record<string, string>, name: string): string | undefined {
+	const lower = name.toLowerCase();
+	const key = Object.keys(headers).find((k) => k.toLowerCase() === lower);
+	return key ? headers[key] : undefined;
+}
+
+export async function fetchMirrorFrameViaRange(ip: string): Promise<Image> {
+	let timeoutHandle: ReturnType<typeof window.setTimeout>;
+	const timeout = new Promise<never>((_, reject) => {
+		timeoutHandle = window.setTimeout(
+			() => reject(new DOMException('The operation timed out.', 'TimeoutError')),
+			MIRROR_TIMEOUT_MS,
+		);
+	});
+
+	let response;
+	try {
+		response = await Promise.race([
+			requestUrl({
+				url: `http://${ip}:8080/screencast.mjpeg`,
+				throw: false,
+				headers: { Range: `bytes=0-${MIRROR_RANGE_BYTES - 1}` },
+			}),
+			timeout,
+		]);
+	} catch (err) {
+		const name = (err as { name?: string } | null)?.name;
+		if (name === 'TimeoutError') {
+			throw new Error(
+				`Supernote at ${ip} didn't stop sending screen-mirror data within ${MIRROR_TIMEOUT_MS / 1000}s. `
+				+ `Its mirror server doesn't appear to support partial (Range) requests, which mobile capture `
+				+ `relies on, so this device/firmware may not support screen mirroring capture from mobile.`
+			);
+		}
+		throw new Error(`Could not reach Supernote at ${ip} (${err instanceof Error ? err.message : String(err)}).`);
+	} finally {
+		window.clearTimeout(timeoutHandle!);
+	}
+
+	if (response.status !== 200 && response.status !== 206) {
+		throw new Error(`Supernote's screen-mirror server returned status ${response.status}.`);
+	}
+
+	const contentType = headerValue(response.headers, 'content-type') ?? null;
+	const frame = extractMjpegFrame(new Uint8Array(response.arrayBuffer), contentType);
+	if (!frame) {
+		throw new Error(
+			`Received ${MIRROR_RANGE_BYTES} bytes from the screen-mirror stream but didn't find a complete `
+			+ `JPEG frame in it. The device may not support partial (Range) requests for this endpoint.`
+		);
+	}
+	return frame;
+}


### PR DESCRIPTION
## Summary

Attempts to fix #186 (screen mirroring capture failing on Obsidian mobile) by having the mobile path request a bounded slice of the mirror stream with a `Range` header instead of reading the full indefinite MJPEG stream. `requestUrl` (the only cross-origin-safe API on mobile) only resolves once a response fully completes, and the mirror endpoint's stream never completes on its own - the theory was that the Supernote's on-device mirror server would honor `Range` and close the connection early, giving `requestUrl` something to resolve.

## Result: doesn't work

Tested against real hardware (temporarily forcing the same Range-based path on desktop for faster iteration). The Supernote's screen-mirror server does not honor the `Range` header - the request just times out the same way an unbounded one would.

Closing without merging. Leaving this open as a historical record for #186 and for anyone else who considers the same approach: it's a dead end. Screen-mirror capture on Obsidian mobile appears to require either a single-frame snapshot endpoint on the device side (not currently offered) or a streaming-capable native networking API from Obsidian (not currently offered) - neither of which this plugin can work around on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)