### PR TITLE
Add SVG export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This plugin has seven main features:
 
 - 🔗 Embed a note inline in another note with `![[example.note]]` (scrollable, with page nav), or just one page with `![[example.note#page=2]]`.
 
-- ➡️  Export Supernote `*.note` files as PNGs and/or markdown files and attach them to your Vault.
+- ➡️  Export Supernote `*.note` files as PNGs, SVGs, PDFs and/or markdown files and attach them to your Vault.
 
 - 🧠 Attach all of today's modified Supernote notes and text to the current Obsidian note with the "Import notes edited today" command (great when paired with [daily notes](https://obsidian.md/help/plugins/daily-notes))
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { installAtPolyfill } from './polyfills';
 import { App, Modal, Notice, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, Component, Scope, Platform, setIcon } from 'obsidian';
-import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS, ImportFormat } from './settings';
-import { SupernoteX, ILink, RecognitionStatuses, fetchMirrorFrame, extractPdfPageData } from 'supernote-typescript';
+import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS, ImportFormat, PageExportImageFormat } from './settings';
+import { SupernoteX, ILink, RecognitionStatuses, fetchMirrorFrame, extractPdfPageData, addSvgPage } from 'supernote-typescript';
 import { encode } from 'image-js';
 import { DownloadListModal, UploadListModal } from './FileListModal';
 import { ImportTodayModal } from './ImportTodayModal';
@@ -50,6 +50,18 @@ function dataUrlToBuffer(dataUrl: string): ArrayBuffer {
 // "data:image/png;base64,..." -> "image/png"
 function dataUrlMimeType(dataUrl: string): string {
     return dataUrl.slice('data:'.length, dataUrl.indexOf(';'));
+}
+
+// Builds one standalone SVG document for a single already-rasterized page,
+// reusing the same PNG bytes ImageConverter produced (rather than
+// re-rasterizing via supernote-typescript's own toSvg(), which would decode
+// the page a second time) and extractPdfPageData() for the recognized-text
+// overlay, the same source addPdfPage()/buildPdfInWorker() draw their own
+// invisible text layer from.
+function buildSvgForPage(sn: SupernoteX, pageNumber: number, imageDataUrl: string): string {
+    const { pageWidth, pageHeight, pages } = extractPdfPageData(sn, pageNumber);
+    const pngBytes = new Uint8Array(dataUrlToBuffer(imageDataUrl));
+    return addSvgPage(pages[0], pngBytes, pageWidth, pageHeight);
 }
 
 // app.fileManager.generateMarkdownLink() follows the vault's "Use Wikilinks"
@@ -361,6 +373,20 @@ class VaultWriter {
 		return imgs;
 	}
 
+	// SVG equivalent of writeImageFiles() — same already-rasterized `images`
+	// input, but each page is wrapped into a standalone SVG document (see
+	// buildSvgForPage()) rather than saved as a raw PNG. SVG is text, not
+	// binary, so this uses vault.create() rather than createBinary().
+	async writeSvgFiles(basename: string, sn: SupernoteX, images: string[]): Promise<TFile[]> {
+		const imgs: TFile[] = [];
+		for (let i = 0; i < images.length; i++) {
+			const svg = buildSvgForPage(sn, i + 1, images[i]);
+			const filename = await this.app.fileManager.getAvailablePathForAttachment(`${basename}-${i + 1}.svg`);
+			imgs.push(await this.app.vault.create(filename, svg));
+		}
+		return imgs;
+	}
+
 	async attachMarkdownFile(file: TFile) {
 		const note = await this.app.vault.readBinary(file);
 		const sn = new SupernoteX(new Uint8Array(note));
@@ -379,6 +405,17 @@ class VaultWriter {
 
 		const images = await this.rasterizePages(sn);
 		const imgs = await this.writeImageFiles(file.basename, images);
+		const mdFile = await this.writeMarkdownFile(file, sn, imgs, images);
+		this.notifyExportComplete(mdFile);
+	}
+
+	// SVG equivalent of attachNoteFiles() — see writeSvgFiles().
+	async attachNoteFilesAsSvg(file: TFile) {
+		const note = await this.app.vault.readBinary(file);
+		const sn = new SupernoteX(new Uint8Array(note));
+
+		const images = await this.rasterizePages(sn);
+		const imgs = await this.writeSvgFiles(file.basename, sn, images);
 		const mdFile = await this.writeMarkdownFile(file, sn, imgs, images);
 		this.notifyExportComplete(mdFile);
 	}
@@ -706,7 +743,7 @@ export class SupernoteView extends FileView {
 		});
 		setIcon(exportPageBtn, 'download');
 		exportPageBtn.addEventListener('click', () => {
-			this.exportCurrentPageAsImage().catch((err: unknown) => {
+			this.exportCurrentPageAsImage(this.settings.pageExportImageFormat).catch((err: unknown) => {
 				new ErrorModal(this.app, err instanceof Error ? err : new Error(String(err))).open();
 			});
 		});
@@ -746,16 +783,18 @@ export class SupernoteView extends FileView {
 	}
 
 	// Exports the page currently on screen (viewerEl.currentPage, kept up to
-	// date by the component's own scroll-driven page indicator) as a PNG
-	// attachment - the single-page equivalent of the whole-note export
+	// date by the component's own scroll-driven page indicator) as a PNG or
+	// SVG attachment - the single-page equivalent of the whole-note export
 	// buttons above, for when the user only wants the page they're looking
-	// at right now rather than the whole note. Exposed as a command (see
-	// 'export-current-page-as-image') and the toolbar button above.
+	// at right now rather than the whole note. Exposed as commands (see
+	// 'export-current-page-as-image'/'export-current-page-as-svg') and the
+	// toolbar button above, which passes settings.pageExportImageFormat
+	// rather than a hardcoded format.
 	// Independently re-reads and rasterizes just this one page rather than
 	// reaching into the live <supernote-viewer>'s own internal state -
 	// mirrors how VaultWriter's own export methods already read+convert
 	// independently of whatever's currently displayed.
-	async exportCurrentPageAsImage(): Promise<void> {
+	async exportCurrentPageAsImage(format: PageExportImageFormat = 'png'): Promise<void> {
 		if (!this.viewerEl || this.viewerEl.currentPage === 0) return;
 		const pageNumber = this.viewerEl.currentPage;
 
@@ -763,8 +802,15 @@ export class SupernoteView extends FileView {
 		const sn = new SupernoteX(new Uint8Array(note));
 		const [imageDataUrl] = await new ImageConverter().convertToImages(sn, [pageNumber]);
 
-		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${this.file.basename}-page-${pageNumber}.png`);
-		const savedFile = await this.app.vault.createBinary(filename, dataUrlToBuffer(imageDataUrl));
+		let savedFile: TFile;
+		if (format === 'svg') {
+			const svg = buildSvgForPage(sn, pageNumber, imageDataUrl);
+			const filename = await this.app.fileManager.getAvailablePathForAttachment(`${this.file.basename}-page-${pageNumber}.svg`);
+			savedFile = await this.app.vault.create(filename, svg);
+		} else {
+			const filename = await this.app.fileManager.getAvailablePathForAttachment(`${this.file.basename}-page-${pageNumber}.png`);
+			savedFile = await this.app.vault.createBinary(filename, dataUrlToBuffer(imageDataUrl));
+		}
 
 		// Same "click to open" completion notice as VaultWriter's exports
 		// (see notifyExportComplete(), issue #167 / PR #175).
@@ -1183,6 +1229,31 @@ export default class SupernotePlugin extends Plugin {
 		});
 
 		this.addCommand({
+			id: 'export-note-as-svg-files',
+			name: 'Export this note as a Markdown and SVG files as attachments',
+			checkCallback: (checking: boolean) => {
+				const file = this.app.workspace.getActiveFile();
+				const ext = file?.extension;
+
+				if (ext === "note") {
+					if (checking) {
+						return true
+					}
+					if (!file) {
+						new ErrorModal(this.app, new Error("No file to attach")).open();
+					} else {
+						vw.attachNoteFilesAsSvg(file).catch((err: unknown) => {
+							new ErrorModal(this.app, err instanceof Error ? err : new Error(String(err))).open();
+						});
+					}
+					return true;
+				}
+
+				return false;
+			},
+		});
+
+		this.addCommand({
 			id: 'export-note-as-pdf',
 			name: 'Export this note as PDF',
 			checkCallback: (checking: boolean) => {
@@ -1291,6 +1362,21 @@ export default class SupernotePlugin extends Plugin {
 				if (checking) return true;
 
 				view.exportCurrentPageAsImage().catch((err: unknown) => {
+					new ErrorModal(this.app, err instanceof Error ? err : new Error(String(err))).open();
+				});
+				return true;
+			},
+		});
+
+		this.addCommand({
+			id: 'export-current-page-as-svg',
+			name: 'Export current page as SVG attachment',
+			checkCallback: (checking: boolean) => {
+				const view = this.app.workspace.getActiveViewOfType(SupernoteView);
+				if (!view) return false;
+				if (checking) return true;
+
+				view.exportCurrentPageAsImage('svg').catch((err: unknown) => {
 					new ErrorModal(this.app, err instanceof Error ? err : new Error(String(err))).open();
 				});
 				return true;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -24,6 +24,13 @@ export const IMPORT_FORMAT_LABELS: Record<ImportFormat, string> = {
     'images-text': 'Images and text (text only available for .note)',
 };
 
+export type PageExportImageFormat = 'png' | 'svg';
+
+export const PAGE_EXPORT_IMAGE_FORMAT_LABELS: Record<PageExportImageFormat, string> = {
+    png: 'PNG',
+    svg: 'SVG',
+};
+
 // Obsidian's declarative settings API (1.13+): PluginSettingTab.getSettingDefinitions().
 // Not present in the `obsidian` devDependency's types (pinned pre-1.13, see CLAUDE.md on
 // why this repo can't casually bump it), so the shapes below are hand-typed to match the
@@ -67,6 +74,11 @@ export interface SupernotePluginSettings extends CustomDictionarySettings {
     showExportButtons: boolean;
     fileBrowserSortOrder: FileBrowserSortOrder;
     importFormat: ImportFormat;
+    /** Format the note viewer's toolbar "export current page" button writes
+     *  the page as. The command-palette "Export current page as PNG/SVG
+     *  attachment" commands are unaffected — each always writes its own
+     *  named format regardless of this setting. */
+    pageExportImageFormat: PageExportImageFormat;
     /** Vault folder that device sync writes into; never touches anything outside it. */
     syncFolder: string;
     /**
@@ -90,6 +102,7 @@ export const DEFAULT_SETTINGS: SupernotePluginSettings = {
     showExportButtons: false,
     fileBrowserSortOrder: 'name-asc',
     importFormat: 'images-text',
+    pageExportImageFormat: 'png',
     syncFolder: 'Supernote sync',
     syncPathFiltersRaw: '',
     noteSyncState: {},
@@ -137,6 +150,15 @@ export class SupernoteSettingTab extends PluginSettingTab {
                 control: {
                     type: 'toggle',
                     key: 'showExportButtons',
+                },
+            },
+            {
+                name: 'Export current page as',
+                desc: 'Format the note viewer toolbar\'s page-export button saves the page as. The command palette\'s PNG/SVG-specific export commands are unaffected by this setting.',
+                control: {
+                    type: 'dropdown',
+                    key: 'pageExportImageFormat',
+                    options: PAGE_EXPORT_IMAGE_FORMAT_LABELS,
                 },
             },
             {
@@ -258,6 +280,18 @@ export class SupernoteSettingTab extends PluginSettingTab {
                         this.plugin.settings.showExportButtons = value;
                         await this.plugin.saveSettings();
                     }),
+            );
+
+        new Setting(containerEl)
+            .setName('Export current page as')
+            .setDesc('Format the note viewer toolbar\'s page-export button saves the page as. The command palette\'s PNG/SVG-specific export commands are unaffected by this setting.')
+            .addDropdown(dropdown => dropdown
+                .addOptions(PAGE_EXPORT_IMAGE_FORMAT_LABELS)
+                .setValue(this.plugin.settings.pageExportImageFormat)
+                .onChange(async (value) => {
+                    this.plugin.settings.pageExportImageFormat = value as PageExportImageFormat;
+                    await this.plugin.saveSettings();
+                })
             );
 
         new Setting(containerEl)


### PR DESCRIPTION
## Summary
- Bumps the `supernote-typescript` submodule to include `toSvg()`/`addSvgPage()` (already merged upstream via https://github.com/philips/supernote-typescript/pull/49 and /50): renders a page's raster plus an invisible, positioned recognized-text overlay into a standalone SVG document, mirroring the existing PDF export's text layer.
- Adds `export-note-as-svg-files` command: "Export this note as a Markdown and SVG files as attachments" (SVG equivalent of the existing PNG command).
- Adds `export-current-page-as-svg` command: "Export current page as SVG attachment" (SVG equivalent of the existing PNG command).
- Adds an "Export current page as" (PNG/SVG) setting controlling which format the note viewer toolbar's per-page export button writes. The PNG/SVG-specific command-palette commands are unaffected by this setting — each always writes its own named format.

Closes #213.

## Test plan
- [x] `npm run build` (tsc + esbuild) succeeds
- [x] `npm run lint` — no new warnings/errors
- [x] `npm test` — 202 tests pass
- [x] Manual: load the plugin in an Obsidian vault, run "Export this note as a Markdown and SVG files as attachments" and "Export current page as SVG attachment" on a real `.note` file, confirm generated SVGs render correctly and recognized text is selectable/searchable
- [x] Manual: toggle "Export current page as" setting between PNG/SVG and confirm the toolbar download button follows it