### PR TITLE
Focus the search input when opening file list modals

### DIFF
--- a/src/FileListModal.ts
+++ b/src/FileListModal.ts
@@ -105,6 +105,11 @@ export abstract class FileListModal extends SuggestModal<SupernoteFile> {
         this.buildSortToolbar();
     }
 
+    onOpen() {
+        super.onOpen();
+        this.inputEl.focus();
+    }
+
     private buildSortToolbar() {
         const toolbarEl = createDiv({ cls: 'supernote-toolbar supernote-file-list-toolbar' });
         this.modalEl.prepend(toolbarEl);

--- a/src/FileListModal.ts
+++ b/src/FileListModal.ts
@@ -106,7 +106,7 @@ export abstract class FileListModal extends SuggestModal<SupernoteFile> {
     }
 
     onOpen() {
-        super.onOpen();
+        void super.onOpen();
         this.inputEl.focus();
     }
 


### PR DESCRIPTION
## Summary
- `DownloadListModal` ("attach file from device") and `UploadListModal` both extend the shared `FileListModal` base class, which extends Obsidian's `SuggestModal`, but neither explicitly focused the built-in search input on open — users had to click into it before typing.
- Added an `onOpen()` override on `FileListModal` that calls `super.onOpen()` then `this.inputEl.focus()`, fixing focus for both modals.

## Test plan
- [x] `./scripts/build` (submodule + root build) completes cleanly
- [x] `tsc --noEmit` reports no errors