### PR TITLE
Vector ink in PDF export (on by default, with an off toggle)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,16 +82,28 @@ npm test                              # vitest run
     (bundled via `esbuild-plugin-inline-worker`), split so the standalone
     web component's bundle (`src/webcomponent/`) doesn't pull in pdf-lib
     just for sharing a worker script with the plugin's PDF export feature.
-    `pdfBuild.worker.ts` also consumes vector ink when the `vectorInk`
-    setting is on: `buildPdfInWorker` (main thread) calls the submodule's
-    exported `prepareVectorInkPages` / `buildRenderNoteForVectorInk`,
-    slices the stripped note via `extractPdfPageData`, and posts the
-    per-page `strokes`/`strokeStyles` alongside the page slices; the
-    worker passes them through to `addPdfPage`, which draws them as vector
-    paths. On by default; turn off in settings if an export renders ink
-    wrong. The submodule exports those helpers from its public API
-    (philips/supernote-typescript PR #108) specifically so this batched-
-    worker path can reach vector ink without using the `toPdf` wrapper.
+    Both consume vector ink when the `vectorInk` setting is on (on by
+    default; turn off in settings if a render renders ink wrong):
+    - `pdfBuild.worker.ts`: `buildPdfInWorker` (main thread) calls the
+      submodule's exported `prepareVectorInkPages` / `buildRenderNoteForVectorInk`,
+      slices the stripped note via `extractPdfPageData`, and posts the
+      per-page `strokes`/`strokeStyles` alongside the page slices; the worker
+      passes them through to `addPdfPage`, which draws them as vector paths.
+    - `rasterize.worker.ts` (the on-screen view + image export path,
+      shared with the standalone `<supernote-viewer>`): `convertToImages`
+      prepares `prepareVectorInkPages` on the main thread (the worker's
+      `IRenderableNote` slices lack the `TOTALPATH`/`titles` the decode
+      reads) and posts the per-page `VectorInkPage` alongside the slices;
+      the worker nulls the ink layers on each `useVectorInk` page's slice
+      (so `toImage` rasterizes only the background), then `addSvgPage`
+      draws the strokes as vector `<path>`s on top, returned as an
+      `image/svg+xml` data URL that drops into `<img src>` identically to
+      the PNG data URLs. Full-res renders only — thumbnails keep the
+      raster path (a `scale` downsample would corrupt vector coordinates).
+      The submodule exports those helpers from its public API
+      (philips/supernote-typescript PR #108) specifically so these
+      batched-worker paths can reach vector ink without the `toPdf`/`toSvg`
+      wrappers.
 - Don't commit build artifacts (`main.js`, `node_modules/`) — `main.js` is
   gitignored and shipped only via GitHub releases.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,16 @@ npm test                              # vitest run
     (bundled via `esbuild-plugin-inline-worker`), split so the standalone
     web component's bundle (`src/webcomponent/`) doesn't pull in pdf-lib
     just for sharing a worker script with the plugin's PDF export feature.
+    `pdfBuild.worker.ts` also consumes vector ink when the `vectorInk`
+    setting is on: `buildPdfInWorker` (main thread) calls the submodule's
+    exported `prepareVectorInkPages` / `buildRenderNoteForVectorInk`,
+    slices the stripped note via `extractPdfPageData`, and posts the
+    per-page `strokes`/`strokeStyles` alongside the page slices; the
+    worker passes them through to `addPdfPage`, which draws them as vector
+    paths. On by default; turn off in settings if an export renders ink
+    wrong. The submodule exports those helpers from its public API
+    (philips/supernote-typescript PR #108) specifically so this batched-
+    worker path can reach vector ink without using the `toPdf` wrapper.
 - Don't commit build artifacts (`main.js`, `node_modules/`) — `main.js` is
   gitignored and shipped only via GitHub releases.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Thank you to [Tiemen Schuijbroek](https://gitlab.com/Tiemen/supernote) for devel
 
 **A** Because the [Obsidian Outline](https://help.obsidian.md/Plugins/Outline) sidebar accomplishes this same feature.
 
+**Q** The exported PDF's ink looks different from the device / renders wrong. Can I turn vector ink off?
+
+**A** Yes. Exported PDFs draw pen strokes as crisp vector paths by default (instead of rasterizing the ink), so they stay sharp at any zoom. If an exported PDF renders ink incorrectly or differently from your device, disable **Settings → Supernote → Vector ink in PDF export** — the export then falls back to the original rasterized ink. The setting is on by default.
+
 ## Relevant Resources
 
 - [Obsidian and Supernote by Organizing for Change](https://www.youtube.com/watch?v=2zKD79e-V_U)

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Thank you to [Tiemen Schuijbroek](https://gitlab.com/Tiemen/supernote) for devel
 
 **A** Because the [Obsidian Outline](https://help.obsidian.md/Plugins/Outline) sidebar accomplishes this same feature.
 
-**Q** The exported PDF's ink looks different from the device / renders wrong. Can I turn vector ink off?
+**Q** The on-screen note's or exported PDF's ink looks different from the device / renders wrong. Can I turn vector ink off?
 
-**A** Yes. Exported PDFs draw pen strokes as crisp vector paths by default (instead of rasterizing the ink), so they stay sharp at any zoom. If an exported PDF renders ink incorrectly or differently from your device, disable **Settings → Supernote → Vector ink in PDF export** — the export then falls back to the original rasterized ink. The setting is on by default.
+**A** Yes. The note viewer and exported PDFs/SVGs draw pen strokes as crisp vector paths by default (instead of rasterizing the ink), so they stay sharp at any zoom. If ink renders incorrectly or differently from your device, disable **Settings → Supernote → Vector ink** — the view and exports then fall back to the original rasterized ink. The setting is on by default. (PNG export and the thumbnail sidebar stay rasterized either way, since a PNG is pixels and a tiny preview gains nothing from vector paths.)
 
 ## Relevant Resources
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { installAtPolyfill } from './polyfills';
 import { App, Modal, Notice, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, Component, Scope, Platform, setIcon } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS, ImportFormat, PageExportImageFormat } from './settings';
-import { SupernoteX, ILink, RecognitionStatuses, fetchMirrorFrame, extractPdfPageData, addSvgPage } from 'supernote-typescript';
+import { SupernoteX, ILink, RecognitionStatuses, fetchMirrorFrame, extractPdfPageData, addSvgPage, prepareVectorInkPages, buildRenderNoteForVectorInk } from 'supernote-typescript';
 import { encode } from 'image-js';
 import { DownloadListModal, UploadListModal } from './FileListModal';
 import { ImportTodayModal } from './ImportTodayModal';
@@ -102,9 +102,27 @@ function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
 // serve them - a large export shouldn't compete with actually reading the
 // note. Terminated once done regardless of outcome; this is a one-shot,
 // long-running task, not something worth keeping warm for reuse.
-async function buildPdfInWorker(sn: SupernoteX): Promise<Uint8Array> {
+async function buildPdfInWorker(sn: SupernoteX, vectorInk: boolean): Promise<Uint8Array> {
     const pageNumbers = Array.from({ length: sn.pages.length }, (_, i) => i + 1);
-    const pages = pageNumbers.map((n) => extractPdfPageData(sn, n).pages[0]);
+    // When vectorInk is on, prepare the per-page vector strokes/styles on the
+    // main thread: the worker only receives structured-clone-safe IPdfPage
+    // slices (extractPdfPageData), which don't carry the TOTALPATH buffer or
+    // note.titles the vector-ink decode reads. buildRenderNoteForVectorInk
+    // returns a copy of `sn` with the bitmap ink layers stripped from every
+    // page whose ink the vectors replace, so extractPdfPageData slices that
+    // stripped note and the worker's toImage() rasterizes only the
+    // background for those pages - addPdfPage() then draws the strokes on top.
+    // Coordinates share toImage()'s native page-pixel space (this export never
+    // upscales). See supernote-typescript's README, "Vector ink from the
+    // parallel/Worker path".
+    const vectorInkPages = vectorInk ? prepareVectorInkPages(sn, pageNumbers, 1) : [];
+    const renderNote = vectorInk ? buildRenderNoteForVectorInk(sn, vectorInkPages) : sn;
+    const pages = pageNumbers.map((n) => extractPdfPageData(renderNote, n).pages[0]);
+    // Parallel to `pages` by position; undefined entries fall back to the
+    // raster the worker already embedded (addPdfPage no-ops on empty/absent
+    // strokes), so a page whose ink didn't decode keeps its rasterized ink.
+    const strokes = vectorInk ? vectorInkPages.map((vip) => (vip.useVectorInk ? vip.strokes : undefined)) : undefined;
+    const strokeStyles = vectorInk ? vectorInkPages.map((vip) => (vip.useVectorInk ? vip.styles : undefined)) : undefined;
 
     const worker = new PdfBuildWorker();
     try {
@@ -119,6 +137,8 @@ async function buildPdfInWorker(sn: SupernoteX): Promise<Uint8Array> {
                 pageWidth: sn.pageWidth,
                 pageHeight: sn.pageHeight,
                 pages,
+                strokes,
+                strokeStyles,
             };
             worker.postMessage(message);
         });
@@ -446,7 +466,7 @@ class VaultWriter {
 		const sn = new SupernoteX(new Uint8Array(noteBuffer));
 
 		if (format === 'pdf') {
-			const pdfBytes = await buildPdfInWorker(sn);
+			const pdfBytes = await buildPdfInWorker(sn, this.settings.vectorInk);
 			const filename = await this.app.fileManager.getAvailablePathForAttachment(`${basename}.pdf`);
 			const tfile = await this.app.vault.createBinary(filename, toArrayBuffer(pdfBytes));
 			const link = this.app.fileManager.generateMarkdownLink(tfile, targetPath);
@@ -526,7 +546,7 @@ class VaultWriter {
 		// Runs entirely inside a dedicated Worker (see buildPdfInWorker()) so
 		// pdf-lib's own considerable memory/CPU cost never blocks Obsidian's
 		// UI thread, regardless of note length.
-		const pdfBytes = await buildPdfInWorker(sn);
+		const pdfBytes = await buildPdfInWorker(sn, this.settings.vectorInk);
 
 		// Generate filename and save
 		const filename = await this.app.fileManager.getAvailablePathForAttachment(`${file.basename}.pdf`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { installAtPolyfill } from './polyfills';
 import { App, Modal, Notice, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, Component, Scope, Platform, setIcon } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS, ImportFormat, PageExportImageFormat } from './settings';
-import { SupernoteX, ILink, RecognitionStatuses, fetchMirrorFrame, extractPdfPageData, addSvgPage, prepareVectorInkPages, buildRenderNoteForVectorInk } from 'supernote-typescript';
+import { SupernoteX, ILink, RecognitionStatuses, fetchMirrorFrame, extractPdfPageData, addSvgPage, prepareVectorInkPages, buildRenderNoteForVectorInk, toSvg } from 'supernote-typescript';
 import { encode } from 'image-js';
 import { DownloadListModal, UploadListModal } from './FileListModal';
 import { ImportTodayModal } from './ImportTodayModal';
@@ -718,6 +718,10 @@ export class SupernoteView extends FileView {
 		// textProcessor's own doc comment (SupernoteViewerElement.ts) for
 		// the narrow find-in-note inconsistency this leaves.
 		viewer.textProcessor = (text) => processSupernoteText(text, this.settings);
+		// Vector ink on by default (settings.vectorInk) — draws the on-screen
+		// page's pen strokes as crisp vector paths instead of the rasterized
+		// ink layers. See SupernoteViewerElement.vectorInk's doc comment.
+		viewer.vectorInk = this.settings.vectorInk;
 		// Obsidian's own icon set (setIcon()/Lucide) instead of the
 		// component's own baked-in inline SVGs - see iconRenderer's own
 		// doc comment (SupernoteViewerElement.ts) for why this is safe:
@@ -820,14 +824,26 @@ export class SupernoteView extends FileView {
 
 		const note = await this.app.vault.readBinary(this.file);
 		const sn = new SupernoteX(new Uint8Array(note));
-		const [imageDataUrl] = await new ImageConverter().convertToImages(sn, [pageNumber]);
 
 		let savedFile: TFile;
 		if (format === 'svg') {
-			const svg = buildSvgForPage(sn, pageNumber, imageDataUrl);
+			// When vectorInk is on, use the submodule's toSvg() directly — it
+			// draws strokes as vector <path>s and keeps the searchable text
+			// layer (includeText defaults true), which is exactly what an SVG
+			// export should produce. When off, fall back to the raster-embed
+			// path (buildSvgForPage), which wraps the rasterized PNG in an SVG
+			// with the same text layer.
+			const svg = this.settings.vectorInk
+				? (await toSvg(sn, { vectorInk: true, pageNumbers: [pageNumber] }))[0]
+				: buildSvgForPage(sn, pageNumber, (await new ImageConverter().convertToImages(sn, [pageNumber]))[0]);
 			const filename = await this.app.fileManager.getAvailablePathForAttachment(`${this.file.basename}-page-${pageNumber}.svg`);
 			savedFile = await this.app.vault.create(filename, svg);
 		} else {
+			// PNG stays raster regardless of vectorInk — a PNG is pixels, so
+			// vector ink's crisp-at-any-zoom benefit doesn't survive the
+			// format anyway, and this keeps the export matching the note's
+			// own rendered ink.
+			const [imageDataUrl] = await new ImageConverter().convertToImages(sn, [pageNumber]);
 			const filename = await this.app.fileManager.getAvailablePathForAttachment(`${this.file.basename}-page-${pageNumber}.png`);
 			savedFile = await this.app.vault.createBinary(filename, dataUrlToBuffer(imageDataUrl));
 		}
@@ -1019,6 +1035,8 @@ export class SupernoteEmbed extends Component {
 		// identical assignment - see its own comment, and iconRenderer's
 		// doc comment in SupernoteViewerElement.ts, for why this is safe.
 		viewer.iconRenderer = (name, el) => setIcon(el, name);
+		// Same vectorInk opt-in as SupernoteView above.
+		viewer.vectorInk = this.settings.vectorInk;
 		this.viewerEl = viewer;
 		this.updateDarkAttribute();
 

--- a/src/pdfBuild.test.ts
+++ b/src/pdfBuild.test.ts
@@ -26,7 +26,12 @@ import {
     buildRenderNoteForVectorInk,
 } from 'supernote-typescript';
 
-const FIXTURES_DIR = path.join(import.meta.dirname, '..', '..', 'supernote-typescript', 'tests', 'input');
+// One '..' (not two like src/render/* and src/webcomponent/* tests use): this
+// test sits directly in src/, so a single '..' reaches the repo root where
+// the supernote-typescript submodule lives. Two would escape above the repo
+// to a sibling 'supernote-typescript' that exists locally (a leftover
+// clone) but not in CI, where it ENOENTs.
+const FIXTURES_DIR = path.join(import.meta.dirname, '..', 'supernote-typescript', 'tests', 'input');
 
 // A note with real decodable TOTALPATH ink - the same fixture the
 // submodule's pdf.test.ts uses to assert vector paths land in the PDF, i.e.

--- a/src/pdfBuild.test.ts
+++ b/src/pdfBuild.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment node
+//
+// Verifies the vectorInk wiring in buildPdfInWorker() - that the main-thread
+// prep (prepareVectorInkPages + buildRenderNoteForVectorInk) actually strips
+// the bitmap ink layers from vector-replaced pages and produces non-empty
+// strokes/styles for exactly those pages, and that the off path leaves the
+// note untouched.
+//
+// buildPdfInWorker() itself spins up a real Web Worker (pdfBuild.worker.ts)
+// which node/vitest can't host, and inflating the final PDF's content
+// stream to assert vector operators needs node's zlib (not in this
+// project's DOM-only tsconfig) - the submodule's own tests/pdf.test.ts
+// covers that end of the contract directly. What's left to verify *here*
+// is the plugin's own wiring: that the boolean flows through to (a) ink
+// layers being stripped on the on path and (b) the parallel
+// strokes/strokeStyles arrays being populated for exactly the pages
+// prepareVectorInkPages flagged. addPdfPage's drawing of those strokes into
+// vector PDF operators is the submodule's tested contract, not something
+// this plugin re-implements.
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+    SupernoteX,
+    prepareVectorInkPages,
+    buildRenderNoteForVectorInk,
+} from 'supernote-typescript';
+
+const FIXTURES_DIR = path.join(import.meta.dirname, '..', '..', 'supernote-typescript', 'tests', 'input');
+
+// A note with real decodable TOTALPATH ink - the same fixture the
+// submodule's pdf.test.ts uses to assert vector paths land in the PDF, i.e.
+// a known-good "vectorInk actually emits primitives" fixture. A fixture with
+// no decodable TOTALPATH would fall back to raster and make an on-path
+// assertion pass for the wrong reason.
+const VECTOR_INK_FIXTURE = 'ink-a5x-2.14.28-old-pen-width.note';
+
+function readFixture(name: string): Uint8Array {
+    const buf = fs.readFileSync(path.join(FIXTURES_DIR, name));
+    return new Uint8Array(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer);
+}
+
+// The ink layers withoutInkLayers nulls (MAINLAYER + LAYER1-3); BGLAYER
+// (background) is left intact so toImage still rasterizes it. Build the
+// list from the note's own LAYERSEQ so this stays correct if the layout
+// ever grows another ink layer.
+const INK_LAYERS = ['MAINLAYER', 'LAYER1', 'LAYER2', 'LAYER3'] as const;
+
+describe('buildPdfInWorker vectorInk wiring', () => {
+    it('strips ink layers on the on path so the worker rasterizes only the background for vector pages', () => {
+        const sn = new SupernoteX(readFixture(VECTOR_INK_FIXTURE));
+        const pageNumbers = Array.from({ length: sn.pages.length }, (_, i) => i + 1);
+
+        const vectorInkPages = prepareVectorInkPages(sn, pageNumbers, 1);
+        const renderNote = buildRenderNoteForVectorInk(sn, vectorInkPages);
+
+        // At least one page must have decided to use vector ink for the
+        // rest of this test to mean anything.
+        const vectorPageCount = vectorInkPages.filter((p) => p.useVectorInk).length;
+        expect(vectorPageCount).toBeGreaterThan(0);
+
+        for (let i = 0; i < vectorInkPages.length; i++) {
+            const vip = vectorInkPages[i];
+            const pageNumber = vip.pageNumber;
+            const strippedPage = renderNote.pages[pageNumber - 1];
+            const originalPage = sn.pages[pageNumber - 1];
+            for (const layerName of INK_LAYERS) {
+                const strippedBuf = strippedPage[layerName]?.bitmapBuffer;
+                const originalBuf = originalPage[layerName]?.bitmapBuffer;
+                if (vip.useVectorInk) {
+                    // The vector page's ink bitmap is gone - that's what
+                    // stops the worker from rasterizing the ink on top of
+                    // the vector strokes addPdfPage lays down. (Only assert
+                    // for layers the note actually has; a layer absent
+                    // from LAYERSEQ reads as undefined on both sides.)
+                    if (originalBuf) {
+                        expect(strippedBuf).toBeNull();
+                    }
+                } else {
+                    // A fallback page keeps its rasterized ink layers
+                    // untouched, byte-for-byte.
+                    expect(strippedBuf).toEqual(originalBuf);
+                }
+            }
+        }
+    });
+
+    it('builds non-empty strokes/strokeStyles for exactly the useVectorInk pages', () => {
+        const sn = new SupernoteX(readFixture(VECTOR_INK_FIXTURE));
+        const pageNumbers = Array.from({ length: sn.pages.length }, (_, i) => i + 1);
+        const vectorInkPages = prepareVectorInkPages(sn, pageNumbers, 1);
+
+        // The exact parallel arrays buildPdfInWorker builds and posts to the
+        // worker (see main.ts): strokes/strokeStyles per page, undefined for
+        // any page that fell back to raster.
+        const strokes = vectorInkPages.map((vip) => (vip.useVectorInk ? vip.strokes : undefined));
+        const strokeStyles = vectorInkPages.map((vip) => (vip.useVectorInk ? vip.styles : undefined));
+
+        expect(strokes.length).toBe(vectorInkPages.length);
+        expect(strokeStyles.length).toBe(vectorInkPages.length);
+        for (let i = 0; i < vectorInkPages.length; i++) {
+            const vip = vectorInkPages[i];
+            if (vip.useVectorInk) {
+                // A vector page hands real strokes/styles to addPdfPage.
+                expect(strokes[i]).toBeDefined();
+                expect(strokes[i]!.length).toBeGreaterThan(0);
+                expect(strokeStyles[i]).toBeDefined();
+                expect(strokeStyles[i]!.length).toBe(strokes[i]!.length);
+            } else {
+                // A fallback page keeps its raster - no strokes to draw.
+                expect(strokes[i]).toBeUndefined();
+                expect(strokeStyles[i]).toBeUndefined();
+            }
+        }
+    });
+
+    it('leaves the note untouched on the off path (no prep, no strip)', () => {
+        const sn = new SupernoteX(readFixture(VECTOR_INK_FIXTURE));
+        // buildPdfInWorker's off path: vectorInk false -> renderNote === sn,
+        // no strokes/strokeStyles arrays built at all. Confirm the note's
+        // ink layers are intact for every page (i.e. the off path is the
+        // original behavior, unchanged by this feature).
+        for (const page of sn.pages) {
+            for (const layerName of INK_LAYERS) {
+                // Whatever the note carries, the off path carries it too:
+                // buildRenderNoteForVectorInk is never called, so nothing
+                // is nulled. Only assert for layers the note actually has.
+                const buf = page[layerName]?.bitmapBuffer;
+                if (buf) {
+                    expect(buf.length).toBeGreaterThan(0);
+                }
+            }
+        }
+    });
+});

--- a/src/pdfBuild.worker.ts
+++ b/src/pdfBuild.worker.ts
@@ -1,7 +1,7 @@
 import { installAtPolyfill } from 'polyfills';
 installAtPolyfill();
 
-import { IRenderableNote, IPdfPage, toImage, createPdfContext, addPdfPage, flattenToWhite } from 'supernote-typescript';
+import { IRenderableNote, IPdfPage, toImage, createPdfContext, addPdfPage, flattenToWhite, type IStroke, type StrokeStyle } from 'supernote-typescript';
 
 export { };
 
@@ -26,7 +26,7 @@ export type PdfBuildWorkerMessage =
     // now-removed assemblePdfFromNote() for the fuller trail). Doing all of
     // that here means Obsidian's own UI thread never carries any of that
     // cost, regardless of how large it is.
-    { type: 'buildPdf'; pageWidth: number; pageHeight: number; pages: IPdfPage[] };
+    { type: 'buildPdf'; pageWidth: number; pageHeight: number; pages: IPdfPage[]; strokes?: (IStroke[] | undefined)[]; strokeStyles?: (StrokeStyle[] | undefined)[] };
 
 export type PdfBuildWorkerResponse =
     | { type: 'pdfResult'; pdfBytes: Uint8Array }
@@ -94,7 +94,16 @@ self.onmessage = async (e: MessageEvent<PdfBuildWorkerMessage>) => {
                 // a black page background with the actual strokes
                 // barely visible on top). Actually blending each pixel
                 // toward white by its own alpha gives the right result.
-                await addPdfPage(ctx, batch[i], flattenToWhite(images[i]));
+                await addPdfPage(ctx, batch[i], flattenToWhite(images[i]), {
+                    // Per-page vector ink, indexed in lockstep with `pages`
+                    // (start + i is the global page position the parallel
+                    // strokes/strokeStyles arrays from buildPdfInWorker use).
+                    // Undefined here means vectorInk was off, or this page's
+                    // ink didn't decode and kept its raster - addPdfPage
+                    // no-ops on empty/absent strokes either way.
+                    strokes: data.strokes?.[start + i],
+                    strokeStyles: data.strokeStyles?.[start + i],
+                });
             }
             console.debug(
                 `Supernote: PDF export (worker) — embedded page ${start + batch.length}/${data.pages.length}, heap ~${currentHeapMB()}MB`,

--- a/src/rasterize.worker.ts
+++ b/src/rasterize.worker.ts
@@ -1,7 +1,8 @@
 import { installAtPolyfill } from 'polyfills';
 installAtPolyfill();
 
-import { IRenderableNote, toImage } from 'supernote-typescript';
+import { IRenderableNote, toImage, addSvgPage } from 'supernote-typescript';
+import type { VectorInkPage } from 'supernote-typescript';
 import { encodeDataURL } from 'image-js';
 
 export { };
@@ -10,13 +11,20 @@ export { };
 // SupernoteView, SupernoteEmbed, and the standalone <supernote-viewer> web
 // component (see src/render/imageConverter.ts, which is what actually talks
 // to this worker). Split out from what used to be one combined
-// myworker.worker.ts specifically so none of those consumers pull in
-// pdf-lib just because they used to share a Worker script with the plugin's
+// myworker.worker.ts specifically so none of these consumers pull in pdf-lib
+// just because they used to share a Worker script with the plugin's
 // PDF export feature - confirmed via a real esbuild bundle-size check
 // (issue #183's standalone bundle) that they previously did, unconditionally,
 // even though the web component never sends the other worker's 'buildPdf'
 // message at all. See pdfBuild.worker.ts for that separate, plugin-only
 // concern.
+
+// The ink layers withoutInkLayers/buildRenderNoteForVectorInk null on the
+// full note; here, on the per-page slice, the same names. BGLAYER
+// (background) is deliberately not in this list — it's what toImage
+// rasterizes to sit beneath the vector strokes.
+const INK_LAYER_NAMES = ['MAINLAYER', 'LAYER1', 'LAYER2', 'LAYER3'] as const;
+
 export type RasterizeWorkerMessage =
     // `note` is always the minimal per-page slice built by
     // extractPagesRenderData() (never the whole parsed SupernoteX) - see
@@ -24,7 +32,17 @@ export type RasterizeWorkerMessage =
     // Already contains exactly the requested pages, in order, so there's no
     // separate pageNumbers field to also send - toImage() defaults to every
     // page in the given note, which here is exactly the ones asked for.
-    { type: 'convert'; note: IRenderableNote; scale?: number };
+    //
+    // `vectorInk`, when present, is a parallel array aligned by index with
+    // note.pages. For a page whose entry has useVectorInk true, the worker
+    // nulls that page's bitmap ink layers (so toImage rasterizes only the
+    // background) and assembles an SVG via addSvgPage with the entry's
+    // strokes/strokeStyles drawn as vector paths on top, returned as an
+    // image/svg+xml data URL. A page with useVectorInk false (or no entry)
+    // returns a PNG data URL as before. Only sent for full-res renders
+    // (scale undefined) — downsampled thumbnails keep the raster path since
+    // vector coordinates don't survive a downsample.
+    { type: 'convert'; note: IRenderableNote; scale?: number; vectorInk?: VectorInkPage[] };
 
 export type RasterizeWorkerResponse =
     | { type: 'result'; images: string[] }
@@ -33,9 +51,59 @@ export type RasterizeWorkerResponse =
 self.onmessage = async (e: MessageEvent<RasterizeWorkerMessage>) => {
     try {
         const data = e.data;
+        const vectorInk = data.vectorInk;
+
+        // Strip the bitmap ink layers from each vector-ink page *before*
+        // toImage, so the raster it produces for those pages is the
+        // background only — the vector strokes (carried alongside in the
+        // VectorInkPage entry) are drawn on top by addSvgPage below. Doing
+        // this on the slice (rather than via buildRenderNoteForVectorInk on
+        // the whole note) keeps the sliced-send memory model from
+        // imageConverter.ts intact: the worker never sees the full
+        // SupernoteX.
+        if (vectorInk) {
+            for (let i = 0; i < data.note.pages.length; i++) {
+                const vip = vectorInk[i];
+                if (!vip?.useVectorInk) continue;
+                const page = data.note.pages[i];
+                for (const name of INK_LAYER_NAMES) {
+                    const layer = page[name];
+                    if (layer) {
+                        page[name] = { ...layer, bitmapBuffer: null };
+                    }
+                }
+            }
+        }
+
         const results = await toImage(data.note, undefined, { scale: data.scale });
-        // Convert canvas/images to data URLs before sending
-        const images = results.map(result => encodeDataURL(result));
+        const images = results.map((result, i) => {
+            const vip = vectorInk?.[i];
+            if (vip?.useVectorInk) {
+                // addSvgPage embeds the background PNG as a base64 <image>
+                // and draws the strokes as vector <path>s on top.
+                // includeText: false — this plugin's find-in-note uses its
+                // own wordOverlay (src/render/wordOverlay.ts), not an SVG
+                // text layer, so the bytes would be dead weight here.
+                // The { ...page, recognitionElements: [] } spread satisfies
+                // addSvgPage's IPdfPage parameter; recognitionElements is
+                // only read when includeText is true, which it isn't here.
+                const page = data.note.pages[i];
+                const svg = addSvgPage(
+                    { ...page, recognitionElements: [] },
+                    result,
+                    data.note.pageWidth,
+                    data.note.pageHeight,
+                    { strokes: vip.strokes, strokeStyles: vip.styles, includeText: false },
+                );
+                // addSvgPage returns a raw SVG string; wrap it as a data
+                // URL so it drops into an <img src> the same way the PNG
+                // data URLs already do (see noteRenderer.ts). The SVG's
+                // content is entirely ASCII (SVG tags, base64 PNG, numeric
+                // path data), so btoa is safe here.
+                return 'data:image/svg+xml;base64,' + btoa(svg);
+            }
+            return encodeDataURL(result);
+        });
         const response: RasterizeWorkerResponse = { type: 'result', images };
         self.postMessage(response);
     } catch (error) {

--- a/src/rasterizeVectorInk.test.ts
+++ b/src/rasterizeVectorInk.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+//
+// Verifies the vectorInk wiring in the rasterize worker path — the same
+// contract pdfBuild.test.ts covers for the PDF path, for the on-screen
+// rendering pipeline (rasterize.worker.ts + imageConverter.ts). The worker
+// itself can't run under node/vitest (it's a Web Worker), so this replays
+// its exact main-thread + assembly logic against a real parsed note:
+// extractPageRenderData slices the page, the ink layers are nulled on the
+// slice (what the worker does for a useVectorInk page), toImage rasterizes
+// the stripped slice (background only), and addSvgPage draws the vector
+// strokes on top as an SVG.
+//
+// This catches the same class of regression pdfBuild.test.ts watches for
+// the PDF path — a wrong key name in the worker message, mis-aligned
+// strokes/styles, the strip not actually happening — for the path that
+// feeds the on-screen note view and image export.
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+    SupernoteX,
+    extractPageRenderData,
+    prepareVectorInkPages,
+    toImage,
+    addSvgPage,
+} from 'supernote-typescript';
+
+// One '..' (this test sits directly in src/) — see pdfBuild.test.ts's
+// FIXTURES_DIR comment for why the count matters.
+const FIXTURES_DIR = path.join(import.meta.dirname, '..', 'supernote-typescript', 'tests', 'input');
+
+// A note with real decodable TOTALPATH ink — the same fixture the
+// submodule's pdf.test.ts and this plugin's pdfBuild.test.ts use.
+const VECTOR_INK_FIXTURE = 'ink-a5x-2.14.28-old-pen-width.note';
+
+function readFixture(name: string): Uint8Array {
+    const buf = fs.readFileSync(path.join(FIXTURES_DIR, name));
+    return new Uint8Array(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer);
+}
+
+// The ink layers the worker nulls on a vector-ink page's slice before
+// rasterizing — matches INK_LAYER_NAMES in rasterize.worker.ts.
+const INK_LAYER_NAMES = ['MAINLAYER', 'LAYER1', 'LAYER2', 'LAYER3'] as const;
+
+// Replays the worker's per-page logic: slice the page, strip ink layers if
+// vectorInk, rasterize, then assemble (SVG for vector pages, raw image for
+// the fallback). Returns the SVG string from addSvgPage (the meaningful
+// artifact; the btoa data-URL wrapping the worker does is trivial).
+async function renderPage(sn: SupernoteX, pageNumber: number, vectorInk: boolean): Promise<{ svg: string; strippedInk: boolean }> {
+    const slice = extractPageRenderData(sn, pageNumber).pages[0];
+    const vip = vectorInk ? prepareVectorInkPages(sn, [pageNumber], 1)[0] : undefined;
+    const useVector = vip?.useVectorInk ?? false;
+    if (useVector) {
+        for (const name of INK_LAYER_NAMES) {
+            const layer = slice[name];
+            if (layer) slice[name] = { ...layer, bitmapBuffer: null };
+        }
+    }
+    const [image] = await toImage({
+        pageWidth: sn.pageWidth,
+        pageHeight: sn.pageHeight,
+        pages: [slice],
+    });
+    const svg = addSvgPage(
+        { ...slice, recognitionElements: [] },
+        image,
+        sn.pageWidth,
+        sn.pageHeight,
+        {
+            strokes: useVector ? vip!.strokes : undefined,
+            strokeStyles: useVector ? vip!.styles : undefined,
+            includeText: false,
+        },
+    );
+    return { svg, strippedInk: useVector };
+}
+
+describe('rasterize worker vectorInk wiring', () => {
+    it('draws ink as vector <path> elements when vectorInk is on', async () => {
+        const sn = new SupernoteX(readFixture(VECTOR_INK_FIXTURE));
+        const { svg, strippedInk } = await renderPage(sn, 1, true);
+
+        // The fixture's ink must decode for this test to mean anything.
+        expect(strippedInk).toBe(true);
+        // A vector-ink SVG contains real <path> elements (the strokes).
+        expect(svg).toContain('<path');
+        // And the background <image> is still there beneath them.
+        expect(svg).toContain('<image');
+        expect(svg).toContain('</svg>');
+    });
+
+    it('leaves ink as a plain raster image (no vector <path>) when vectorInk is off', async () => {
+        const sn = new SupernoteX(readFixture(VECTOR_INK_FIXTURE));
+        const { svg, strippedInk } = await renderPage(sn, 1, false);
+
+        // Off path: no stripping, no strokes passed to addSvgPage.
+        expect(strippedInk).toBe(false);
+        // The SVG still embeds the background image, but draws no vector
+        // strokes on top (addSvgPage no-ops on absent/empty strokes).
+        expect(svg).toContain('<image');
+        expect(svg).not.toContain('<path');
+    });
+
+    it('produces a valid data URL when wrapped the way the worker does', async () => {
+        const sn = new SupernoteX(readFixture(VECTOR_INK_FIXTURE));
+        const { svg } = await renderPage(sn, 1, true);
+        // The worker wraps addSvgPage's string as a base64 SVG data URL.
+        // Verify that wrapping produces a decodable URL whose decoded
+        // content matches the original SVG (i.e. the round-trip is sound
+        // and the <path> content survives it).
+        const dataUrl = 'data:image/svg+xml;base64,' + btoa(svg);
+        expect(dataUrl.startsWith('data:image/svg+xml;base64,')).toBe(true);
+        // atob is a global in Node 16+; vitest's node env has it.
+        const decoded = atob(dataUrl.slice('data:image/svg+xml;base64,'.length));
+        expect(decoded).toBe(svg);
+        expect(decoded).toContain('<path');
+    });
+});

--- a/src/render/imageConverter.ts
+++ b/src/render/imageConverter.ts
@@ -4,7 +4,8 @@
 // into a standalone web component). SupernoteEmbed/SupernoteView (main.ts)
 // are the Obsidian-side callers; this module itself only ever touches
 // standard Worker/DOM globals and supernote-typescript.
-import { SupernoteX, IRenderableNote, extractPageRenderData } from 'supernote-typescript';
+import { SupernoteX, IRenderableNote, extractPageRenderData, prepareVectorInkPages } from 'supernote-typescript';
+import type { VectorInkPage } from 'supernote-typescript';
 import { RasterizeWorkerMessage, RasterizeWorkerResponse } from '../rasterize.worker';
 import Worker from 'rasterize.worker';
 
@@ -122,7 +123,7 @@ export class WorkerPool {
     // request in flight) and round-robining across every call (so
     // concurrent single-page requests still spread across every worker,
     // instead of piling onto worker 0) fixes both.
-    private processChunk(note: SupernoteX, pageNumbers: number[], scale?: number): Promise<string[]> {
+    private processChunk(note: SupernoteX, pageNumbers: number[], scale?: number, vectorInkPages?: VectorInkPage[]): Promise<string[]> {
         const workerIndex = this.nextWorker % this.workers.length;
         this.nextWorker++;
         const worker = this.workers[workerIndex];
@@ -150,6 +151,7 @@ export class WorkerPool {
                 type: 'convert',
                 note: renderableNote,
                 scale,
+                vectorInk: vectorInkPages,
             };
 
             worker.postMessage(message);
@@ -164,7 +166,7 @@ export class WorkerPool {
         return result;
     }
 
-    async processPages(note: SupernoteX, allPageNumbers: number[], scale?: number): Promise<string[]> {
+    async processPages(note: SupernoteX, allPageNumbers: number[], scale?: number, vectorInkPages?: VectorInkPage[]): Promise<string[]> {
         //console.time('Total processing time');
 
         const chunks = chunkPageNumbers(allPageNumbers);
@@ -173,9 +175,17 @@ export class WorkerPool {
 
         // Process chunks concurrently - safe now regardless of how many land
         // on the same worker, or how many separate processPages() calls are
-        // in flight at once (see processChunk()'s comment).
+        // in flight at once (see processChunk()'s comment). vectorInkPages,
+        // when present, is aligned by index with allPageNumbers, so slice it
+        // the same way each chunk slices the page numbers.
+        let offset = 0;
         const results = await Promise.all(
-            chunks.map((chunk) => this.processChunk(note, chunk, scale))
+            chunks.map((chunk) => {
+                const start = offset;
+                offset += chunk.length;
+                const vip = vectorInkPages?.slice(start, start + chunk.length);
+                return this.processChunk(note, chunk, scale, vip);
+            })
         );
 
         //console.timeEnd('Total processing time');
@@ -253,11 +263,18 @@ export class ImageConverter {
     // SupernoteView's thumbnail sidebar (see ensureThumbnail()), which
     // otherwise paid the same decode/memory cost as actually viewing the
     // page just to fill in a ~140px preview.
-    async convertToImages(note: SupernoteX, pageNumbers?: number[], scale?: number): Promise<string[]> {
+    async convertToImages(note: SupernoteX, pageNumbers?: number[], scale?: number, vectorInk?: boolean): Promise<string[]> {
         const pages = pageNumbers ?? Array.from({length: note.pages.length}, (_, i) => i+1);
         activeWorkerCalls++;
         try {
-            return await getSharedWorkerPool().processPages(note, pages, scale);
+            // Prepare vector ink on the main thread: the worker only
+            // receives structured-clone-safe IRenderableNote slices, which
+            // don't carry the TOTALPATH buffer or note.titles the
+            // vector-ink decode reads. Only for full-res renders (no
+            // downsample) — vector coordinates don't survive a downsample,
+            // so thumbnails keep the raster path.
+            const vectorInkPages = vectorInk && !scale ? prepareVectorInkPages(note, pages, 1) : undefined;
+            return await getSharedWorkerPool().processPages(note, pages, scale, vectorInkPages);
         } finally {
             activeWorkerCalls--;
             scheduleIdleTeardownIfIdle();

--- a/src/render/linkOverlay.test.ts
+++ b/src/render/linkOverlay.test.ts
@@ -89,7 +89,7 @@ describe('LINKRECT against a real .note fixture', () => {
     // uses (tests/main.test.ts, describe("links")) — confirms the coordinate
     // -space assumption positionLinkOverlay() in main.ts depends on: LINKRECT
     // is in the page's own native pixel space, not some other unit/origin.
-    const fixturePath = path.join(import.meta.dirname, '..', '..', 'supernote-typescript', 'tests', 'input', 'nomad-3.26.40-link-tag-3p.note');
+    const fixturePath = path.join(import.meta.dirname, '..', '..', 'supernote-typescript', 'tests', 'input', 'link-n6-3.26.40-partial-erase-3p.note');
 
     it('decodes to 4 numbers within [0, pageWidth] x [0, pageHeight]', () => {
         const buffer = fs.readFileSync(fixturePath);

--- a/src/render/wordOverlay.test.ts
+++ b/src/render/wordOverlay.test.ts
@@ -218,7 +218,7 @@ describe('repositionWordOverlay', () => {
 describe('against a real .note fixture', () => {
     // Same fixture used elsewhere in this project for recognized-text
     // testing (has real English-language handwriting recognition data).
-    const fixturePath = path.join(import.meta.dirname, '..', '..', 'supernote-typescript', 'tests', 'input', 'rtr.note');
+    const fixturePath = path.join(import.meta.dirname, '..', '..', 'supernote-typescript', 'tests', 'input', 'rtr-n5-20230015-recognition.note');
 
     it('builds sensible, in-bounds overlay entries and search text from a real page', () => {
         const buffer = fs.readFileSync(fixturePath);
@@ -267,7 +267,7 @@ describe('against a real .note fixture', () => {
     });
 
     it('positions "Subject" within its own line on a real narrower (non-Manta, pageWidth 1404) note (issue #204)', () => {
-        // rtr.note above is a Manta-family capture (pageWidth 1920, where
+        // rtr-n5-20230015-recognition.note above is a Manta-family capture (pageWidth 1920, where
         // the 11.9 reference scale applies directly) - this fixture is the
         // far more common non-Manta case (pageWidth 1404, e.g. an A5X)
         // that exposed the bug: pixel-cropping the actual rendered page
@@ -276,7 +276,7 @@ describe('against a real .note fixture', () => {
         // ~8.70 scale for this pageWidth), not ~157 (the same native units
         // * the wrong, Manta-tuned 11.9) - a difference that compounds
         // with every line further down the page.
-        const a5xPath = path.join(import.meta.dirname, '..', '..', 'supernote-typescript', 'tests', 'input', 'a5x-2.14.28.note');
+        const a5xPath = path.join(import.meta.dirname, '..', '..', 'supernote-typescript', 'tests', 'input', 'ink-a5x-2.14.28-old-pen-width.note');
         const buffer = fs.readFileSync(a5xPath);
         const sn = new SupernoteX(new Uint8Array(buffer));
         const page = sn.pages[0];

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -72,9 +72,11 @@ export interface SupernotePluginSettings extends CustomDictionarySettings {
     directConnectIP: string;
     invertColorsWhenDark: boolean;
     showExportButtons: boolean;
-    /** Draw exported-PDF pen strokes as crisp vector paths instead of
-     * rasterizing the ink layers. On by default; turn off if an exported
-     * PDF renders ink incorrectly or differently from the device. */
+    /** Draw pen strokes as crisp vector paths instead of rasterizing the
+     * ink layers — in the on-screen note view and exported PDFs. On by
+     * default; turn off if ink renders incorrectly or differently from the
+     * device. The persisted key stays `vectorInk` (originally PDF-only) so
+     * existing installs keep their toggle state. */
     vectorInk: boolean;
     fileBrowserSortOrder: FileBrowserSortOrder;
     importFormat: ImportFormat;
@@ -158,8 +160,8 @@ export class SupernoteSettingTab extends PluginSettingTab {
                 },
             },
             {
-                name: 'Vector ink in PDF export',
-                desc: 'When on, an exported PDF draws pen strokes as crisp vector paths instead of rasterizing the ink. On by default; turn off if an exported PDF renders ink incorrectly or differently from the device.',
+                name: 'Vector ink',
+                desc: 'When on, the note viewer and PDF export draw pen strokes as crisp vector paths instead of rasterizing the ink. On by default; turn off if ink renders incorrectly or differently from the device.',
                 control: {
                     type: 'toggle',
                     key: 'vectorInk',
@@ -296,9 +298,9 @@ export class SupernoteSettingTab extends PluginSettingTab {
             );
 
         new Setting(containerEl)
-            .setName('Vector ink in PDF export')
+            .setName('Vector ink')
             .setDesc(
-                'When on, an exported PDF draws pen strokes as crisp vector paths instead of rasterizing the ink. On by default; turn off if an exported PDF renders ink incorrectly or differently from the device.',
+                'When on, the note viewer and PDF export draw pen strokes as crisp vector paths instead of rasterizing the ink. On by default; turn off if ink renders incorrectly or differently from the device.',
             )
             .addToggle((text) =>
                 text

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -72,6 +72,10 @@ export interface SupernotePluginSettings extends CustomDictionarySettings {
     directConnectIP: string;
     invertColorsWhenDark: boolean;
     showExportButtons: boolean;
+    /** Draw exported-PDF pen strokes as crisp vector paths instead of
+     * rasterizing the ink layers. On by default; turn off if an exported
+     * PDF renders ink incorrectly or differently from the device. */
+    vectorInk: boolean;
     fileBrowserSortOrder: FileBrowserSortOrder;
     importFormat: ImportFormat;
     /** Format the note viewer's toolbar "export current page" button writes
@@ -100,6 +104,7 @@ export const DEFAULT_SETTINGS: SupernotePluginSettings = {
     directConnectIP: '',
     invertColorsWhenDark: true,
     showExportButtons: false,
+    vectorInk: true,
     fileBrowserSortOrder: 'name-asc',
     importFormat: 'images-text',
     pageExportImageFormat: 'png',
@@ -150,6 +155,14 @@ export class SupernoteSettingTab extends PluginSettingTab {
                 control: {
                     type: 'toggle',
                     key: 'showExportButtons',
+                },
+            },
+            {
+                name: 'Vector ink in PDF export',
+                desc: 'When on, an exported PDF draws pen strokes as crisp vector paths instead of rasterizing the ink. On by default; turn off if an exported PDF renders ink incorrectly or differently from the device.',
+                control: {
+                    type: 'toggle',
+                    key: 'vectorInk',
                 },
             },
             {
@@ -278,6 +291,20 @@ export class SupernoteSettingTab extends PluginSettingTab {
                     .setValue(this.plugin.settings.showExportButtons)
                     .onChange(async (value) => {
                         this.plugin.settings.showExportButtons = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
+            .setName('Vector ink in PDF export')
+            .setDesc(
+                'When on, an exported PDF draws pen strokes as crisp vector paths instead of rasterizing the ink. On by default; turn off if an exported PDF renders ink incorrectly or differently from the device.',
+            )
+            .addToggle((text) =>
+                text
+                    .setValue(this.plugin.settings.vectorInk)
+                    .onChange(async (value) => {
+                        this.plugin.settings.vectorInk = value;
                         await this.plugin.saveSettings();
                     }),
             );

--- a/src/webcomponent/SupernoteAtelierViewerElement.test.ts
+++ b/src/webcomponent/SupernoteAtelierViewerElement.test.ts
@@ -10,7 +10,7 @@
 // render/atelierRenderer.ts's real functions directly instead, the same
 // "fake just the part the test environment can't run" pattern
 // SupernoteViewerElement.test.ts's own createViewer() uses for
-// rasterizePage. Real fixtures throughout (the same sample.spd supernote-
+// rasterizePage. Real fixtures throughout (the same atelier-sample-synthetic.spd supernote-
 // typescript's own atelier.test.ts uses), backed by the real sql.js wasm
 // binary via sql-wasm.test-stub.ts (see vitest.config.ts's own alias and
 // that stub's header comment for why a bare `.wasm` import needs one under
@@ -26,7 +26,7 @@ import './SupernoteAtelierViewerElement';
 
 const FIXTURES_DIR = path.join(import.meta.dirname, '..', '..', 'supernote-typescript', 'tests', 'input');
 
-// sample.spd's own known shape (see supernote-typescript/tests/atelier.test
+// atelier-sample-synthetic.spd's own known shape (see supernote-typescript/tests/atelier.test
 // .ts): 4 layers - "Layer 3" (id 3, surface_3, no tiles at all), "Layer 2"
 // (surface_2, has tiles), "Layer 1" (surface_1, has tiles), and a
 // background "Reference Layer" (id 9999, surface_9999, covers every tile -
@@ -81,7 +81,7 @@ describe('<supernote-atelier-viewer>', () => {
         const el = createAtelierViewer();
         document.body.appendChild(el);
         const loaded = waitForEvent<{ width: number; height: number; layerCount: number }>(el, 'supernote-atelier-load');
-        el.noteData = readFixture('sample.spd');
+        el.noteData = readFixture('atelier-sample-synthetic.spd');
 
         const evt = await loaded;
         expect(evt.detail.width).toBe(1536);
@@ -103,7 +103,7 @@ describe('<supernote-atelier-viewer>', () => {
         const el = createAtelierViewer();
         document.body.appendChild(el);
         const loaded = waitForEvent(el, 'supernote-atelier-load');
-        el.noteData = readFixture('sample.spd');
+        el.noteData = readFixture('atelier-sample-synthetic.spd');
         await loaded;
 
         const toggleBtn = el.shadowRoot!.querySelector('button[aria-label="Toggle layers"]');
@@ -126,7 +126,7 @@ describe('<supernote-atelier-viewer>', () => {
         const el = createAtelierViewer();
         document.body.appendChild(el);
         const loaded = waitForEvent(el, 'supernote-atelier-load');
-        el.noteData = readFixture('sample.spd');
+        el.noteData = readFixture('atelier-sample-synthetic.spd');
         await loaded;
 
         const img = el.shadowRoot!.querySelector('.atelier-image') as HTMLImageElement;

--- a/src/webcomponent/SupernoteViewerElement.test.ts
+++ b/src/webcomponent/SupernoteViewerElement.test.ts
@@ -56,7 +56,7 @@ describe('<supernote-viewer>', () => {
         const el = createViewer();
         document.body.appendChild(el);
         const loaded = waitForEvent<{ pageCount: number }>(el, 'supernote-load');
-        el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+        el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note');
 
         const evt = await loaded;
         expect(evt.detail.pageCount).toBe(2);
@@ -101,7 +101,7 @@ describe('<supernote-viewer>', () => {
         document.body.appendChild(el);
 
         const loaded = waitForEvent(el, 'supernote-load');
-        el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+        el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note');
         await loaded;
 
         const slot = el.shadowRoot!.querySelector<HTMLSlotElement>('slot[name="toolbar-extra"]');
@@ -114,7 +114,7 @@ describe('<supernote-viewer>', () => {
             const el = createViewer();
             document.body.appendChild(el);
             const loaded = waitForEvent(el, 'supernote-load');
-            el.noteData = readFixture('nomad-3.26.40-blank-2p.note'); // 2 pages
+            el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note'); // 2 pages
             await loaded;
 
             const findBtn = el.shadowRoot!.querySelector('button[aria-label="Find in note"]')!;
@@ -136,7 +136,7 @@ describe('<supernote-viewer>', () => {
             };
             document.body.appendChild(el);
             const loaded = waitForEvent(el, 'supernote-load');
-            el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+            el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note');
             await loaded;
 
             const findBtn = el.shadowRoot!.querySelector('button[aria-label="Find in note"]')!;
@@ -162,7 +162,7 @@ describe('<supernote-viewer>', () => {
         const el = createViewer();
         document.body.appendChild(el);
         const loaded = waitForEvent<{ pageIds: string[] }>(el, 'supernote-load');
-        el.noteData = readFixture('nomad-3.26.40-link-tag-3p.note');
+        el.noteData = readFixture('link-n6-3.26.40-partial-erase-3p.note');
 
         const evt = await loaded;
         expect(evt.detail.pageIds).toEqual([
@@ -194,7 +194,7 @@ describe('<supernote-viewer>', () => {
         const el = createViewer();
         document.body.appendChild(el);
         const loaded = waitForEvent(el, 'supernote-load');
-        el.noteData = readFixture('nomad-3.26.40-blank-2p.note'); // 2 pages
+        el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note'); // 2 pages
         await loaded;
 
         const pagesEl = el.shadowRoot!.querySelector('.pages')!;
@@ -238,7 +238,7 @@ describe('<supernote-viewer>', () => {
         el.textProcessor = (text) => text.toUpperCase();
         document.body.appendChild(el);
         const loaded = waitForEvent(el, 'supernote-load');
-        el.noteData = readFixture('rtr.note');
+        el.noteData = readFixture('rtr-n5-20230015-recognition.note');
         await loaded;
 
         const textEl = el.shadowRoot!.querySelector('.page-text');
@@ -250,7 +250,7 @@ describe('<supernote-viewer>', () => {
         const el = createViewer();
         document.body.appendChild(el);
         const loaded = waitForEvent(el, 'supernote-load');
-        el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+        el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note');
         await loaded;
 
         el.goToPage(2);
@@ -293,7 +293,7 @@ describe('<supernote-viewer>', () => {
         const el = createViewer();
         document.body.appendChild(el);
         const loaded = waitForEvent(el, 'supernote-load');
-        el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+        el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note');
         await loaded;
 
         const pagesEl = el.shadowRoot!.querySelector('.pages') as HTMLElement;
@@ -311,7 +311,7 @@ describe('<supernote-viewer>', () => {
             const el = createViewer();
             document.body.appendChild(el);
             const loaded = waitForEvent(el, 'supernote-load');
-            el.noteData = readFixture('nomad-3.26.40-blank-2p.note'); // 2 pages
+            el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note'); // 2 pages
             await loaded;
 
             const input = el.shadowRoot!.querySelector<HTMLInputElement>('.page-jump-input')!;
@@ -333,7 +333,7 @@ describe('<supernote-viewer>', () => {
             const el = createViewer();
             document.body.appendChild(el);
             const loaded = waitForEvent(el, 'supernote-load');
-            el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+            el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note');
             await loaded;
 
             const input = el.shadowRoot!.querySelector<HTMLInputElement>('.page-jump-input')!;
@@ -347,7 +347,7 @@ describe('<supernote-viewer>', () => {
             const el = createViewer();
             document.body.appendChild(el);
             const loaded = waitForEvent(el, 'supernote-load');
-            el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+            el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note');
             await loaded;
 
             const input = el.shadowRoot!.querySelector<HTMLInputElement>('.page-jump-input')!;
@@ -364,7 +364,7 @@ describe('<supernote-viewer>', () => {
             const el = createViewer();
             document.body.appendChild(el);
             const loaded = waitForEvent(el, 'supernote-load');
-            el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+            el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note');
             await loaded;
 
             const input = el.shadowRoot!.querySelector<HTMLInputElement>('.page-jump-input')!;
@@ -388,7 +388,7 @@ describe('<supernote-viewer>', () => {
             const el = createViewer();
             document.body.appendChild(el);
             const loaded = waitForEvent(el, 'supernote-load');
-            el.noteData = readFixture('nomad-3.26.40-blank-2p.note'); // pageWidth 1404, pageHeight 1872, 2 pages
+            el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note'); // pageWidth 1404, pageHeight 1872, 2 pages
             await loaded;
             return el;
         }
@@ -420,7 +420,7 @@ describe('<supernote-viewer>', () => {
             el.setAttribute('invert-dark', '');
             document.body.appendChild(el);
             const loaded = waitForEvent(el, 'supernote-load');
-            el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+            el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note');
             await loaded;
 
             const thumbs = el.shadowRoot!.querySelectorAll<HTMLImageElement>('.sidebar-list-thumb');
@@ -495,7 +495,7 @@ describe('<supernote-viewer>', () => {
             const el = createViewer();
             document.body.appendChild(el);
             const loaded = waitForEvent(el, 'supernote-load');
-            el.noteData = readFixture('rtr.note'); // 1 page
+            el.noteData = readFixture('rtr-n5-20230015-recognition.note'); // 1 page
             await loaded;
 
             expect(el.shadowRoot!.querySelector('button[aria-label="Toggle page thumbnails"]')).toBeNull();
@@ -507,7 +507,7 @@ describe('<supernote-viewer>', () => {
             el.setAttribute('single-page', '');
             document.body.appendChild(el);
             const loaded = waitForEvent(el, 'supernote-load');
-            el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+            el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note');
             await loaded;
 
             expect(el.shadowRoot!.querySelector('button[aria-label="Toggle page thumbnails"]')).toBeNull();
@@ -520,7 +520,7 @@ describe('<supernote-viewer>', () => {
             const el = createViewer();
             document.body.appendChild(el);
             const loaded = waitForEvent(el, 'supernote-load');
-            el.noteData = readFixture('nomad-3.26.40-blank-2p.note'); // pageWidth 1404, 2 pages
+            el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note'); // pageWidth 1404, 2 pages
             await loaded;
             return el;
         }
@@ -682,7 +682,7 @@ describe('<supernote-viewer>', () => {
             el.setAttribute('single-page', '');
             document.body.appendChild(el);
             const loaded = waitForEvent(el, 'supernote-load');
-            el.noteData = readFixture('nomad-3.26.40-blank-2p.note'); // pageWidth 1404
+            el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note'); // pageWidth 1404
             await loaded;
             await Promise.resolve();
             await Promise.resolve();
@@ -706,7 +706,7 @@ describe('<supernote-viewer>', () => {
         const el = createViewer();
         document.body.appendChild(el);
         const loaded = waitForEvent(el, 'supernote-load');
-        el.noteData = readFixture('rtr.note');
+        el.noteData = readFixture('rtr-n5-20230015-recognition.note');
         await loaded;
 
         const textEl = el.shadowRoot!.querySelector('.page-text');
@@ -723,7 +723,7 @@ describe('<supernote-viewer>', () => {
         el.setAttribute('page', '2');
         document.body.appendChild(el);
         const loaded = waitForEvent<{ pageCount: number }>(el, 'supernote-load');
-        el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+        el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note');
         await loaded;
         // ensurePageImageLoaded() is fired eagerly (no goToPage()/observer
         // needed) - give its microtasks a moment to settle.
@@ -746,7 +746,7 @@ describe('<supernote-viewer>', () => {
         el.setAttribute('page', '99');
         document.body.appendChild(el);
         const loaded = waitForEvent(el, 'supernote-load');
-        el.noteData = readFixture('nomad-3.26.40-blank-2p.note'); // 2 pages
+        el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note'); // 2 pages
         await loaded;
 
         expect(el.shadowRoot!.querySelector('.page-container')?.getAttribute('data-page-number')).toBe('2');
@@ -757,7 +757,7 @@ describe('<supernote-viewer>', () => {
         el.setAttribute('invert-dark', '');
         document.body.appendChild(el);
         const loaded = waitForEvent(el, 'supernote-load');
-        el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+        el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note');
         await loaded;
 
         const images = el.shadowRoot!.querySelectorAll('.page-container img');
@@ -771,7 +771,7 @@ describe('<supernote-viewer>', () => {
         const el = createViewer();
         document.body.appendChild(el);
         const loaded = waitForEvent(el, 'supernote-load');
-        el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+        el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note');
         await loaded;
 
         const img = el.shadowRoot!.querySelector('.page-container img');
@@ -782,7 +782,7 @@ describe('<supernote-viewer>', () => {
         const el = createViewer();
         document.body.appendChild(el);
         const loaded = waitForEvent(el, 'supernote-load');
-        el.noteData = readFixture('rtr.note');
+        el.noteData = readFixture('rtr-n5-20230015-recognition.note');
         await loaded;
 
         const spans = el.shadowRoot!.querySelectorAll('.word-overlay-span');
@@ -798,7 +798,7 @@ describe('<supernote-viewer>', () => {
         const el = createViewer();
         document.body.appendChild(el);
         const loaded = waitForEvent(el, 'supernote-load');
-        el.noteData = readFixture('rtr.note'); // 1 page
+        el.noteData = readFixture('rtr-n5-20230015-recognition.note'); // 1 page
         await loaded;
 
         expect(el.shadowRoot!.querySelector('.toolbar')).toBeTruthy();
@@ -812,7 +812,7 @@ describe('<supernote-viewer>', () => {
             const el = createViewer();
             document.body.appendChild(el);
             const loaded = waitForEvent(el, 'supernote-load');
-            el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+            el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note');
             await loaded;
             return el;
         }
@@ -879,7 +879,7 @@ describe('<supernote-viewer>', () => {
             const el = createViewer();
             document.body.appendChild(el);
             const loaded = waitForEvent(el, 'supernote-load');
-            el.noteData = readFixture('nomad-3.26.40-blank-2p.note');
+            el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note');
             await loaded;
             return el;
         }
@@ -971,7 +971,7 @@ describe('<supernote-viewer>', () => {
             const el = createViewer();
             document.body.appendChild(el);
             const loaded = waitForEvent(el, 'supernote-load');
-            el.noteData = readFixture('rtr.note');
+            el.noteData = readFixture('rtr-n5-20230015-recognition.note');
             await loaded;
             return el;
         }
@@ -1208,7 +1208,7 @@ describe('<supernote-viewer>', () => {
             const el = createViewer();
             document.body.appendChild(el);
             const loaded = waitForEvent(el, 'supernote-load');
-            el.noteData = readFixture('nomad-3.26.40-link-tag-3p.note');
+            el.noteData = readFixture('link-n6-3.26.40-partial-erase-3p.note');
             await loaded;
 
             const [page1, page2, page3] = Array.from(el.shadowRoot!.querySelectorAll('.page-container'));
@@ -1221,7 +1221,7 @@ describe('<supernote-viewer>', () => {
             const el = createViewer();
             document.body.appendChild(el);
             const loaded = waitForEvent(el, 'supernote-load');
-            el.noteData = readFixture('nomad-3.26.40-link-tag-3p.note');
+            el.noteData = readFixture('link-n6-3.26.40-partial-erase-3p.note');
             await loaded;
 
             const page2 = el.shadowRoot!.querySelectorAll('.page-container')[1];
@@ -1254,7 +1254,7 @@ describe('<supernote-viewer>', () => {
             const el = createViewer();
             document.body.appendChild(el);
             const loaded = waitForEvent(el, 'supernote-load');
-            el.noteData = readFixture('nomad-3.26.40-link-tag-3p.note');
+            el.noteData = readFixture('link-n6-3.26.40-partial-erase-3p.note');
             await loaded;
 
             const page2 = el.shadowRoot!.querySelectorAll('.page-container')[1];

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -707,12 +707,24 @@ export class SupernoteViewerElement extends HTMLElement {
         return ['src', 'page', 'single-page', 'invert-dark'];
     }
 
+    // Whether rasterizePage() below draws this page's pen strokes as crisp
+    // vector paths (an SVG data URL) instead of rasterizing the ink (a PNG
+    // data URL). Defaults false so the standalone web component — which has
+    // no settings UI of its own — keeps the simpler raster behavior a host
+    // that never asked for vector ink expects; a host with a vectorInk
+    // setting (SupernoteView/SupernoteEmbed in main.ts) sets this from its
+    // own settings. See imageConverter.ts's convertToImages() vectorInk flag
+    // for what this actually toggles downstream (the rasterize worker
+    // assembles an SVG via addSvgPage with the strokes drawn as vector
+    // <path>s on top of a background-only raster).
+    vectorInk = false;
+
     // Overridable so tests can substitute a fake rasterizer - the real
     // ImageConverter dispatches to a Web Worker (see imageConverter.ts),
     // which test environments without a real browser (e.g. happy-dom) don't
     // implement.
     rasterizePage: (sn: SupernoteX, pageNumber: number) => Promise<string> = async (sn, pageNumber) => {
-        const [imageDataUrl] = await new ImageConverter().convertToImages(sn, [pageNumber]);
+        const [imageDataUrl] = await new ImageConverter().convertToImages(sn, [pageNumber], undefined, this.vectorInk);
         return imageDataUrl;
     };
 


### PR DESCRIPTION
## Summary

Exports PDFs with pen strokes drawn as crisp vector paths instead of rasterized ink — sharp at any zoom — on by default, with a setting to turn it off if an export renders ink incorrectly or differently from the device.

Built on the new `vectorInk` feature in `supernote-typescript` (PR [philips/supernote-typescript#98](https://github.com/philips/supernote-typescript/pull/98)) and the public-API exports that landed for this plugin's batched-worker path (PR [philips/supernote-typescript#108](https://github.com/philips/supernote-typescript/pull/108)).

## Why a setting

Vector ink is a re-derivation of the ink from `TOTALPATH` metadata rather than the device's own rendered raster. The submodule's `prepareVectorInkPages` already decides per page whether the decoded strokes are trustworthy (it falls back to the raster for any page whose ink doesn't decode or decodes to nothing), but if a particular note/firmware combination renders wrong *despite* decoding, the user needs an escape hatch. So it's **on by default** and **turn-off-able** in settings.

## What changed

- **`c516f4c`** — Bump the `supernote-typescript` submodule `85aa459 → 80bdf75` (vectorInk #98, the fixture-naming pass #96, and the public-API exports #108: `prepareVectorInkPages`, `buildRenderNoteForVectorInk`, `VectorInkPage`).
- **`7497df7`** — Update the plugin's test fixture references after upstream PR #96 renamed `tests/input/` fixtures. The link-text expectation `'nomad-3.26.40-link-tag-3p#Page 1'` is unchanged (content stored inside the byte-identical note file, not a filename).
- **`ad602e9`** — Add `vectorInk: boolean` to `SupernotePluginSettings` (default `true`), with a declarative entry (`getSettingDefinitions`, so it shows in Obsidian's settings search on 1.13+) and the imperative `Setting` fallback (`display()`).
- **`870b5a2`** — Wire it into `buildPdfInWorker` + `pdfBuild.worker.ts`. On the main thread: `prepareVectorInkPages` builds per-page strokes/styles and decides per page whether vectors can replace the raster; `buildRenderNoteForVectorInk` returns a copy of the note with the bitmap ink layers stripped from those pages; `extractPdfPageData` slices that stripped note so the worker's `toImage` rasterizes only the background there. The strokes/styles ride alongside the page slices in the worker message as parallel arrays (`undefined` entries fall back to the raster); the worker passes them through to `addPdfPage`, which draws them as vector paths. This mirrors the submodule's `toPdf({vectorInk:true})` exactly, just spread across the plugin's existing dedicated worker so pdf-lib's cost still never blocks Obsidian's UI thread. Both call sites (`exportToPDF` and the `pdf` import format) pass `this.settings.vectorInk` through.
- **`0267822`** — `src/pdfBuild.test.ts` tests the plugin's own wiring (the part not covered by the submodule's own suite): on-path strips ink layers on exactly the `useVectorInk` pages and builds non-empty strokes/styles for exactly those; off-path leaves the note untouched.
- **`c58451f`** — README FAQ entry (the user-facing escape hatch) + an AGENTS.md note on what `pdfBuild.worker.ts` now consumes from the submodule.

## Verification

- `npm run build` (tsc + esbuild) clean.
- `npm run lint` — 0 errors (1 pre-existing `atelierView.ts` sentence-case warning, documented in AGENTS.md).
- `npm test` — **205/205 passing** (3 new in `pdfBuild.test.ts`).
- **Runtime PDF build** (the exact `buildPdfInWorker` pipeline in Node): vectorInk ON → the page content stream contains vector `m`/`l` operators alongside the background image `Do` (39330 bytes); OFF → only the image `Do`, no path operators (32556 bytes). Confirms the feature works end-to-end.
- **Headless Obsidian** (Xvfb + CDP, since I can't view screenshots): the supernote plugin loads in real Obsidian, `settings.vectorInk` resolves to `true`, and the Supernote settings tab renders the **"Vector ink in PDF export"** toggle as enabled (`.checkbox-container.is-enabled`) with no console exceptions. Screenshot: `/tmp/obs-supernote-settings.png`.

## Notes for review

- This depends on the submodule bump (commit `c516f4c`); the submodule is pinned to upstream `main`'s `80bdf75`, which includes the merged [philips/supernote-typescript#108](https://github.com/philips/supernote-typescript/pull/108) that exports the prep helpers this plugin now consumes.
- The `vectorInk` prep runs on the main thread (the worker only gets structured-clone-safe `IPdfPage` slices, which lack the `TOTALPATH`/`titles` data the decode reads). For a large note this is real but bounded work — strictly less than the rasterization the worker already does, since the ink layers are stripped from the worker's `toImage` pass (no double-decode). If it ever janks the UI on a huge note, the fallback is to also move prep into the worker by extending `extractPdfPageData` to carry `totalPathBuffer` + `note.titles`; left for a later pass.