### PR TITLE
Fix word-overlay and export text-layer alignment on N6/A6X (#219)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -61,7 +61,17 @@ function dataUrlMimeType(dataUrl: string): string {
 function buildSvgForPage(sn: SupernoteX, pageNumber: number, imageDataUrl: string): string {
     const { pageWidth, pageHeight, pages } = extractPdfPageData(sn, pageNumber);
     const pngBytes = new Uint8Array(dataUrlToBuffer(imageDataUrl));
-    return addSvgPage(pages[0], pngBytes, pageWidth, pageHeight);
+    // Pass the note's device family + native pageWidth so the invisible
+    // recognition-text overlay lands at the right position on every device
+    // (N6/A6X use their own pageWidth as the recognition canvas, not the
+    // 1920px reference A5X/Manta do — issue #219). nativePageWidth == the
+    // pageWidth here since this path never upscales; addSvgPage still needs
+    // it explicitly so a future caller rendering an upscaled image through
+    // here wouldn't silently regress.
+    return addSvgPage(pages[0], pngBytes, pageWidth, pageHeight, {
+        equipment: sn.header.APPLY_EQUIPMENT,
+        nativePageWidth: sn.pageWidth,
+    });
 }
 
 // app.fileManager.generateMarkdownLink() follows the vault's "Use Wikilinks"
@@ -139,6 +149,15 @@ async function buildPdfInWorker(sn: SupernoteX, vectorInk: boolean): Promise<Uin
                 pages,
                 strokes,
                 strokeStyles,
+                // The note's device family + native pageWidth drive the
+                // recognition-coordinate scale of the invisible text layer
+                // (N6/A6X use their own pageWidth as the recognition canvas,
+                // not the 1920px reference A5X/Manta do — issue #219).
+                // nativePageWidth == sn.pageWidth here since this path never
+                // upscales; addPdfPage still needs it explicitly so the
+                // canvas is recoverable if a future caller renders upscaled.
+                equipment: sn.header.APPLY_EQUIPMENT,
+                nativePageWidth: sn.pageWidth,
             };
             worker.postMessage(message);
         });

--- a/src/pdfBuild.worker.ts
+++ b/src/pdfBuild.worker.ts
@@ -26,7 +26,22 @@ export type PdfBuildWorkerMessage =
     // now-removed assemblePdfFromNote() for the fuller trail). Doing all of
     // that here means Obsidian's own UI thread never carries any of that
     // cost, regardless of how large it is.
-    { type: 'buildPdf'; pageWidth: number; pageHeight: number; pages: IPdfPage[]; strokes?: (IStroke[] | undefined)[]; strokeStyles?: (StrokeStyle[] | undefined)[] };
+    {
+        type: 'buildPdf';
+        pageWidth: number;
+        pageHeight: number;
+        pages: IPdfPage[];
+        strokes?: (IStroke[] | undefined)[];
+        strokeStyles?: (StrokeStyle[] | undefined)[];
+        // Device family (`header.APPLY_EQUIPMENT`) and native pageWidth for
+        // the invisible recognition-text layer's coordinate scale — see
+        // recognitionCoordinateScale in supernote-typescript. N6/A6X use
+        // their own pageWidth as the recognition canvas, not the 1920px
+        // reference A5X/Manta do, so without these the exported PDF's
+        // searchable text drifts off the ink on those devices (issue #219).
+        equipment?: string;
+        nativePageWidth?: number;
+    };
 
 export type PdfBuildWorkerResponse =
     | { type: 'pdfResult'; pdfBytes: Uint8Array }
@@ -103,6 +118,8 @@ self.onmessage = async (e: MessageEvent<PdfBuildWorkerMessage>) => {
                     // no-ops on empty/absent strokes either way.
                     strokes: data.strokes?.[start + i],
                     strokeStyles: data.strokeStyles?.[start + i],
+                    equipment: data.equipment,
+                    nativePageWidth: data.nativePageWidth,
                 });
             }
             console.debug(

--- a/src/render/wordOverlay.test.ts
+++ b/src/render/wordOverlay.test.ts
@@ -25,7 +25,7 @@ describe('buildWordOverlay', () => {
         ]);
         const container = document.createElement('div');
 
-        const entries = buildWordOverlay(page, container, 1, 1920);
+        const entries = buildWordOverlay(page, container, 1, 1920, 'N5');
 
         expect(entries).toHaveLength(1);
         expect(entries[0].label).toBe('Real');
@@ -41,7 +41,7 @@ describe('buildWordOverlay', () => {
         ]);
         const container = document.createElement('div');
 
-        const [entry] = buildWordOverlay(page, container, 1, 1920);
+        const [entry] = buildWordOverlay(page, container, 1, 1920, 'N5');
 
         expect(entry.nativeX).toBeCloseTo(10 * 11.9);
         expect(entry.nativeY).toBeCloseTo(20 * 11.9);
@@ -49,24 +49,50 @@ describe('buildWordOverlay', () => {
         expect(entry.nativeHeight).toBeCloseTo(40 * 11.9);
     });
 
-    it('scales proportionally to pageWidth, not a fixed 11.9, for narrower (non-Manta) devices (issue #204)', () => {
-        // Real, reported bug: notes from the far more common non-Manta
-        // device family (pageWidth 1404, e.g. an A5X) used the same fixed
-        // 11.9 scale tuned for Manta's 1920px-wide pages, landing
-        // recognized-word highlights increasingly far below the actual
-        // pen strokes the further down the page a word sat - confirmed by
-        // cropping the actual rendered page image at both the old and
-        // corrected positions against a real A5X note fixture.
+    it('scales proportionally to pageWidth, not a fixed 11.9, for A5X (whose recognition canvas is 1920, not its 1404 pageWidth) (issue #204)', () => {
+        // Real, reported bug: A5X (pageWidth 1404) renders recognition
+        // against a 1920px-wide canvas - the same one Manta uses - so its
+        // boxes need scaling down to the narrower page. Using the same fixed
+        // 11.9 scale tuned for that 1920px canvas landed recognized-word
+        // highlights increasingly far below the actual pen strokes the
+        // further down the page a word sat - confirmed by cropping the
+        // actual rendered page image at both the old and corrected
+        // positions against a real A5X note fixture.
         const page = fakePage([
             { label: 'x', type: 'Text', words: [{ label: 'x', 'bounding-box': { x: 10, y: 20, width: 30, height: 40 } }] },
         ]);
         const container = document.createElement('div');
 
-        const [entry] = buildWordOverlay(page, container, 1, 1404);
+        const [entry] = buildWordOverlay(page, container, 1, 1404, 'A5X');
 
         const expectedScale = (1404 * 11.9) / 1920;
         expect(entry.nativeX).toBeCloseTo(10 * expectedScale);
         expect(entry.nativeY).toBeCloseTo(20 * expectedScale);
+    });
+
+    it('uses the raw 11.9 scale at pageWidth 1404 for non-A5X devices (N6/Nomad, A6X), whose recognition canvas IS their pageWidth (issue #219)', () => {
+        // The other side of issue #204's over-generalization: #204 assumed
+        // *every* non-Manta device renders recognition against the 1920px
+        // canvas and scaled all of them by pageWidth/1920. That is correct
+        // for A5X but wrong for N6 (Nomad) and A6X, which both have
+        // pageWidth 1404 yet render recognition natively at 1404 - so their
+        // boxes line up at the raw 11.9 and the pageWidth/1920 shrink
+        // (down to ~8.70) pulls them a full line high per line down the
+        // page. Confirmed against real N6/A6X fixtures by rendering each
+        // page and measuring ink density inside the recognition boxes
+        // across a scale sweep: 11.9 peaks sharply, 8.70 is a trough.
+        const page = fakePage([
+            { label: 'x', type: 'Text', words: [{ label: 'x', 'bounding-box': { x: 10, y: 20, width: 30, height: 40 } }] },
+        ]);
+        const container = document.createElement('div');
+
+        for (const equipment of ['N6', 'A6X']) {
+            const [entry] = buildWordOverlay(page, container, 1, 1404, equipment);
+            expect(entry.nativeX).toBeCloseTo(10 * 11.9);
+            expect(entry.nativeY).toBeCloseTo(20 * 11.9);
+            expect(entry.nativeWidth).toBeCloseTo(30 * 11.9);
+            expect(entry.nativeHeight).toBeCloseTo(40 * 11.9);
+        }
     });
 
     it('keeps a word without a bounding box as a null-el entry rather than dropping it', () => {
@@ -82,7 +108,7 @@ describe('buildWordOverlay', () => {
         ]);
         const container = document.createElement('div');
 
-        const entries = buildWordOverlay(page, container, 1, 1920);
+        const entries = buildWordOverlay(page, container, 1, 1920, 'N5');
 
         expect(entries.map((e) => e.label)).toEqual(['paragraph', ' ', 'test']);
         expect(entries[1].el).toBeNull();
@@ -95,7 +121,7 @@ describe('buildWordOverlay', () => {
         ]);
         const container = document.createElement('div');
 
-        expect(buildWordOverlay(page, container, 1, 1920)).toHaveLength(0);
+        expect(buildWordOverlay(page, container, 1, 1920, 'N5')).toHaveLength(0);
     });
 });
 
@@ -113,7 +139,7 @@ describe('buildWordSearchText', () => {
                 ],
             },
         ]);
-        const entries = buildWordOverlay(page, container, 1, 1920);
+        const entries = buildWordOverlay(page, container, 1, 1920, 'N5');
 
         const { text } = buildWordSearchText(entries);
 
@@ -133,7 +159,7 @@ describe('buildWordSearchText', () => {
                 ],
             },
         ]);
-        const entries = buildWordOverlay(page, container, 1, 1920);
+        const entries = buildWordOverlay(page, container, 1, 1920, 'N5');
 
         const { text, entryAt } = buildWordSearchText(entries);
         expect(text).toBe('Real time');
@@ -175,7 +201,7 @@ describe('buildWordSearchText', () => {
                     ],
                 },
             ]);
-            const entries = buildWordOverlay(page, container, 1, 1920);
+            const entries = buildWordOverlay(page, container, 1, 1920, 'N5');
             const { text, entriesInRange } = buildWordSearchText(entries);
             expect(text).toBe('With enough space');
 
@@ -195,7 +221,7 @@ describe('repositionWordOverlay', () => {
     it('scales native rects into the currently rendered CSS pixel size', () => {
         const container = document.createElement('div');
         const page = fakePage([{ label: 'x', type: 'Text', words: [{ label: 'x', 'bounding-box': { x: 10, y: 10, width: 10, height: 10 } }] }]);
-        const entries = buildWordOverlay(page, container, 1, 1920);
+        const entries = buildWordOverlay(page, container, 1, 1920, 'N5');
         // native x/y/w/h are all 10 * 11.9 = 119
 
         repositionWordOverlay(entries, 238, 238, 238, 238); // rendered == native -> scale 1
@@ -226,7 +252,7 @@ describe('against a real .note fixture', () => {
         const page = sn.pages[0];
         const container = document.createElement('div');
 
-        const entries = buildWordOverlay(page, container, 1, sn.pageWidth);
+        const entries = buildWordOverlay(page, container, 1, sn.pageWidth, sn.header.APPLY_EQUIPMENT);
         expect(entries.length).toBeGreaterThan(0);
 
         const boxed = entries.filter((e) => e.el !== null);
@@ -260,7 +286,7 @@ describe('against a real .note fixture', () => {
         const page = sn.pages[0];
         const container = document.createElement('div');
 
-        const entries = buildWordOverlay(page, container, 1, sn.pageWidth);
+        const entries = buildWordOverlay(page, container, 1, sn.pageWidth, sn.header.APPLY_EQUIPMENT);
         const { text } = buildWordSearchText(entries);
 
         expect(text).toBe(page.text);
@@ -283,11 +309,42 @@ describe('against a real .note fixture', () => {
         const container = document.createElement('div');
 
         expect(sn.pageWidth).toBe(1404);
-        const entries = buildWordOverlay(page, container, 1, sn.pageWidth);
+        expect(sn.header.APPLY_EQUIPMENT).toBe('A5X');
+        const entries = buildWordOverlay(page, container, 1, sn.pageWidth, sn.header.APPLY_EQUIPMENT);
         const subject = entries.find((e) => e.label === 'Subject');
 
         expect(subject).toBeDefined();
         const expectedScale = (1404 * 11.9) / 1920;
         expect(subject!.nativeY).toBeCloseTo(13.224001 * expectedScale, 0);
+    });
+
+    it('positions N6 (Nomad) recognized words at the raw 11.9 scale, not the A5X-style pageWidth/1920 shrink (issue #219)', () => {
+        // link-n6-3.26.40-partial-erase-3p.note is one of the two N6 fixtures
+        // issue #219 called out: its word-overlay spans lined up on A5X/N5
+        // files but drifted off the ink on this one. pageWidth is 1404 -
+        // identical to A5X - yet (per the ink-density sweep across scales
+        // documented in wordOverlay.ts's recognitionCoordinateScale comment)
+        // its recognition boxes line up at the raw 11.9, not at the
+        // (1404 * 11.9) / 1920 ≈ 8.70 the pre-fix code applied. The page's
+        // first recognized word is "INK"; asserting its native position
+        // against 11.9 (and explicitly NOT against 8.70) pins the fix.
+        const n6Path = path.join(import.meta.dirname, '..', '..', 'supernote-typescript', 'tests', 'input', 'link-n6-3.26.40-partial-erase-3p.note');
+        const buffer = fs.readFileSync(n6Path);
+        const sn = new SupernoteX(new Uint8Array(buffer));
+        const page = sn.pages[0];
+        const container = document.createElement('div');
+
+        expect(sn.pageWidth).toBe(1404);
+        expect(sn.header.APPLY_EQUIPMENT).toBe('N6');
+        const entries = buildWordOverlay(page, container, 1, sn.pageWidth, sn.header.APPLY_EQUIPMENT);
+        const ink = entries.find((e) => e.label === 'INK');
+        expect(ink).toBeDefined();
+
+        // box { x: 4.6615, y: 12.097501, width: 22.956001, height: 7.0700006 }
+        // * 11.9 (the correct N6 scale):
+        expect(ink!.nativeX).toBeCloseTo(4.6615 * 11.9, 0);
+        expect(ink!.nativeY).toBeCloseTo(12.097501 * 11.9, 0);
+        // ...and explicitly NOT the pre-fix 8.70 value (would be ~105, not ~144):
+        expect(ink!.nativeY).not.toBeCloseTo(12.097501 * ((1404 * 11.9) / 1920), 0);
     });
 });

--- a/src/render/wordOverlay.ts
+++ b/src/render/wordOverlay.ts
@@ -41,29 +41,46 @@ export interface WordOverlayEntry {
 }
 
 // Recognized word bounding boxes are stored in raster-pixel units divided by
-// a scale factor - NOT a universal constant, confirmed via real device
-// files: 11.9 (this constant's own long-standing value, and
-// supernote-typescript/src/pdf.ts's identical copy - see that constant's
-// own comment) only holds for notes from Manta-family devices
-// (SupernoteX's own `header.APPLY_EQUIPMENT === 'N5'` check, pageWidth
-// 1920) - real-world testing against an A5X-family note (pageWidth 1404,
-// the *default* for every device other than Manta) found recognized-word
-// highlights landing up to a full page-height below the actual pen
-// strokes (issue #204's second checkbox), the error compounding with
-// distance down the page in exactly the way a wrong *multiplicative*
-// factor would, not a fixed offset.
+// a scale factor that is NOT a universal constant - it depends on which
+// device family produced the note, confirmed via real device files.
 //
-// Cropping the actual rendered page image at the position each formula
-// predicts (not just eyeballing) confirmed the fix directly: 11.9 is
-// exactly right for a 1920px-wide page and only that page width -
-// scaling it down by the same ratio the actual page is narrower than
-// 1920 lines every word up tightly again on a 1404-wide (A5X) page.
-// I.e. the true constant is a *reference page width*, not a scale
-// factor: recognition coordinates are defined against a fixed
-// 1920/11.9 ≈ 161.34-unit-wide canvas, and need dividing by whatever
-// fraction of 1920px this particular note's own page actually is.
-function recognitionCoordinateScale(pageWidth: number): number {
-    return (pageWidth * 11.9) / 1920;
+// The recognition engine renders each page to a fixed-width "reference
+// canvas" before recognizing, and stores bounding boxes in that canvas's
+// pixel space divided by 11.9 (this constant's own long-standing value, and
+// supernote-typescript/src/pdf.ts's identical copy - see that constant's own
+// comment). So the universal part is: canvas_pixel = recognition_unit * 11.9.
+// What is *not* universal is the reference canvas width:
+//
+//   - A5X (pageWidth 1404) renders recognition against a 1920px-wide canvas
+//     - the same one Manta uses - so its boxes need scaling down to the
+//     narrower page: page_pixel = unit * 11.9 * (1404 / 1920) ≈ unit * 8.70.
+//     This was issue #204: a fixed 11.9 landed A5X highlights a full
+//     page-height below the actual pen strokes, the error compounding with
+//     distance down the page in exactly the way a wrong multiplicative
+//     factor would.
+//   - Every other device family with recognition data we have - Manta (N5,
+//     pageWidth 1920), Nomad (N6, pageWidth 1404), and A6X (pageWidth 1404) -
+//     renders recognition against a canvas *equal to its own pageWidth*, so
+//     the pageWidth/1920 shrink from #204 is a no-op for Manta (1920/1920)
+//     but actively WRONG for N6/A6X: it shrinks their boxes by 1404/1920 to
+//     a scale of ~8.70 when they already line up at the raw 11.9. Issue #219:
+//     the word-overlay spans lined up on A5X and N5 files but drifted off the
+//     ink on N6 files (and, by the same mechanism, A6X).
+//
+// I.e. #204's "recognition coordinates are defined against a fixed 1920-unit
+// canvas" model was over-generalized from a single A5X fixture: A5X really
+// is the only known device whose recognition canvas (1920) differs from its
+// pageWidth (1404). For every other device the canvas IS the pageWidth, so
+// the correct scale is just the raw 11.9 and the pageWidth/1920 factor must
+// NOT be applied. (A pre-X A5, if one exists, may also upsample to 1920 the
+// way A5X does - we have no fixture to confirm; only A5X is special-cased
+// here, deliberately, because it's the only one the data covers.)
+function recognitionCoordinateScale(pageWidth: number, equipment: string): number {
+    // A5X is the only known device whose recognition canvas (1920) differs
+    // from its own pageWidth. For everyone else the canvas equals pageWidth,
+    // so the pageWidth/1920 factor collapses to 1 and the raw 11.9 applies.
+    const referenceCanvasWidth = equipment === 'A5X' ? 1920 : pageWidth;
+    return (pageWidth * 11.9) / referenceCanvasWidth;
 }
 
 // Some recognition environments produce mojibake-looking labels that are
@@ -109,10 +126,11 @@ export function buildWordOverlay(
     container: HTMLElement,
     pageNumber: number,
     pageWidth: number,
+    equipment: string,
 ): WordOverlayEntry[] {
     const entries: WordOverlayEntry[] = [];
     const textElements = page.recognitionElements.filter((element) => element.type === 'Text');
-    const scale = recognitionCoordinateScale(pageWidth);
+    const scale = recognitionCoordinateScale(pageWidth, equipment);
 
     for (let elementIndex = 0; elementIndex < textElements.length; elementIndex++) {
         for (const word of textElements[elementIndex].words) {

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -1255,7 +1255,7 @@ export class SupernoteViewerElement extends HTMLElement {
             // overlay is built and correctly positioned" a plain invariant
             // rather than something a caller needs to check the render mode
             // to reason about.
-            const wordEntries = notePage ? buildWordOverlay(notePage, page.containerEl, page.pageNumber, sn.pageWidth) : [];
+            const wordEntries = notePage ? buildWordOverlay(notePage, page.containerEl, page.pageNumber, sn.pageWidth, sn.header.APPLY_EQUIPMENT) : [];
 
             const linkEntries = buildLinkOverlay(linksByPage.get(page.pageNumber - 1) ?? [], page.containerEl);
             for (const entry of linkEntries) {


### PR DESCRIPTION
## Fixes #219

The `word-overlay-span`s (the invisible per-word boxes that power find-in-note in `<supernote-viewer>`) were misaligned on Nomad (N6) files but fine on A5X/N5.

### Root cause

`recognitionCoordinateScale` assumed **every** device's recognition canvas is 1920px and scaled all of them by `pageWidth/1920`. That was derived from a single A5X fixture and over-generalized. The recognition canvas is a **fixed per-device constant**: `1920` for Manta (N5) and A5X, but the device's **own native pageWidth** for Nomad (N6) and A6X (1404). So N6/A6X want the raw 11.9 at native resolution — the `pageWidth/1920` shrink pulled their boxes to ~8.70, drifting highlights off the ink the further down the page a word sat.

Confirmed by rendering every recognition-bearing fixture and measuring ink density inside the recognition boxes across a scale sweep: A5X peaks at ~8.70, N5/N6/A6X all peak at 11.9.

### The fix

Three plugin paths build a recognition text layer; all now thread the note's device family (`header.APPLY_EQUIPMENT`) and native pageWidth:

- **`src/render/wordOverlay.ts`** — the on-screen `<supernote-viewer>` word-overlay spans (find-in-note). `buildWordOverlay` gains an `equipment` param; `recognitionCoordinateScale` special-cases A5X (the only known device whose 1920 canvas differs from its 1404 pageWidth) and uses the device's own pageWidth for everyone else. `SupernoteViewerElement` passes `sn.header.APPLY_EQUIPMENT`.
- **`src/main.ts buildSvgForPage`** — per-page SVG export. Passes `equipment` + `nativePageWidth` to `addSvgPage`.
- **`src/main.ts buildPdfInWorker` + `src/pdfBuild.worker.ts`** — PDF export. `PdfBuildWorkerMessage` gains `equipment` + `nativePageWidth`, forwarded to `addPdfPage`.

The on-screen `rasterize.worker.ts` path uses `includeText: false` (no text layer), so it needs no change.

### Submodule bump

Bumps `supernote-typescript` to `b95d1fd` (merge of [supernote-typescript#110](https://github.com/philips/supernote-typescript/pull/110)), which makes the matching fix in the submodule's `recognitionCoordinateScale` and threads `equipment` through `toPdf`/`toSvg`/`addPdfPage`/`addSvgPage` and their tests. That bump also pulls in the submodule's test-fixture rename (a `{purpose}-{device}-{version}-{description}` convention), so this PR updates the plugin's test fixture references to the new names too.

### Verification

`npm test` 204/204, `npm run lint` clean (only the pre-existing sentence-case warning), `npm run build` clean.

End-to-end via the plugin's `buildSvgForPage` on `link-n6-3.26.40-partial-erase-3p.note` (one of #219's failing files):

| fixture | equip | word | fixed y | legacy y | moved |
|---|---|---|---|---|---|
| link-n6-3.26.40-partial-erase-3p | N6 | INK | 228.1 | 166.8 | **61.3px** ✓ |
| ink-a5x-2.14.28-old-pen-width | A5X | Subject | 200.7 | 200.7 | 0.0 (no regression) |
| rtr-n5-20230015-recognition | N5 | Real | 272.3 | 272.3 | 0.0 (no regression) |

The N6 case corrects by ~61px; A5X and N5 are unchanged, so the fix doesn't regress the families #204 was for.

### Tests added

`src/render/wordOverlay.test.ts`:
- N6/A6X at pageWidth 1404 use the raw 11.9 (not the A5X-style `pageWidth/1920` shrink).
- Real-fixture test against `link-n6-3.26.40-partial-erase-3p.note` pinning `INK` to `* 11.9` and explicitly **not** `* 8.70`.
- Updated the existing #204 test to pass `A5X` (still expects the 8.70 scale — A5X unchanged).