### PR TITLE
Security audit phases 1-3: verify network egress posture, harden device path handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "2.9.1",
 			"license": "MIT",
 			"dependencies": {
-				"esbuild-plugin-inline-worker": "^0.1.1",
 				"fast-png": "^7.0.1",
 				"image-js": "^1.7.0",
 				"pdf-lib": "^1.17.1",
@@ -22,6 +21,7 @@
 				"@types/node": "20.19.43",
 				"builtin-modules": "3.3.0",
 				"esbuild": "^0.28.2",
+				"esbuild-plugin-inline-worker": "^0.1.1",
 				"eslint": "^9.39.5",
 				"eslint-plugin-obsidianmd": "^0.4.1",
 				"globals": "^17.7.0",
@@ -134,6 +134,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -150,6 +151,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -166,6 +168,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -182,6 +185,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -198,6 +202,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -214,6 +219,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -230,6 +236,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -246,6 +253,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -262,6 +270,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -278,6 +287,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -294,6 +304,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -310,6 +321,7 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -326,6 +338,7 @@
 			"cpu": [
 				"mips64el"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -342,6 +355,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -358,6 +372,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -374,6 +389,7 @@
 			"cpu": [
 				"s390x"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -390,6 +406,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -406,6 +423,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -422,6 +440,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -438,6 +457,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -454,6 +474,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -470,6 +491,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -486,6 +508,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -502,6 +525,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -518,6 +542,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -534,6 +559,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2212,6 +2238,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/concat-map": {
@@ -2659,6 +2686,7 @@
 			"version": "0.28.2",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
 			"integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -2700,6 +2728,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/esbuild-plugin-inline-worker/-/esbuild-plugin-inline-worker-0.1.1.tgz",
 			"integrity": "sha512-VmFqsQKxUlbM51C1y5bRiMeyc1x2yTdMXhKB6S//++g9aCBg8TfGsbKxl5ZDkCGquqLY+RmEk93TBNd0i35dPA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "latest",
@@ -3509,6 +3538,7 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
 			"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"commondir": "^1.0.1",
@@ -5052,6 +5082,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
 			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^6.0.0"
@@ -5067,6 +5098,7 @@
 			"version": "6.3.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -5587,6 +5619,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -5621,6 +5654,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -5696,6 +5730,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
 			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"find-up": "^4.0.0"
@@ -5708,6 +5743,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
 			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"locate-path": "^5.0.0",
@@ -5721,6 +5757,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
 			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"p-locate": "^4.1.0"
@@ -5733,6 +5770,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
 			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"p-try": "^2.0.0"
@@ -5748,6 +5786,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
 			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"p-limit": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"@types/node": "20.19.43",
 		"builtin-modules": "3.3.0",
 		"esbuild": "^0.28.2",
+		"esbuild-plugin-inline-worker": "^0.1.1",
 		"eslint": "^9.39.5",
 		"eslint-plugin-obsidianmd": "^0.4.1",
 		"globals": "^17.7.0",
@@ -37,7 +38,6 @@
 		"vitest": "4.1.10"
 	},
 	"dependencies": {
-		"esbuild-plugin-inline-worker": "^0.1.1",
 		"fast-png": "^7.0.1",
 		"image-js": "^1.7.0",
 		"pdf-lib": "^1.17.1",

--- a/plans/SECURITY-AUDIT-PHASES-1-3.md
+++ b/plans/SECURITY-AUDIT-PHASES-1-3.md
@@ -1,0 +1,182 @@
+# Security Audit — Phases 1–3 Results (static, data-flow, dependency/bundle)
+
+**Status:** Phases 1–3 complete. Phase 4 (runtime verification) and Phases 5–6
+(guards / final report) pending.
+
+**Audited at:**
+- Plugin: `49f6518ec954ba1504bf9466228623acdcea8152`
+- Submodule `supernote-typescript`: `b95d1fdf2e7b3b037f0343c948572aa237c422f1` (v0.5.4-85-gb95d1fd)
+- Bundle: rebuilt fresh via `./scripts/build` (production, minified) during this audit.
+
+## Phase 1 — Static source scan: result
+
+Every network-capable API hit in `src/`, `supernote-typescript/src/`,
+`scripts/`, and the esbuild configs is accounted for by the allowlist (details
+under Phase 2 / Phase 3). No unlisted hits.
+
+| API | Hits | Verdict |
+|---|---|---|
+| `requestUrl` | `src/deviceFetch.ts` only | Allowlist #1 ✓ |
+| `fetch(` | `supernote-typescript/src/mirror.ts:8`; `src/webcomponent/SupernoteViewerElement.ts:1082`; `src/webcomponent/SupernoteAtelierViewerElement.ts:438` | Allowlist #2 + the two known web-component `src` loads ✓ (fetch path unreachable in plugin — see below) |
+| `XMLHttpRequest` / `WebSocket` / `EventSource` / `sendBeacon` | 0 in source | ✓ |
+| Dynamic `import(` / `importScripts` / `<script>`/`<link>` DOM injection | 0 | ✓ (no dynamic code loading at runtime) |
+| `http(s)://` / `ws://` literals | `deviceFetch.ts:80` (`http://${ip}:8089${path}`), `mirror.ts:4` (`http://${ipAddress}/screencast.mjpeg`), plus `w3.org` SVG-namespace strings | ✓ |
+| `new URL(` | 0 | ✓ |
+| `img.src` / media elements | `noteRenderer.ts`, `sidebarList.ts`, web components — all assigned `imageDataUrl`/`composite.dataUrl` (data URLs from local renders) | ✓ |
+| Workers (`rasterize`, `pdfBuild`, `atelierComposite`) | no `fetch`/`importScripts`/XHR in any worker | ✓ |
+| `postMessage` surfaces | only dedicated bundled Workers (`self.onmessage` ↔ `worker.onmessage` pairs); no window-level `message` listener, no iframes, no `window.open` | ✓ |
+| `navigator.*` | `navigator.hardwareConcurrency` reads only | ✓ |
+
+Reproducible commands (rerun verbatim for re-audit):
+
+```bash
+grep -rn --include='*.ts' --include='*.mts' --include='*.mjs' -E \
+  '\bfetch\s*\(|requestUrl|XMLHttpRequest|WebSocket|EventSource|sendBeacon' \
+  src/ supernote-typescript/src/ scripts/ esbuild*.mjs
+grep -rn --include='*.ts' -E '\bimport\s*\(|importScripts|createElement\(\s*.script.' src/ supernote-typescript/src/
+grep -rn --include='*.ts' -E 'https?://|wss?://' src/ supernote-typescript/src/ scripts/
+grep -rn --include='*.ts' -E 'new URL\(|\.src\s*=|new Audio|navigator\.' src/ supernote-typescript/src/
+grep -rn --include='*.ts' -E 'postMessage|onmessage|iframe|window\.open|FormData' src/ supernote-typescript/src/
+```
+
+Non-issues re-confirmed:
+- **Web-component `fetch(src)`**: all four plugin-side instantiations
+  (`main.ts:824`, `main.ts:1081`, `atelierView.ts:145`, `atelierView.ts:224`)
+  set `viewer.noteData = bytes` and never set a `src` attribute;
+  `loadBytes()` returns `_noteData` before reaching `getAttribute('src')`.
+  The fetch path only runs in the standalone bundles. (CSP note for
+  standalone docs: deferred to Phase 6.)
+- **Scripts**: `scripts/setup-obsidian-test-env` curls
+  `api.github.com/repos/obsidianmd/obsidian-releases` — dev-time only,
+  developer-initiated, not part of the shipped artifact.
+
+## Phase 2 — Data-flow review of allowlisted call sites
+
+### #1 `fetchFromDevice()` — `requestUrl` → `http://{ip}:8089{path}`
+
+**Host provenance — verified.** All callers pass `settings.directConnectIP`
+verbatim: `FileListModal.ts:30/177/253/351`, `ImportTodayModal.ts:166-170`,
+`syncEngine.ts:105/130`. `directConnectIP` is constrained by
+`IP_VALIDATION_PATTERN` (`settings.ts:6` — strict dotted-quad IPv4, no scheme,
+port, `/`, `@`, or credentials) in both the declarative settings control
+(`settings.ts:140`) and the classic settings tab (`settings.ts:257`), plus
+`FileListModal.ts:331` before uploads. A hand-edited `data.json` could bypass
+the pattern — that is user choice, not plugin exfiltration (recorded).
+
+**Path construction — finding F1 below.** `path` is interpolated unvalidated;
+sources are the constant `/` or device-supplied `uri` fields from directory
+listings.
+
+**Redirects — finding F2 below.** `requestUrl` follows redirects by default.
+
+**Write side (path traversal, GHSA-3gx3-r874-5pp4):**
+- `syncEngine` ✓ — writes only through `deviceUriToVaultPath()`
+  (`deviceSync.ts`), which drops `.`/`..` segments and strips
+  `\\:*?"<>|` chars; regression tests present in `deviceSync.test.ts`.
+- `ImportTodayModal` ✓ — files come via `scanDeviceSupernoteTree()`, whose
+  `uriMatchesName` gate requires `name` to equal a single `uri` segment;
+  since segments cannot contain `/`, a name reaching
+  `buildInsertableContent()` cannot contain slashes, so
+  `getAvailablePathForAttachment(name)` is traversal-safe here.
+- `DownloadListModal` — finding F3 below (browse listing bypasses the
+  `uriMatchesName` gate).
+
+### #2 Screen mirroring — `fetch()` → `http://{ip}:8080/screencast.mjpeg`
+
+**Verified.** Sole call site `main.ts:1248`:
+`fetchMirrorFrame(\`${this.settings.directConnectIP}:8080\`)`. No other URL
+shape reaches `fetchMirrorFrame`. The WKWebView/CORS rationale comment at
+`main.ts:1223-1229` matches reality (mobile fails fast with an actionable
+error; only desktop issues the fetch). Response handling parses MJPEG parts
+and decodes JPEG bytes locally — no URL/HTML from the response is ever
+followed or executed. Same redirect caveat as F2 applies to this `fetch`.
+
+### Settings hygiene
+
+Covered above: IP shape validated at every settings entry point; stored
+locally; used as-is. Optional hardening (validating on load, not just on
+save) noted but not required by the threat model.
+
+## Phase 3 — Dependency & bundle audit
+
+**Bundle network surface (fresh production `main.js`):** exactly two request
+URLs are ever constructed:
+
+```
+http://${t}:8089${e}          (deviceFetch — allowlist #1)
+http://${t}/screencast.mjpeg  (mirror — allowlist #2)
+```
+
+Other occurrences in the bundle, all accounted for:
+- `fetch(` ×5: 1 mirror, 2 web-component `src` loads (dead in plugin), 2
+  sql.js emscripten-glue wasm fallbacks (dead — see below).
+- `XMLHttpRequest` ×9: 7 image-js `Image.load()` URL loaders (bundled but
+  never called — plugin only uses `decode(bytes)`), 2 sql.js sync-XHR wasm
+  fallbacks (dead).
+- `locateFile` ×4 (2 unique × 2 sql.js copies): default-arg glue, never
+  evaluated to a fetch when `wasmBinary` is set.
+- `eval("require")` ×4: sql.js node-builtin probe (`stream`), inert in the
+  renderer, never remote code.
+- All `https://…` strings are error-message / PDF-producer text, not
+  requests. No `ws://`, no `importScripts`.
+
+**sql.js wasm — verified a data blob, not a runtime fetch.**
+`atelierRenderer.ts:18` imports `sql.js/dist/sql-wasm.wasm` (esbuild
+`.wasm: 'binary'` loader, inlined in the bundle — same config repeated for
+the inline-worker build) and passes `wasmBinary` at both call sites
+(`atelierRenderer.ts:33`, worker equivalent). In the bundled minified glue,
+the fetch fallback is gated behind `if(!wasmBinary)` and the instantiate path
+short-circuits `if (file==wasmBinaryFile && wasmBinary) → new
+Uint8Array(wasmBinary)` — confirmed by direct inspection of the minified
+code. No CDN URL survives.
+
+**esbuild externals — verified.** `main` config: `obsidian`, `electron`,
+codemirror/lezer packages, node builtins — all Obsidian-runtime-provided.
+Web-component configs: node builtins only. Nothing externalizes to a CDN or
+runtime loader.
+
+**npm audit — 4 high, all dev-only.** `brace-expansion` (×5 paths),
+`fast-uri`, `js-yaml`, `nanoid` — every occurrence resolves under the
+eslint/typescript-eslint toolchain (`npm ls` verified); none are reachable
+from `main.js` (runtime deps: `fast-png`, `image-js`, `pdf-lib`, `sql.js` —
+see F4 for the one mislabel).
+
+**Standalone web-component bundles (`dist/supernote-viewer.js`,
+`dist/supernote-atelier-viewer.js`):** contain only the intended
+`fetch(src)` load plus the same dead image-js/sql.js glue described above.
+
+## Findings
+
+**Remediation status (post-audit pass):** F1, F3, and F4 fixed (see below);
+F2 and F5 remain accepted-as-documented. The F3 fix also tightened the
+`scanDeviceSupernoteTree` gate with `isPlainFileName` — while implementing it
+we noticed the GHSA-3gx3 backstop (`uriMatchesName`, which splits only on
+`/`) did not block backslash-laden names (e.g. `..\..\evil.note`) reaching
+`getAvailablePathForAttachment` via the import-today flow, since Obsidian's
+path normalization turns `\` into `/`; the new gate closes that for sync,
+import-today, and the interactive browse/download path alike. Covered by
+regression tests in `src/deviceFetch.test.ts` (host pinning) and
+`src/FileListModal.test.ts` (entry trust).
+
+| ID | Severity | Location | Description | Remediation |
+|---|---|---|---|---|
+| F1 | Low (requires hostile device/impersonator) | `src/deviceFetch.ts:80` | Device-supplied `path` is interpolated into `http://${ip}:8089${path}` without enforcing a leading `/`. A crafted listing `uri` like `@evil.example/x` yields `http://ip:8089@evil.example/x`, which WHATWG URL parsing reads as userinfo `ip:8089` + host `evil.example` — the request leaves the device host. Violates the "host derives only from settings" rule even though the attacker needs the device's LAN position. | **Fixed:** `fetchFromDevice` now normalizes `path` to a leading `/` (prefix, so odd-but-benign listings keep working); a leading `/` terminates the URL authority right after the port, pinning the host. Regression tests in `deviceFetch.test.ts`. |
+| F2 | Info (documented exception) | `deviceFetch.ts` (requestUrl), `mirror.ts` (fetch) | Both transports follow redirects by default; a hostile "device" could 302 anywhere (notably: exfiltrating an upload's POST body off-LAN). **Decision recorded:** an on-LAN attacker who can impersonate the device is already in a strong position (it can serve arbitrary file bytes that land in the vault; user pointed the plugin at it deliberately). Accept and document; no mitigation planned. Revisit only if a `redirect: 'manual'`-equivalent becomes available in `requestUrl`. | None (documented). Consider noting in future `SECURITY.md`. |
+| F3 | Low (defense-in-depth) | `src/FileListModal.ts` `DownloadListModal.onChooseSuggestion` | Interactive browse/download writes via `getAvailablePathForAttachment(file.name)` where `name` comes straight from the listing — this path does **not** pass through `scanDeviceSupernoteTree`'s `uriMatchesName` gate (the GHSA-3gx3 fix covers sync + import-today only). Unknown whether Obsidian's `getAvailablePathForAttachment` sanitizes `../` in the supplied name. | **Fixed:** `isTrustedListingEntry` (uri/name consistency + `isPlainFileName`: non-empty, not `.`/`..`, no `/` or `\`) guards `DownloadListModal` before fetch, and now also strengthens the `scanDeviceSupernoteTree` gate (closing the backslash-name gap noted above for import-today). Regression tests in `FileListModal.test.ts`. |
+| F4 | Info (hygiene) | `package.json` | `esbuild-plugin-inline-worker` is listed under `dependencies` but is build-time only (imported solely by `esbuild.config.mjs`); never bundled. | **Fixed:** moved to `devDependencies`, lockfile regenerated. Runtime deps are now exactly `fast-png`, `image-js`, `pdf-lib`, `sql.js`. |
+| F5 | Info (verified non-issue) | `npm audit` | 4 high advisories all resolve under devDependency eslint toolchain; none reachable from shipped code. | None. Re-run per release. |
+
+## Conclusions
+
+- **Primary objective (phases 1–3 scope): confirmed.** The only outbound
+  network connections constructible from source or bundle are to
+  `{settings.directConnectIP}:8089` (browse/download/upload/sync/import) and
+  `{settings.directConnectIP}:8080` (screen mirror), with the sole caveats
+  F1 (path interpolation, hostile-device-only) and F2 (redirect following,
+  accepted).
+- No dynamic code loading, no `eval` beyond sql.js's inert node probe, no
+  postMessage surfaces reachable cross-origin, wasm embedded as build-time
+  data.
+- Phase 4 (runtime egress logging + mock device) should specifically cover:
+  F3's `getAvailablePathForAttachment` traversal question, and the zero-egress
+  scenarios (idle load, note viewing/export, embeds).

--- a/src/FileListModal.test.ts
+++ b/src/FileListModal.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { scanDeviceSupernoteTree } from './FileListModal';
+import { fetchFromDevice } from './deviceFetch';
+
+vi.mock('obsidian', () => ({
+    // FileListModal (extends SuggestModal) and its transitive imports
+    // (ErrorModal extends Modal, settings.ts extends PluginSettingTab) need
+    // these at module scope; everything else is only referenced inside class
+    // methods that these tests never run.
+    SuggestModal: class { },
+    Modal: class { },
+    Notice: class { },
+    MarkdownView: class { },
+    PluginSettingTab: class { },
+}));
+
+vi.mock('./deviceFetch', () => ({
+    fetchFromDevice: vi.fn(),
+    buildMultipartBody: vi.fn(),
+    DEVICE_TRANSFER_TIMEOUT_MS: 120_000,
+}));
+
+// Builds one device "Browse and Access" directory-listing response whose
+// HTML embeds the given entries as JSON, in the exact shape
+// fetchSupernoteDirectory parses back out. (Avoid `'` in names — the device
+// embeds the JSON inside a single-quoted JS string.)
+function mockListing(entries: { name: string; uri?: string; isDirectory?: boolean }[]) {
+    const fileList = entries.map((e) => ({
+        name: e.name,
+        size: 1,
+        date: '2026/01/01 12:00',
+        uri: e.uri ?? `/${e.name}`,
+        extension: 'note',
+        isDirectory: e.isDirectory ?? false,
+    }));
+    const json = JSON.stringify({
+        deviceName: 'A5X',
+        fileList,
+        routeList: [],
+        totalByteSize: 0,
+        totalMemory: 0,
+        usedMemory: 0,
+    });
+    return {
+        ok: true,
+        status: 200,
+        text: async () => `const json = '${json}'`,
+        arrayBuffer: async () => new ArrayBuffer(0),
+    };
+}
+
+describe('scanDeviceSupernoteTree entry trust (GHSA-3gx3-r874-5pp4 follow-up)', () => {
+    beforeEach(() => {
+        vi.mocked(fetchFromDevice).mockReset();
+    });
+
+    it('keeps well-formed entries', async () => {
+        vi.mocked(fetchFromDevice).mockResolvedValue(mockListing([
+            { name: 'diary.note' },
+            { name: 'sketch.spd' },
+        ]));
+
+        const files = await scanDeviceSupernoteTree('192.168.1.50');
+
+        expect(files.map((f) => f.name).sort()).toEqual(['diary.note', 'sketch.spd']);
+    });
+
+    it('drops entries whose name and uri disagree on the filename', async () => {
+        // name passes the .note filter; the uri it would actually be
+        // downloaded from points elsewhere (e.g. carries traversal segments).
+        vi.mocked(fetchFromDevice).mockResolvedValue(mockListing([
+            { name: 'innocent.note', uri: '/../../evil.note' },
+        ]));
+
+        expect(await scanDeviceSupernoteTree('192.168.1.50')).toEqual([]);
+    });
+
+    it('drops entries whose name contains a forward slash', async () => {
+        vi.mocked(fetchFromDevice).mockResolvedValue(mockListing([
+            { name: '../../../etc/passwd.note', uri: '/Note/../../../etc/passwd.note' },
+        ]));
+
+        expect(await scanDeviceSupernoteTree('192.168.1.50')).toEqual([]);
+    });
+
+    it('drops entries whose name contains a backslash', async () => {
+        // uriMatchesName alone can't see this one: device uris are only split
+        // on "/", so a name with "\\" in it still "matches" the uri's final
+        // segment. Obsidian path normalization later turns "\\" into "/",
+        // making this a traversal once it reaches getAvailablePathForAttachment.
+        vi.mocked(fetchFromDevice).mockResolvedValue(mockListing([
+            { name: '..\\..\\evil.note', uri: '/Note/..\\..\\evil.note' },
+        ]));
+
+        expect(await scanDeviceSupernoteTree('192.168.1.50')).toEqual([]);
+    });
+
+    it('drops entries named "." or ".."', async () => {
+        vi.mocked(fetchFromDevice).mockResolvedValue(mockListing([
+            { name: '..', uri: '/Note/..' },
+            { name: '.', uri: '/Note/.' },
+        ]));
+
+        expect(await scanDeviceSupernoteTree('192.168.1.50')).toEqual([]);
+    });
+
+    it('still recurses into directories the listing marks as such', async () => {
+        vi.mocked(fetchFromDevice)
+            .mockResolvedValueOnce(mockListing([
+                { name: 'EXPORT', isDirectory: true, uri: '/EXPORT' },
+            ]))
+            .mockResolvedValueOnce(mockListing([
+                { name: 'inside.note', uri: '/EXPORT/inside.note' },
+            ]));
+
+        const files = await scanDeviceSupernoteTree('192.168.1.50');
+
+        expect(files.map((f) => f.name)).toEqual(['inside.note']);
+    });
+});

--- a/src/FileListModal.ts
+++ b/src/FileListModal.ts
@@ -1,6 +1,6 @@
 import { App, SuggestModal, Notice, MarkdownView, TFile } from 'obsidian';
 import SupernotePlugin from './main';
-import { SupernotePluginSettings, IP_VALIDATION_PATTERN, FileBrowserSortOrder } from 'settings';
+import { SupernotePluginSettings, IP_VALIDATION_PATTERN, FileBrowserSortOrder } from './settings';
 import { parseDeviceDate } from './deviceDate';
 import { fetchFromDevice, buildMultipartBody, DEVICE_TRANSFER_TIMEOUT_MS } from './deviceFetch';
 import { ErrorModal } from './ErrorModal';
@@ -60,7 +60,7 @@ export async function scanDeviceSupernoteTree(ip: string, path = '/', visited: S
     for (const entry of entries) {
         if (entry.isDirectory) {
             results.push(...await scanDeviceSupernoteTree(ip, entry.uri, visited));
-        } else if (SYNCABLE_EXTENSION_PATTERN.test(entry.name) && uriMatchesName(entry.uri, entry.name)) {
+        } else if (SYNCABLE_EXTENSION_PATTERN.test(entry.name) && isTrustedListingEntry(entry)) {
             results.push(entry);
         }
     }
@@ -76,6 +76,26 @@ export async function scanDeviceSupernoteTree(ip: string, path = '/', visited: S
 function uriMatchesName(uri: string, name: string): boolean {
     const segments = uri.split('/').filter((s) => s.length > 0);
     return segments[segments.length - 1] === name;
+}
+
+// A "plain" filename: non-empty, not a dot segment, and containing no path
+// separators. Complements uriMatchesName (which can't see "\\" — device
+// uris are only ever split on "/"): a device-supplied name carrying "/",
+// "\\", or being "."/".." is the path-traversal primitive once it reaches
+// getAvailablePathForAttachment/vault.createBinary, because Obsidian's path
+// normalization turns "\\" into "/" and does not strip ".." segments
+// (same class of bug as GHSA-3gx3-r874-5pp4, which fixed the sync write
+// path; this guards every path that writes a device-supplied name).
+function isPlainFileName(name: string): boolean {
+    return name.length > 0 && name !== '.' && name !== '..'
+        && !name.includes('/') && !name.includes('\\');
+}
+
+// Guard for any consumer about to write a device-listing entry into the
+// vault under its own name: the entry must be self-consistent (name matches
+// the uri's final segment) *and* the name must be a plain filename.
+function isTrustedListingEntry(file: SupernoteFile): boolean {
+    return uriMatchesName(file.uri, file.name) && isPlainFileName(file.name);
 }
 
 function compareByDirectoryThenNameThenDate(a: SupernoteFile, b: SupernoteFile): number {
@@ -250,6 +270,17 @@ export class DownloadListModal extends FileListModal {
                 this.open();
             } else {
                 try {
+                    // Unlike sync/import-today (whose files all pass through
+                    // scanDeviceSupernoteTree's isTrustedListingEntry gate),
+                    // this browse path hands the listing entry straight to
+                    // getAvailablePathForAttachment under its own name — refuse
+                    // entries that could smuggle a traversal segment through it
+                    // before fetching anything.
+                    if (!isTrustedListingEntry(file)) {
+                        throw new Error(
+                            `Device listing returned inconsistent data for "${file.name}" — refusing to download it.`
+                        );
+                    }
                     const fileResponse = await fetchFromDevice(this.settings.directConnectIP, file.uri, 'Failed to download file', {
                         timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS,
                     });

--- a/src/deviceFetch.test.ts
+++ b/src/deviceFetch.test.ts
@@ -121,6 +121,44 @@ describe('fetchFromDevice', () => {
             'Failed to load file list: could not reach Supernote at 192.168.1.50 (net::ERR_CONNECTION_REFUSED).'
         );
     });
+
+    describe('path normalization (host pinning)', () => {
+        // The path comes from parsed device directory listings, i.e. from a
+        // device an on-LAN attacker could impersonate. Without a leading "/",
+        // a crafted path reparsesthe URL so the request leaves the device
+        // host entirely — see fetchFromDevice's comment in deviceFetch.ts.
+        it('prefixes a missing leading slash so an "@"-led path cannot smuggle in another host', async () => {
+            vi.mocked(requestUrl).mockResolvedValue(mockResponse());
+
+            await fetchFromDevice('192.168.1.50', '@evil.example/secret.note', 'Failed to download file');
+
+            // With the "/", "ip:8089" can only parse as the authority
+            // (host:port), never as userinfo of "evil.example".
+            expect(requestUrl).toHaveBeenCalledWith(
+                expect.objectContaining({ url: 'http://192.168.1.50:8089/@evil.example/secret.note' }),
+            );
+        });
+
+        it('prefixes a backslash-led path, which otherwise also terminates the URL authority', async () => {
+            vi.mocked(requestUrl).mockResolvedValue(mockResponse());
+
+            await fetchFromDevice('192.168.1.50', '\\evil.example/x.note', 'Failed to download file');
+
+            expect(requestUrl).toHaveBeenCalledWith(
+                expect.objectContaining({ url: 'http://192.168.1.50:8089/\\evil.example/x.note' }),
+            );
+        });
+
+        it('leaves already-absolute paths untouched, including "@" in later segments', async () => {
+            vi.mocked(requestUrl).mockResolvedValue(mockResponse());
+
+            await fetchFromDevice('192.168.1.50', '/Note/@mentions/x.note', 'Failed to load file list');
+
+            expect(requestUrl).toHaveBeenCalledWith(
+                expect.objectContaining({ url: 'http://192.168.1.50:8089/Note/@mentions/x.note' }),
+            );
+        });
+    });
 });
 
 describe('buildMultipartBody', () => {

--- a/src/deviceFetch.ts
+++ b/src/deviceFetch.ts
@@ -66,6 +66,17 @@ export async function fetchFromDevice(
 ): Promise<DeviceResponse> {
     const { timeoutMs = DEVICE_REQUEST_TIMEOUT_MS, ...requestInit } = init;
 
+    // Pin the request to the device host: `path` comes from parsed device
+    // directory listings, so a hostile or impersonating device controls its
+    // contents. Without a leading "/", a crafted path like
+    // "@evil.example/x" would make the URL's authority parse as userinfo
+    // "ip:8089" plus host "evil.example" (WHATWG URL parsing treats
+    // everything up to the first "/", "\\", "?", or "#" as the authority).
+    // A leading "/" terminates the authority right after the port, so the
+    // host can never be escaped. Normalizing (prefixing) rather than
+    // rejecting keeps odd-but-benign listings from real devices working.
+    const safePath = path.startsWith('/') ? path : `/${path}`;
+
     let timeoutHandle: ReturnType<typeof window.setTimeout>;
     const timeout = new Promise<never>((_, reject) => {
         timeoutHandle = window.setTimeout(
@@ -77,7 +88,7 @@ export async function fetchFromDevice(
     try {
         const response = await Promise.race([
             requestUrl({
-                url: `http://${ip}:8089${path}`,
+                url: `http://${ip}:8089${safePath}`,
                 throw: false,
                 ...requestInit,
             }),


### PR DESCRIPTION
## Summary

Executes phases 1–3 of `plans/SECURITY-AUDIT-PLAN.md` (static source scan, data-flow review, dependency/bundle audit) and fixes the actionable findings. Full report: `plans/SECURITY-AUDIT-PHASES-1-3.md`.

**Audited at** plugin `49f6518`, submodule `b95d1fd`, plus a fresh production build of `main.js`.

## Result

**Primary objective confirmed**: the only outbound network connections constructible from source or bundle are

- `http://{settings.directConnectIP}:8089` — device browse/download/upload, auto-sync, import-today (`requestUrl` via `deviceFetch.ts`), and
- `http://{settings.directConnectIP}:8080` — screen mirroring (`fetchMirrorFrame`).

with hosts derived solely from the user setting (strict dotted-quad validation at every settings entry point). No `WebSocket`/`XMLHttpRequest`/`EventSource`/`sendBeacon` reachable, no dynamic `import()`/`importScripts`, no cross-origin-reachable `postMessage`, no runtime CDN fetches (sql.js wasm is an embedded build-time blob; its fetch/XHR fallbacks are provably dead in the minified glue), and the web-component `fetch(src)` path is unreachable in the plugin (every instantiation sets `noteData`, never `src`). The 4 high npm-audit advisories are all eslint-toolchain devDependencies, unreachable from shipped code.

## Fixes

- **F1 (host pinning)** — `fetchFromDevice()` normalizes the request path to a leading `/`. Path comes from device directory listings, so a hostile/impersonating device controls it; without the slash a crafted uri (`@evil.example/x`) reparses the URL authority as userinfo `ip:8089` + host `evil.example`, sending the request off-device.
- **F3 (listing-entry trust)** — new `isTrustedListingEntry()` guard (uri/name consistency + plain-filename check) now covers every flow writing a device-listing entry into the vault under its own name. Closes two gaps beyond the GHSA-3gx3 fix: the interactive browse/download path had no gate before `getAvailablePathForAttachment(file.name)`, and the existing backstop split only on `/`, so backslash-laden names could still traverse via import-today.
- **F4** — `esbuild-plugin-inline-worker` moved to `devDependencies` (build-time only, never bundled).

F2 (both transports follow redirects — accepted per the audit's threat model) and F5 are documented, not changed.

## Testing

- 9 new regression tests (3 host-pinning in `deviceFetch.test.ts`, 6 entry-trust in new `FileListModal.test.ts`).
- `npm test` 219/219 pass; `npm run lint` 0 errors (1 pre-existing warning untouched); `npm run build` clean; rebuilt bundle still constructs only the two allowlisted URLs.

## Follow-ups (phases 4–6, not in this PR)

Runtime egress verification under headless Obsidian with a mock device server, standing lint/test guards, and `SECURITY.md`.