### PR TITLE
Web components: style shadow root via adoptedStyleSheets, not a <style> element

### DIFF
--- a/src/webcomponent/SupernoteAtelierViewerElement.ts
+++ b/src/webcomponent/SupernoteAtelierViewerElement.ts
@@ -326,9 +326,14 @@ export class SupernoteAtelierViewerElement extends HTMLElement {
     constructor() {
         super();
         const shadow = this.attachShadow({ mode: 'open' });
-        const style = document.createElement('style');
-        style.textContent = STYLE;
-        shadow.appendChild(style);
+        // Constructable stylesheet rather than a <style> element - same
+        // reason as SupernoteViewerElement's own constructor (issue #229):
+        // Obsidian's community-plugin scan statically errors on any
+        // created/attached <style> element, even in a shadow root where
+        // styles.css can't reach.
+        const sheet = new CSSStyleSheet();
+        sheet.replaceSync(STYLE);
+        shadow.adoptedStyleSheets = [sheet];
 
         this.rootEl = document.createElement('div');
         this.rootEl.className = 'root';

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -814,9 +814,17 @@ export class SupernoteViewerElement extends HTMLElement {
     constructor() {
         super();
         const shadow = this.attachShadow({ mode: 'open' });
-        const style = document.createElement('style');
-        style.textContent = STYLE;
-        shadow.appendChild(style);
+        // Constructable stylesheet rather than a <style> element: identical
+        // styling, but Obsidian's community-plugin scan errors on any
+        // created/attached <style> element (the rule targets light-DOM CSS
+        // injection; this one lives in the shadow root, where styles.css
+        // can't reach, so the flag is a false positive - but the scan is
+        // static and can't tell the difference, issue #229). Requires
+        // Chrome/Edge 99+, Firefox 101+, Safari 16.4+ (see
+        // webcomponent-usage.md's "Current limitations").
+        const sheet = new CSSStyleSheet();
+        sheet.replaceSync(STYLE);
+        shadow.adoptedStyleSheets = [sheet];
 
         this.rootEl = document.createElement('div');
         this.rootEl.className = 'root';

--- a/webcomponent-usage.md
+++ b/webcomponent-usage.md
@@ -159,6 +159,11 @@ return <supernote-viewer ref={ref} />;
 
 ## Current limitations
 
+- **Browser floor.** The component styles its shadow root with a constructable
+  stylesheet (`adoptedStyleSheets`, issue #229), which needs Chrome/Edge 99+ (Jan 2022),
+  Firefox 101+ (Aug 2022), or Safari 16.4+ (Mar 2023). Older WebViews (e.g. iOS 16.0–16.3)
+  won't render it styled - everything else it relies on (custom elements v1, `ResizeObserver`,
+  web workers, ES2020 modules) is older than that, so this is the binding requirement.
 - **Read-only.** No save/export/download UI - see issue #183 for why (needs a browser-native Blob/download
   story, not built yet).
 - **No selectable/searchable image text layer.** The recognized-text toggle shows the note's recognized


### PR DESCRIPTION
Fixes #229 (option A from that issue's triage; split out of #228).

## What

Both web component constructors styled their shadow root by creating and
attaching a `<style>` element:

```ts
const style = document.createElement('style');
style.textContent = STYLE;
shadow.appendChild(style);
```

Obsidian's community-plugin scan reports this as the one **error** in its
output: "Creating and attaching 'style' elements is not allowed." The rule
targets light-DOM CSS injection, but these `<style>` elements live in the
shadow root (where `styles.css` cannot reach at all), so the finding is a
false positive — except the scan is static and can't tell the difference,
and the error gates community-listing submission.

This switches both constructors to **constructable stylesheets**:

```ts
const sheet = new CSSStyleSheet();
sheet.replaceSync(STYLE);
shadow.adoptedStyleSheets = [sheet];
```

Identical styling, no `<style>` element anywhere in the source.

## Compatibility cost (documented)

`adoptedStyleSheets` needs Chrome/Edge 99+ (Jan 2022), Firefox 101+ (Aug
2022), Safari 16.4+ (Mar 2023). That applies to:

- plain-browser consumers of the standalone `dist/` bundles — noted in
  `webcomponent-usage.md`'s "Current limitations" (the component already
  requires custom elements v1, `ResizeObserver`, web workers, ES2020
  modules, so this is the new binding floor);
- Obsidian **iOS** users on iOS 16.0–16.3 (WKWebView < 16.4).

No effect inside Obsidian desktop (Electron, Chromium far newer than 99).

## Verified

- `tsc -noEmit` (via `npm run build`), `npm run lint` (0 errors), `npm test`
  (219/219 — happy-dom fully supports `adoptedStyleSheets`/`replaceSync`),
  `npm run build` + both `build:*-webcomponent` bundles all succeed.
- `grep -r "createElement('style')" src/` comes back empty.
- **Not** done: the visual render check under headless Obsidian / the demo
  page in a real browser (see the acceptance criteria in #229) — left for
  manual review, per the repo's usual workflow for rendering changes.
