### PR TITLE
Drop the builtin-modules devDependency; use node:module's own list

### DIFF
--- a/esbuild.atelier-webcomponent.config.mjs
+++ b/esbuild.atelier-webcomponent.config.mjs
@@ -8,7 +8,10 @@ import esbuild from "esbuild";
 import process from "process";
 import path from "path";
 import { fileURLToPath } from "url";
-import builtins from "builtin-modules";
+// Node's own builtin-module list - the community-plugin scan (issue
+// #228) flags the `builtin-modules` npm package, which on modern Node is
+// only a thin filter over this.
+import { builtinModules } from "node:module";
 import inlineWorkerPlugin from "esbuild-plugin-inline-worker";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -54,7 +57,7 @@ const context = await esbuild.context({
 	// also has to be repeated into the plugin's nested build here, not just
 	// declared once at this level.
 	plugins: [inlineWorkerPlugin({ loader: { '.wasm': 'binary' } })],
-	external: [...builtins],
+	external: [...builtinModules],
 	format: "esm",
 	target: "es2020",
 	logLevel: "info",

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -2,7 +2,10 @@ import esbuild from "esbuild";
 import process from "process";
 import path from "path";
 import { fileURLToPath } from "url";
-import builtins from "builtin-modules";
+// Node's own builtin-module list - the community-plugin scan (issue
+// #228) flags the `builtin-modules` npm package, which on modern Node is
+// only a thin filter over this.
+import { builtinModules } from "node:module";
 import inlineWorkerPlugin from "esbuild-plugin-inline-worker";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -59,7 +62,7 @@ const context = await esbuild.context({
 		"@lezer/common",
 		"@lezer/highlight",
 		"@lezer/lr",
-		...builtins],
+		...builtinModules],
 	format: "cjs",
 	target: "es2018",
 	logLevel: "info",

--- a/esbuild.webcomponent.config.mjs
+++ b/esbuild.webcomponent.config.mjs
@@ -10,7 +10,10 @@ import esbuild from "esbuild";
 import process from "process";
 import path from "path";
 import { fileURLToPath } from "url";
-import builtins from "builtin-modules";
+// Node's own builtin-module list - the community-plugin scan (issue
+// #228) flags the `builtin-modules` npm package, which on modern Node is
+// only a thin filter over this.
+import { builtinModules } from "node:module";
 import inlineWorkerPlugin from "esbuild-plugin-inline-worker";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -39,7 +42,7 @@ const context = await esbuild.context({
 	},
 	bundle: true,
 	plugins: [inlineWorkerPlugin()],
-	external: [...builtins],
+	external: [...builtinModules],
 	format: "esm",
 	target: "es2020",
 	logLevel: "info",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
 				"@types/color": "^3.0.6",
 				"@types/jest": "^29.5.12",
 				"@types/node": "20.19.43",
-				"builtin-modules": "3.3.0",
 				"esbuild": "^0.28.2",
 				"esbuild-plugin-inline-worker": "^0.1.1",
 				"eslint": "^9.39.5",
@@ -27,7 +26,7 @@
 				"globals": "^17.7.0",
 				"happy-dom": "^20.11.1",
 				"jiti": "^2.7.0",
-				"obsidian": "*",
+				"obsidian": "latest",
 				"tslib": "2.4.0",
 				"typescript": "6.0.3",
 				"typescript-eslint": "^8.65.0",
@@ -2089,18 +2088,6 @@
 			},
 			"engines": {
 				"node": ">=4.0"
-			}
-		},
-		"node_modules/builtin-modules": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
-			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/call-bind": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 		"@types/color": "^3.0.6",
 		"@types/jest": "^29.5.12",
 		"@types/node": "20.19.43",
-		"builtin-modules": "3.3.0",
 		"esbuild": "^0.28.2",
 		"esbuild-plugin-inline-worker": "^0.1.1",
 		"eslint": "^9.39.5",


### PR DESCRIPTION
Fixes #230 (split out of #228).

## What

The scan warning: "builtin-modules should be replaced with an alternative
package" (es-tooling/module-replacements).

`builtin-modules@3.3.0` is a devDependency used only by the three esbuild
configs to build each build's `external: [...]` list. On modern Node it's
itself just a thin filter over `require('module').builtinModules` (Node
9.3+), so rather than swap in a replacement package, this drops the
dependency entirely:

```js
import { builtinModules } from "node:module";
// ...
external: [...builtinModules],
```

applied to `esbuild.config.mjs`, `esbuild.webcomponent.config.mjs`, and
`esbuild.atelier-webcomponent.config.mjs`. (The `is-core-module`
alternative from the es-tooling doc works too, but it adds a dependency
where none is needed.)

The only behavioral difference from `builtin-modules` is the small filter
it applies (drops `sys` and internal-looking names, which recent Node's
`builtinModules` already excludes) — irrelevant for an `external` list.

## Verified

- `package-lock.json` updated via `npm install`; `builtin-modules` fully
  gone from the tree. (The lockfile diff also syncs the root `obsidian`
  entry from `"*"` to `"latest"` to match `package.json` — pre-existing
  drift, no dependency change.)
- `npm run build`, `npm run build:webcomponent`,
  `npm run build:atelier-webcomponent` all succeed, and `npm test` passes
  (219/219).
