### PR TITLE
sql-wasm.test-stub: dynamic fs/path imports instead of static ones

### DIFF
--- a/src/sql-wasm.test-stub.ts
+++ b/src/sql-wasm.test-stub.ts
@@ -18,8 +18,13 @@
 // and sidesteps needing @types/node's "module" package typings (which,
 // unlike "fs"/"path", didn't resolve cleanly under this project's
 // moduleResolution: "bundler" setting).
-import * as fs from 'fs';
-import * as path from 'path';
+// Dynamic imports, not static ones - Obsidian's community-plugin scan
+// (issue #228) warns on any static Node built-in import (Node APIs aren't
+// available on mobile). This file is vitest-only and never bundled, so a
+// plain top-level dynamic import (vitest supports top-level await) is all
+// that's needed; the Platform.isDesktop guard the warning suggests would
+// be meaningless here, since the file only ever runs under Node's vitest.
+const [fs, path] = await Promise.all([import('fs'), import('path')]);
 
 const wasmPath = path.join(import.meta.dirname, '..', 'node_modules', 'sql.js', 'dist', 'sql-wasm.wasm');
 const buf = fs.readFileSync(wasmPath);


### PR DESCRIPTION
Fixes #231 (split out of #228) — option 1 from that issue (convert to
dynamic imports).

## What

The scan warning: "Do not import Node.js built-in module fs/path. Node.js
APIs are not available on mobile. Use a dynamic import() or require()
guarded by Platform.isDesktop instead."

`src/sql-wasm.test-stub.ts` is a vitest-only stand-in for the
`sql.js/dist/sql-wasm.wasm` binary import — referenced solely through
`resolve.alias` in `vitest.config.ts`, never bundled into `main.js`
(esbuild resolves the real `.wasm` via its `binary` loader instead). So
the warning has no shipping impact, and the `Platform.isDesktop` guard it
suggests is meaningless here (the file only ever runs under Node's
vitest). Converting the two static imports to a plain top-level dynamic
import is the whole change:

```ts
const [fs, path] = await Promise.all([import('fs'), import('path')]);
```

Note: bare specifiers, not `node:`-prefixed — under this project's
`moduleResolution: "bundler"` setting, `tsc` resolves `import('fs')` but
fails with TS2591 on `import('node:fs')` (verified directly).

## Verified

- `npm test` (219/219 — the atelier tests load this stub through the
  vitest alias, exercising the top-level await), `npm run build` (tsc +
  esbuild), `npm run lint` all pass.
- No effect on any shipped artifact (the file was never in one).
