### PR TITLE
AGENTS.md: document the community-plugin scan findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,55 @@ npm test                              # vitest run
   may not match what's actually loaded at runtime. Extend those interfaces if
   you touch more of the pdf.js surface — don't reach back for `any`.
 
+## Community scan
+
+Obsidian's automated community-plugin scan (runs for community-listing
+submissions; the raw output is archived in issue #228) checks the source and
+`styles.css` with `eslint-plugin-obsidianmd` plus its own checks. Findings
+that are intentionally left as-is, and why:
+
+- **`'any' overrides all other types in this union` / `'error'`-type members
+  ("acting as any")** — `src/atelierComposite.worker.ts`'s `spd` field and
+  `src/webcomponent/SupernoteViewerElement.ts`'s `sn` field. The scanner's
+  type-checker can't resolve `supernote-typescript`: it's a git submodule
+  wired up via esbuild/vitest/tsconfig aliases, not an npm dependency (the
+  setup `CLAUDE.md` documents not changing; the scanner clones without the
+  submodule checked out, so the mapped path is empty and those types collapse
+  to `any`/`error`). Local `tsc` (`npm run build`) is clean.
+- **`obsidianmd/prefer-create-el` and `obsidianmd/no-static-styles-assignment`
+  in `src/render/*` and `src/webcomponent/*`** — every flagged file is part of
+  the standalone web-component path (issue #183) and deliberately has zero
+  `obsidian` imports so it runs in a plain browser. `createEl`/
+  `setCssStyles` require importing `obsidian`, which would break the
+  standalone bundles (`esbuild.webcomponent*.mjs` intentionally carry no
+  obsidian alias/external). Many of the flagged style assignments are dynamic
+  runtime values (page `aspect-ratio`, thumbnail sizing, overlay positioning)
+  that can't be CSS classes.
+- **`fetch` in `src/webcomponent/`** — the standalone component fetches its
+  own `src` URL in plain browsers, where `requestUrl` doesn't exist. Same
+  rationale as the `deviceFetch.ts` entry in the Linting section above.
+- **Node built-ins in `src/sql-wasm.test-stub.ts`** — vitest-only alias
+  target, never bundled (esbuild resolves the real `.wasm` via its `binary`
+  loader); the imports are dynamic (issue #231).
+- **CSS findings in `styles.css`** — `display: contents` on the
+  `.supernote-embed` wrapper (the scanner's 1.7.4 baseline is below this
+  plugin's `minAppVersion` 1.8.7, so every supported Obsidian has it), the
+  single `!important` on `.internal-embed.supernote-embed` (the narrowest
+  robust way to beat Live Preview's own `!important` reset — documented in
+  `styles.css` itself), and the `supernote-viewer` / `supernote-atelier-viewer`
+  type selectors (the plugin's own custom elements, which the CSS linter can't
+  know about). Full triage: issue #232.
+
+Already fixed rather than argued with:
+
+- **The scan's one *error* — created/attached `<style>` elements in the two
+  web components.** False positive in spirit (the styles live in the shadow
+  root, where `styles.css` can't reach), but the scan is static and can't tell
+  the difference, so both components now use constructable stylesheets
+  (`adoptedStyleSheets`; issue #229).
+- **`builtin-modules` deprecated-package warning** — the esbuild configs now
+  use `node:module`'s own `builtinModules` list (issue #230).
+
 ## File & folder conventions
 
 - Source lives in `src/`, one concern per file:


### PR DESCRIPTION
Fixes #233 (split out of #228). Also records the disposition of the four
CSS findings triaged in #232 (accepted + documented).

## What

Docs-only. Adds a "Community scan" section to `AGENTS.md` (right after
Linting, since most findings are `eslint-plugin-obsidianmd` rules) so
future contributors — and Obsidian's reviewers — can see at a glance
which scan findings are intentional and why:

- **`any`/`error`-union warnings** — the scanner can't resolve
  `supernote-typescript` (a git submodule wired via aliases, not an npm
  dependency; the setup `CLAUDE.md` documents not changing, and the
  scanner clones without the submodule checked out). Local `tsc` is clean.
- **`prefer-create-el` / `no-static-styles-assignment` in
  `src/render/*` + `src/webcomponent/*`** — the standalone web-component
  path (#183) deliberately has zero `obsidian` imports; `createEl`/
  `setCssStyles` would break the standalone bundles, and much of the
  flagged styling is dynamic runtime values that can't be CSS classes.
- **`fetch` in `src/webcomponent/`** — standalone component fetches its
  own `src` URL in plain browsers, where `requestUrl` doesn't exist
  (same rationale as the existing `deviceFetch.ts` note).
- **Node built-ins in `src/sql-wasm.test-stub.ts`** — vitest-only, never
  bundled; imports are dynamic (#231).
- **The four `styles.css` findings** — scanner's 1.7.4 baseline is below
  `minAppVersion` 1.8.7 (`display: contents`), the one `!important` beats
  Live Preview's own `!important` reset (documented in `styles.css`), and
  the two type selectors are the plugin's own custom elements. Full
  triage: #232.

Plus a short "Already fixed rather than argued with" subsection for the
two findings that got real fixes: the scan's one *error* (created/attached
`<style>` elements → constructable stylesheets, #229) and the
`builtin-modules` deprecation (#230).

No code changes.
