### PR TITLE
Add efficient write-on presentation for supernote-viewer

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -13,7 +13,10 @@
         color-scheme: light dark;
     }
     supernote-viewer {
-        height: 80vh;
+        /* A note page is portrait-shaped. Let the demo grow to that page
+           height instead of trapping most desktop pages in an 80vh scroller. */
+        aspect-ratio: 1 / 1.42;
+        min-height: 100vh;
         margin-top: 1em;
     }
     #status {

--- a/demo/index.html
+++ b/demo/index.html
@@ -33,46 +33,70 @@
 </p>
 <p>
     <strong>Build the bundle first:</strong> this page loads
-    <code>../dist/supernote-viewer.js</code>, which isn't checked into the repo -
-    run <code>npm run build:webcomponent</code> from the project root, then serve this
-    directory over http(s) (module scripts can't load from a <code>file://</code> URL) - e.g.
-    <code>npx serve .</code> from the project root, then open
+    <code>supernote-viewer.js</code> from <code>../dist/</code> (serving the project
+    root), <code>./dist/</code>, or next to this page (serving this directory
+    on its own, bundle copied in) - whichever exists. It isn't checked into
+    the repo: run <code>npm run build:webcomponent</code> from the project root, then
+    serve over http(s) (module scripts can't load from a <code>file://</code> URL) -
+    e.g. <code>npx serve .</code> from the project root, then open
     <code>/demo/</code>.
 </p>
 <input id="file-input" type="file" accept=".note">
 <button id="load-sample" type="button">Load sample note</button>
+<label>
+    <input id="start-blank" type="checkbox"> open blank (write-on, waits for play)
+</label>
 <p id="status"></p>
 <supernote-viewer id="viewer"></supernote-viewer>
 
-<script type="module" src="../dist/supernote-viewer.js"></script>
 <script type="module">
-    const viewer = document.getElementById('viewer');
+    // The bundle lives in the project's dist/ when this directory is
+    // served from the project root, or in ./dist/ or next to this page
+    // when the directory is served on its own and the bundle was copied
+    // in - try each, and say it's missing instead of failing silently.
     const status = document.getElementById('status');
-
-    document.getElementById('file-input').addEventListener('change', async (event) => {
-        const file = event.target.files?.[0];
-        if (!file) return;
-        status.textContent = `Reading ${file.name}…`;
-        viewer.noteData = await file.arrayBuffer();
-    });
-
-    document.getElementById('load-sample').addEventListener('click', async () => {
-        status.textContent = 'Loading sample note…';
+    let bundle = null;
+    for (const src of ['../dist/supernote-viewer.js', './dist/supernote-viewer.js', './supernote-viewer.js']) {
         try {
-            const response = await fetch('./rtr.note');
-            if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
-            viewer.noteData = await response.arrayBuffer();
+            bundle = await import(/* @vite-ignore */ src);
+            break;
         } catch (err) {
-            status.textContent = `Error loading sample note: ${err.message ?? err}`;
+            if (err instanceof SyntaxError) throw err;
         }
-    });
+    }
+    if (!bundle) {
+        status.textContent = 'Could not load supernote-viewer.js - run "npm run build:webcomponent" from the project root (then open /demo/), or copy dist/supernote-viewer.js next to this page.';
+    } else {
+        const viewer = document.getElementById('viewer');
+        const startBlankCheckbox = document.getElementById('start-blank');
 
-    viewer.addEventListener('supernote-load', (event) => {
-        status.textContent = `Loaded ${event.detail.pageCount} page(s).`;
-    });
-    viewer.addEventListener('supernote-error', (event) => {
-        status.textContent = `Error: ${event.detail.error?.message ?? event.detail.error}`;
-    });
+        document.getElementById('file-input').addEventListener('change', async (event) => {
+            const file = event.target.files?.[0];
+            if (!file) return;
+            status.textContent = `Reading ${file.name}…`;
+            viewer.presentation = startBlankCheckbox.checked ? 'write-on-paused' : 'static';
+            viewer.noteData = await file.arrayBuffer();
+        });
+
+        document.getElementById('load-sample').addEventListener('click', async () => {
+            status.textContent = 'Loading sample note…';
+            try {
+                const response = await fetch('./rtr.note');
+                if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                viewer.presentation = startBlankCheckbox.checked ? 'write-on-paused' : 'static';
+                viewer.noteData = await response.arrayBuffer();
+            } catch (err) {
+                status.textContent = `Error loading sample note: ${err.message ?? err}`;
+            }
+        });
+
+        viewer.addEventListener('supernote-load', (event) => {
+            status.textContent = `Loaded ${event.detail.pageCount} page(s).`;
+        });
+        viewer.addEventListener('supernote-error', (event) => {
+            status.textContent = `Error: ${event.detail.error?.message ?? event.detail.error}`;
+        });
+    }
 </script>
 </body>
 </html>

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -16,6 +16,9 @@ export default defineConfig(
 		'esbuild.webcomponent.config.mjs',
 		'esbuild.atelier-webcomponent.config.mjs',
 		'dist',
+		// Manual/CI copies of the standalone bundles served straight from
+		// the demo directory (gitignored, like the root dist/).
+		'demo/dist',
 		'version-bump.mjs',
 		'versions.json',
 		'manifest.json',

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
 				"happy-dom": "^20.11.1",
 				"jiti": "^2.7.0",
 				"obsidian": "latest",
+				"playwright": "^1.62.1",
 				"tslib": "2.4.0",
 				"typescript": "6.0.3",
 				"typescript-eslint": "^8.65.0",
@@ -5780,6 +5781,53 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+			"integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.62.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+			"integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"build:atelier-webcomponent": "tsc -noEmit -skipLibCheck && node esbuild.atelier-webcomponent.config.mjs production",
 		"lint": "eslint .",
 		"test": "vitest run",
+		"test:webcomponent:playwright": "npm run build:webcomponent && node scripts/test-webcomponent-playwright.mjs",
 		"version": "node version-bump.mjs && git add manifest.json versions.json",
 		"push-android": "adb push main.js /sdcard/Documents/SupernoteTest/.obsidian/plugins/supernote"
 	},
@@ -31,6 +32,7 @@
 		"happy-dom": "^20.11.1",
 		"jiti": "^2.7.0",
 		"obsidian": "latest",
+		"playwright": "^1.62.1",
 		"tslib": "2.4.0",
 		"typescript": "6.0.3",
 		"typescript-eslint": "^8.65.0",

--- a/scripts/test-webcomponent-playwright.mjs
+++ b/scripts/test-webcomponent-playwright.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// Browser smoke test for the standalone <supernote-viewer>. It serves the
+// repository itself, loads a real note fixture, and verifies the paused
+// write-on presentation can start playing without the expensive SVG masks.
+//
+// One-time browser setup:
+//   npx playwright install chromium
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { extname, join, normalize, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const projectRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const fixture = join(projectRoot, 'supernote-typescript/tests/input/turkish-a6x-20230015-handwriting-erase.note');
+const mimeTypes = {
+    '.css': 'text/css',
+    '.html': 'text/html',
+    '.js': 'text/javascript',
+    '.note': 'application/octet-stream',
+};
+
+function startServer() {
+    const server = createServer(async (request, response) => {
+        const pathname = new URL(request.url ?? '/', 'http://127.0.0.1').pathname;
+        const relativePath = pathname === '/'
+            ? 'demo/index.html'
+            : pathname.endsWith('/')
+                ? `${pathname.replace(/^\/+/, '')}index.html`
+                : pathname.replace(/^\/+/, '');
+        const file = normalize(join(projectRoot, relativePath));
+        if (!file.startsWith(`${projectRoot}/`)) {
+            response.writeHead(403).end();
+            return;
+        }
+        try {
+            const body = await readFile(file);
+            response.writeHead(200, { 'Content-Type': mimeTypes[extname(file)] ?? 'application/octet-stream' }).end(body);
+        } catch {
+            response.writeHead(404).end();
+        }
+    });
+    return new Promise((resolveServer) => {
+        server.listen(0, '127.0.0.1', () => resolveServer(server));
+    });
+}
+
+const server = await startServer();
+const address = server.address();
+assert(address && typeof address !== 'string');
+let browser;
+try {
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage({ viewport: { width: 1200, height: 900 } });
+    const pageErrors = [];
+    page.on('pageerror', (error) => pageErrors.push(error));
+
+    await page.goto(`http://127.0.0.1:${address.port}/demo/`, { waitUntil: 'networkidle' });
+    await page.locator('#start-blank').check();
+    await page.locator('#file-input').setInputFiles(fixture);
+    await page.waitForFunction(() => document.querySelector('supernote-viewer')?.shadowRoot?.querySelector('.anim-controls.active'));
+
+    const initial = await page.locator('supernote-viewer').evaluate((element) => {
+        const root = element.shadowRoot;
+        if (!root) throw new Error('Viewer has no shadow root');
+        return {
+            masks: root.querySelectorAll('mask').length,
+            previews: root.querySelectorAll('svg path[pathLength="1"]').length,
+            hiddenFinals: [...root.querySelectorAll('svg path[fill^="rgb"]')].filter((path) => path.style.display === 'none').length,
+            hasPlay: !!root.querySelector('button[aria-label="Play write-on animation"]'),
+        };
+    });
+    assert.equal(initial.masks, 0, 'write-on playback must not use SVG masks');
+    assert(initial.previews > 0, 'expected dashed centerline previews');
+    assert(initial.hiddenFinals > 0, 'contours should be hidden before playback');
+    assert(initial.hasPlay, 'paused presentation should expose Play');
+
+    await page.locator('supernote-viewer').evaluate((element) => {
+        const button = element.shadowRoot?.querySelector('button[aria-label="Play write-on animation"]');
+        if (!(button instanceof HTMLButtonElement)) throw new Error('Play button missing');
+        button.click();
+    });
+    await page.waitForFunction(() => {
+        const root = document.querySelector('supernote-viewer')?.shadowRoot;
+        return [...(root?.querySelectorAll('svg path[fill^="rgb"]') ?? [])].some((path) => path.style.display !== 'none');
+    });
+    assert.equal(pageErrors.length, 0, pageErrors.map(String).join('\n'));
+    console.log(`Web-component Playwright smoke test passed (${initial.previews} centerline previews).`);
+} finally {
+    await browser?.close();
+    await new Promise((resolveClose) => server.close(resolveClose));
+}

--- a/src/rasterize.worker.ts
+++ b/src/rasterize.worker.ts
@@ -42,7 +42,16 @@ export type RasterizeWorkerMessage =
     // returns a PNG data URL as before. Only sent for full-res renders
     // (scale undefined) — downsampled thumbnails keep the raster path since
     // vector coordinates don't survive a downsample.
-    { type: 'convert'; note: IRenderableNote; scale?: number; vectorInk?: VectorInkPage[] };
+    //
+    // `backgroundOnly`, when present, is a parallel boolean array aligned
+    // by index with note.pages. A page whose entry is true has its bitmap
+    // ink layers nulled exactly as above but returns a plain PNG data URL
+    // (no addSvgPage) — the bare paper/ruling/background with the ink
+    // stripped, for callers that supply their own ink. That's the
+    // web component's write-on stroke animation mode (see
+    // src/webcomponent/strokeAnimation.ts), which draws the strokes itself,
+    // one at a time, over the returned base layer.
+    { type: 'convert'; note: IRenderableNote; scale?: number; vectorInk?: VectorInkPage[]; backgroundOnly?: boolean[] };
 
 export type RasterizeWorkerResponse =
     | { type: 'result'; images: string[] }
@@ -52,19 +61,20 @@ self.onmessage = async (e: MessageEvent<RasterizeWorkerMessage>) => {
     try {
         const data = e.data;
         const vectorInk = data.vectorInk;
+        const backgroundOnly = data.backgroundOnly;
 
-        // Strip the bitmap ink layers from each vector-ink page *before*
-        // toImage, so the raster it produces for those pages is the
-        // background only — the vector strokes (carried alongside in the
-        // VectorInkPage entry) are drawn on top by addSvgPage below. Doing
-        // this on the slice (rather than via buildRenderNoteForVectorInk on
-        // the whole note) keeps the sliced-send memory model from
-        // imageConverter.ts intact: the worker never sees the full
-        // SupernoteX.
-        if (vectorInk) {
+        // Strip the bitmap ink layers from each vector-ink page (and each
+        // background-only page — same strip, plain-PNG result, see the
+        // `backgroundOnly` comment on the message type) *before* toImage,
+        // so the raster it produces for those pages is the background only —
+        // the vector strokes (carried alongside in the VectorInkPage entry)
+        // are drawn on top by addSvgPage below. Doing this on the slice
+        // (rather than via buildRenderNoteForVectorInk on the whole note)
+        // keeps the sliced-send memory model from imageConverter.ts intact:
+        // the worker never sees the full SupernoteX.
+        if (vectorInk || backgroundOnly) {
             for (let i = 0; i < data.note.pages.length; i++) {
-                const vip = vectorInk[i];
-                if (!vip?.useVectorInk) continue;
+                if (!vectorInk?.[i]?.useVectorInk && !backgroundOnly?.[i]) continue;
                 const page = data.note.pages[i];
                 for (const name of INK_LAYER_NAMES) {
                     const layer = page[name];

--- a/src/render/imageConverter.ts
+++ b/src/render/imageConverter.ts
@@ -123,7 +123,7 @@ export class WorkerPool {
     // request in flight) and round-robining across every call (so
     // concurrent single-page requests still spread across every worker,
     // instead of piling onto worker 0) fixes both.
-    private processChunk(note: SupernoteX, pageNumbers: number[], scale?: number, vectorInkPages?: VectorInkPage[]): Promise<string[]> {
+    private processChunk(note: SupernoteX, pageNumbers: number[], scale?: number, vectorInkPages?: VectorInkPage[], backgroundOnly?: boolean[]): Promise<string[]> {
         const workerIndex = this.nextWorker % this.workers.length;
         this.nextWorker++;
         const worker = this.workers[workerIndex];
@@ -152,6 +152,7 @@ export class WorkerPool {
                 note: renderableNote,
                 scale,
                 vectorInk: vectorInkPages,
+                backgroundOnly,
             };
 
             worker.postMessage(message);
@@ -166,7 +167,11 @@ export class WorkerPool {
         return result;
     }
 
-    async processPages(note: SupernoteX, allPageNumbers: number[], scale?: number, vectorInkPages?: VectorInkPage[]): Promise<string[]> {
+    // `backgroundOnly`, when present, is a parallel array aligned by index
+    // with allPageNumbers (see the `backgroundOnly` comment on
+    // RasterizeWorkerMessage): the worker strips those pages' bitmap ink
+    // layers before rasterizing and returns plain background-only PNGs.
+    async processPages(note: SupernoteX, allPageNumbers: number[], scale?: number, vectorInkPages?: VectorInkPage[], backgroundOnly?: boolean[]): Promise<string[]> {
         //console.time('Total processing time');
 
         const chunks = chunkPageNumbers(allPageNumbers);
@@ -175,16 +180,18 @@ export class WorkerPool {
 
         // Process chunks concurrently - safe now regardless of how many land
         // on the same worker, or how many separate processPages() calls are
-        // in flight at once (see processChunk()'s comment). vectorInkPages,
-        // when present, is aligned by index with allPageNumbers, so slice it
-        // the same way each chunk slices the page numbers.
+        // in flight at once (see processChunk()'s comment). vectorInkPages
+        // and backgroundOnly, when present, are aligned by index with
+        // allPageNumbers, so slice each the same way each chunk slices the
+        // page numbers.
         let offset = 0;
         const results = await Promise.all(
             chunks.map((chunk) => {
                 const start = offset;
                 offset += chunk.length;
                 const vip = vectorInkPages?.slice(start, start + chunk.length);
-                return this.processChunk(note, chunk, scale, vip);
+                const bg = backgroundOnly?.slice(start, start + chunk.length);
+                return this.processChunk(note, chunk, scale, vip, bg);
             })
         );
 
@@ -275,6 +282,24 @@ export class ImageConverter {
             // so thumbnails keep the raster path.
             const vectorInkPages = vectorInk && !scale ? prepareVectorInkPages(note, pages, 1) : undefined;
             return await getSharedWorkerPool().processPages(note, pages, scale, vectorInkPages);
+        } finally {
+            activeWorkerCalls--;
+            scheduleIdleTeardownIfIdle();
+        }
+    }
+
+    // Background-only raster: strips the bitmap ink layers from each
+    // requested page before toImage (see `backgroundOnly` on
+    // RasterizeWorkerMessage) and returns plain PNG data URLs of the bare
+    // paper/ruling/background, no ink — the base layer the web component's
+    // write-on stroke animation mode (src/webcomponent/strokeAnimation.ts)
+    // draws its animated vector ink over. Same memory model as
+    // convertToImages() (sliced pages, chunked, shared pool).
+    async convertToBackgroundImages(note: SupernoteX, pageNumbers?: number[]): Promise<string[]> {
+        const pages = pageNumbers ?? Array.from({length: note.pages.length}, (_, i) => i+1);
+        activeWorkerCalls++;
+        try {
+            return await getSharedWorkerPool().processPages(note, pages, undefined, undefined, pages.map(() => true));
         } finally {
             activeWorkerCalls--;
             scheduleIdleTeardownIfIdle();

--- a/src/webcomponent/SupernoteViewerElement.test.ts
+++ b/src/webcomponent/SupernoteViewerElement.test.ts
@@ -529,7 +529,7 @@ describe('<supernote-viewer>', () => {
             return el;
         }
 
-        it('zoom in/out/reset buttons scale every page and update the label', async () => {
+        it('zoom in/out/reset buttons scale every page without a percentage label', async () => {
             // happy-dom has no real layout engine (.pages' clientWidth
             // defaults to 0 - see applyFitWidth()'s own early-return
             // guard), so fit-width - on by default - never actually
@@ -543,24 +543,21 @@ describe('<supernote-viewer>', () => {
             const zoomInBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Zoom in"]')!;
             const zoomOutBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Zoom out"]')!;
             const resetBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Reset zoom"]')!;
-            const label = el.shadowRoot!.querySelector('.zoom-label')!;
             const containers = el.shadowRoot!.querySelectorAll<HTMLElement>('.page-container');
+            expect(el.shadowRoot!.querySelector('.zoom-label')).toBeNull();
 
             resetBtn.click();
-            expect(label.textContent).toBe('100%');
             expect(containers[0].style.width).toBe('1404px');
             expect(containers[1].style.width).toBe('1404px');
 
             zoomInBtn.click();
-            expect(label.textContent).toBe('125%');
             expect(containers[0].style.width).toBe('1755px'); // 1404 * 1.25
 
             zoomOutBtn.click();
             zoomOutBtn.click();
-            expect(label.textContent).toBe('80%'); // 125% / 1.25 / 1.25
+            expect(containers[0].style.width).toBe('1123.2px'); // 125% / 1.25 / 1.25
 
             resetBtn.click();
-            expect(label.textContent).toBe('100%');
             expect(containers[0].style.width).toBe('1404px');
 
             // Every page's img stays at width: 100% of its own
@@ -574,13 +571,13 @@ describe('<supernote-viewer>', () => {
             const el = await createLoadedViewer();
             const zoomInBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Zoom in"]')!;
             const zoomOutBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Zoom out"]')!;
-            const label = el.shadowRoot!.querySelector('.zoom-label')!;
+            const container = el.shadowRoot!.querySelector<HTMLElement>('.page-container')!;
 
             for (let i = 0; i < 20; i++) zoomInBtn.click();
-            expect(label.textContent).toBe('500%');
+            expect(container.style.width).toBe('7020px');
 
             for (let i = 0; i < 40; i++) zoomOutBtn.click();
-            expect(label.textContent).toBe('5%');
+            expect(container.style.width).toBe('70.2px');
         });
 
         it('any manual zoom action turns off fit-width', async () => {
@@ -597,11 +594,11 @@ describe('<supernote-viewer>', () => {
         it('ctrl+wheel zooms; a plain wheel does not', async () => {
             const el = await createLoadedViewer();
             const pagesEl = el.shadowRoot!.querySelector('.pages') as HTMLElement;
-            const label = el.shadowRoot!.querySelector('.zoom-label')!;
+            const container = el.shadowRoot!.querySelector<HTMLElement>('.page-container')!;
 
             const plainWheel = new WheelEvent('wheel', { deltaY: -100, cancelable: true });
             pagesEl.dispatchEvent(plainWheel);
-            expect(label.textContent).toBe('100%');
+            expect(container.style.width).toBe('100%');
             expect(plainWheel.defaultPrevented).toBe(false);
 
             // happy-dom's WheelEvent constructor doesn't wire up ctrlKey
@@ -614,18 +611,17 @@ describe('<supernote-viewer>', () => {
             Object.defineProperty(ctrlWheel, 'ctrlKey', { value: true });
             pagesEl.dispatchEvent(ctrlWheel);
             expect(ctrlWheel.defaultPrevented).toBe(true);
-            expect(label.textContent).not.toBe('100%');
             // deltaY -100 -> factor min(1.05, 1 - (-100)*0.01) = min(1.05, 2) = 1.05
-            expect(label.textContent).toBe('105%');
+            expect(container.style.width).toBe('1474.2px');
         });
 
         it('two-finger touch pinch zooms (issue #202)', async () => {
             const el = await createLoadedViewer();
             const pagesEl = el.shadowRoot!.querySelector('.pages') as HTMLElement;
-            const label = el.shadowRoot!.querySelector('.zoom-label')!;
+            const container = el.shadowRoot!.querySelector<HTMLElement>('.page-container')!;
             const resetBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Reset zoom"]')!;
             resetBtn.click();
-            expect(label.textContent).toBe('100%');
+            expect(container.style.width).toBe('1404px');
 
             const touch = (id: number, x: number, y: number) =>
                 new Touch({ identifier: id, target: pagesEl, clientX: x, clientY: y });
@@ -643,13 +639,13 @@ describe('<supernote-viewer>', () => {
             pagesEl.dispatchEvent(move);
 
             expect(move.defaultPrevented).toBe(true);
-            expect(label.textContent).toBe('200%');
+            expect(container.style.width).toBe('2808px');
         });
 
         it('a single-finger touchmove does not pinch-zoom', async () => {
             const el = await createLoadedViewer();
             const pagesEl = el.shadowRoot!.querySelector('.pages') as HTMLElement;
-            const label = el.shadowRoot!.querySelector('.zoom-label')!;
+            const container = el.shadowRoot!.querySelector<HTMLElement>('.page-container')!;
             const resetBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Reset zoom"]')!;
             resetBtn.click();
 
@@ -657,7 +653,7 @@ describe('<supernote-viewer>', () => {
             pagesEl.dispatchEvent(new TouchEvent('touchstart', { touches: [touch(100)], cancelable: true }));
             pagesEl.dispatchEvent(new TouchEvent('touchmove', { touches: [touch(50)], cancelable: true }));
 
-            expect(label.textContent).toBe('100%');
+            expect(container.style.width).toBe('1404px');
         });
 
         it('re-enabling fit-width recomputes from .pages\' current width', async () => {
@@ -665,7 +661,6 @@ describe('<supernote-viewer>', () => {
             const pagesEl = el.shadowRoot!.querySelector('.pages') as HTMLElement;
             const fitWidthBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Fit page to viewport width"]')!;
             const zoomOutBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Zoom out"]')!;
-            const label = el.shadowRoot!.querySelector('.zoom-label')!;
             const container = el.shadowRoot!.querySelector<HTMLElement>('.page-container')!;
 
             // happy-dom's clientWidth is always 0 by default - stub it to a
@@ -677,8 +672,7 @@ describe('<supernote-viewer>', () => {
 
             fitWidthBtn.click(); // re-enable -> recomputes immediately
             expect(fitWidthBtn.getAttribute('aria-pressed')).toBe('true');
-            expect(label.textContent).toBe('50%'); // 702 / 1404
-            expect(container.style.width).toBe('702px');
+            expect(container.style.width).toBe('702px'); // 702 / 1404
         });
 
         it('has no toolbar/zoom controls in single-page mode, and stays capped by CSS instead of zoom', async () => {

--- a/src/webcomponent/SupernoteViewerElement.test.ts
+++ b/src/webcomponent/SupernoteViewerElement.test.ts
@@ -14,6 +14,10 @@ import * as path from 'path';
 // document.createElement('supernote-viewer') below is properly typed with
 // no cast needed.
 import './SupernoteViewerElement';
+// Type-only - the side-effect import above both registers the element and
+// its HTMLElementTagNameMap augmentation (so createElement below needs no
+// cast); this just names the class for the animation-test helpers' types.
+import type { SupernoteViewerElement } from './SupernoteViewerElement';
 
 const FIXTURES_DIR = path.join(import.meta.dirname, '..', '..', 'supernote-typescript', 'tests', 'input');
 
@@ -1269,6 +1273,219 @@ describe('<supernote-viewer>', () => {
             // (not the native pixel size) drove the positioning.
             expect(rect.style.left).not.toBe('118px');
             expect(parseFloat(rect.style.left)).toBeCloseTo((118 / 1404) * 500, 0);
+        });
+    });
+
+    describe('write-on animation (prototype)', () => {
+        // Same setup as the rest of this file (real note parsed off disk,
+        // faked rasterizer) plus a faked rasterizeBackgrounds - its real
+        // implementation is the same Worker pipeline as rasterizePage (see
+        // convertToBackgroundImages()), which happy-dom can't run.
+        function createAnimationViewer() {
+            const el = createViewer();
+            el.rasterizeBackgrounds = vi.fn(async (_sn, pageNumbers: number[]) => pageNumbers.map((n) => `data:image/png;base64,bg${n}`));
+            return el;
+        }
+
+        async function loadAndEnterAnimation(el: SupernoteViewerElement): Promise<void> {
+            document.body.appendChild(el);
+            const loaded = waitForEvent<{ pageCount: number }>(el, 'supernote-load');
+            el.noteData = readFixture('turkish-a6x-20230015-handwriting-erase.note');
+            await loaded;
+            el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Toggle write-on animation"]')!.click();
+            // Entry is async: decode (synchronous) → background rasters
+            // (the fake resolves on a microtask) → swap + play. One timer
+            // tick gets past both.
+            await new Promise((resolve) => window.setTimeout(resolve, 0));
+        }
+
+        it('pen button swaps the page to its background raster, overlays the stroke SVG, and plays', async () => {
+            const el = createAnimationViewer();
+            document.body.appendChild(el);
+            const loaded = waitForEvent<{ pageCount: number }>(el, 'supernote-load');
+            el.noteData = readFixture('turkish-a6x-20230015-handwriting-erase.note');
+            await loaded;
+
+            const penBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Toggle write-on animation"]')!;
+            expect(penBtn).toBeTruthy();
+            const animControls = el.shadowRoot!.querySelector('.anim-controls')!;
+            expect(animControls.classList.contains('active')).toBe(false);
+            expect(penBtn.getAttribute('aria-pressed')).toBe('false');
+
+            penBtn.click();
+            await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+            // This note's single page is the only animatable one.
+            expect(el.rasterizeBackgrounds).toHaveBeenCalledTimes(1);
+            expect(el.rasterizeBackgrounds).toHaveBeenCalledWith(expect.anything(), [1]);
+            const container = el.shadowRoot!.querySelector('.page-container')!;
+            expect(container.querySelector('svg.stroke-animation-svg')).not.toBeNull();
+            // The page image is the background-only base layer, not the
+            // lazy-loaded ink raster (which never ran - no Intersection-
+            // Observer in this environment, and the mode guards it anyway).
+            expect(container.querySelector('img')!.getAttribute('src')).toBe('data:image/png;base64,bg1');
+            expect(el.rasterizePage).not.toHaveBeenCalled();
+
+            // The controls group is active, the pen is "pressed", and the
+            // running animator shows as playing (pause glyph + label) with
+            // a written time label.
+            expect(animControls.classList.contains('active')).toBe(true);
+            expect(penBtn.getAttribute('aria-pressed')).toBe('true');
+            expect(el.shadowRoot!.querySelector('button[aria-label="Pause write-on animation"]')).not.toBeNull();
+            expect(el.shadowRoot!.querySelector('.anim-time')!.textContent.trim()).not.toBe('');
+
+            // The play button doubles as pause.
+            el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Pause write-on animation"]')!.click();
+            expect(el.shadowRoot!.querySelector('button[aria-label="Play write-on animation"]')).not.toBeNull();
+        });
+
+        it('write-on-paused opens primed at t=0 - blank until play is pressed', async () => {
+            const el = createAnimationViewer();
+            el.presentation = 'write-on-paused';
+            document.body.appendChild(el);
+            const loaded = waitForEvent<{ pageCount: number }>(el, 'supernote-load');
+            el.noteData = readFixture('turkish-a6x-20230015-handwriting-erase.note');
+            await loaded;
+            // Entry is async: decode (synchronous) → background rasters
+            // (the fake resolves on a microtask) → swap - but no play this
+            // time.
+            await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+            // The note opens in the animation mode's visual state - the
+            // background base layer + stroke overlay - yet paused at t=0:
+            // the controls show the idle play glyph, not the running one.
+            const container = el.shadowRoot!.querySelector('.page-container')!;
+            expect(container.querySelector('img')!.getAttribute('src')).toBe('data:image/png;base64,bg1');
+            expect(container.querySelector('svg.stroke-animation-svg')).not.toBeNull();
+            expect(el.shadowRoot!.querySelector('.anim-controls')!.classList.contains('active')).toBe(true);
+            expect(el.shadowRoot!.querySelector('button[aria-label="Play write-on animation"]')).not.toBeNull();
+            expect(el.shadowRoot!.querySelector('button[aria-label="Pause write-on animation"]')).toBeNull();
+            expect(el.shadowRoot!.querySelector('button[aria-label="Toggle write-on animation"]')!.getAttribute('aria-pressed')).toBe('true');
+            expect(el.presentation).toBe('write-on-paused');
+
+            // Pressing play starts the running animator (pause glyph) and
+            // updates the public presentation state too.
+            el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Play write-on animation"]')!.click();
+            expect(el.shadowRoot!.querySelector('button[aria-label="Pause write-on animation"]')).not.toBeNull();
+            expect(el.presentation).toBe('write-on-playing');
+        });
+
+        it('switches an already-loaded note through the public presentation property', async () => {
+            const el = createAnimationViewer();
+            document.body.appendChild(el);
+            const loaded = waitForEvent<{ pageCount: number }>(el, 'supernote-load');
+            el.noteData = readFixture('turkish-a6x-20230015-handwriting-erase.note');
+            await loaded;
+
+            el.presentation = 'write-on-paused';
+            await new Promise((resolve) => window.setTimeout(resolve, 0));
+            expect(el.presentation).toBe('write-on-paused');
+            expect(el.shadowRoot!.querySelector('svg.stroke-animation-svg')).not.toBeNull();
+
+            el.presentation = 'static';
+            await new Promise((resolve) => window.setTimeout(resolve, 0));
+            expect(el.presentation).toBe('static');
+            expect(el.shadowRoot!.querySelector('svg.stroke-animation-svg')).toBeNull();
+        });
+
+        it('claims write-on pages before background rasterization, so a forced static load cannot reveal ink mid-entry', async () => {
+            const el = createAnimationViewer();
+            let resolveBackgrounds!: (urls: string[]) => void;
+            el.rasterizeBackgrounds = vi.fn(() => new Promise<string[]>((resolve) => { resolveBackgrounds = resolve; }));
+            el.presentation = 'write-on-paused';
+            document.body.appendChild(el);
+            const loaded = waitForEvent<{ pageCount: number }>(el, 'supernote-load');
+            el.noteData = readFixture('turkish-a6x-20230015-handwriting-erase.note');
+            await loaded;
+
+            // The worker is intentionally held pending. goToPage() mimics
+            // an IntersectionObserver/programmatic request for this page's
+            // normal image at exactly this point in real browsers.
+            el.goToPage(1);
+            await Promise.resolve();
+            expect(el.rasterizePage).not.toHaveBeenCalled();
+
+            resolveBackgrounds(['data:image/png;base64,bg1']);
+            await new Promise((resolve) => window.setTimeout(resolve, 0));
+            expect(el.shadowRoot!.querySelector('.page-container img')!.getAttribute('src')).toBe('data:image/png;base64,bg1');
+        });
+
+        it('starts at the default 4× speed, and the speed button cycles 4× → 1× → 2× → ½×', async () => {
+            const el = createAnimationViewer();
+            await loadAndEnterAnimation(el);
+            const speedBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('.anim-speed-btn')!;
+            expect(speedBtn.textContent).toBe('4×');
+            speedBtn.click();
+            expect(speedBtn.textContent).toBe('1×');
+            speedBtn.click();
+            expect(speedBtn.textContent).toBe('2×');
+            speedBtn.click();
+            expect(speedBtn.textContent).toBe('½×');
+            speedBtn.click();
+            expect(speedBtn.textContent).toBe('4×');
+        });
+
+        it('clicking the pen button again exits: overlay removed, base layer evicted, lazy-load restored', async () => {
+            const el = createAnimationViewer();
+            await loadAndEnterAnimation(el);
+            const container = el.shadowRoot!.querySelector('.page-container')!;
+            expect(container.querySelector('svg.stroke-animation-svg')).not.toBeNull();
+
+            const penBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Toggle write-on animation"]')!;
+            penBtn.click();
+            await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+            expect(container.querySelector('svg.stroke-animation-svg')).toBeNull();
+            // The page was never "visible" in this environment (happy-dom
+            // never fires IntersectionObserver), so exit evicts the base
+            // layer and leaves the page lazy - no eager re-raster.
+            expect(container.querySelector('img')!.hasAttribute('src')).toBe(false);
+            expect(el.rasterizePage).not.toHaveBeenCalled();
+            expect(penBtn.getAttribute('aria-pressed')).toBe('false');
+            expect(el.shadowRoot!.querySelector('.anim-controls')!.classList.contains('active')).toBe(false);
+            expect(el.presentation).toBe('static');
+        });
+
+        it('switching to recognized text view exits the animation', async () => {
+            const el = createAnimationViewer();
+            await loadAndEnterAnimation(el);
+            expect(el.shadowRoot!.querySelector('svg.stroke-animation-svg')).not.toBeNull();
+
+            el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Toggle recognized text view"]')!.click();
+            // Presentation transfer runs synchronously inside toggleMode();
+            // the flush is only for the (no-op here) static restore path.
+            await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+            expect(el.shadowRoot!.querySelector('.pages')!.classList.contains('mode-text')).toBe(true);
+            expect(el.shadowRoot!.querySelector('svg.stroke-animation-svg')).toBeNull();
+            expect(el.shadowRoot!.querySelector('button[aria-label="Toggle write-on animation"]')!.getAttribute('aria-pressed')).toBe('false');
+        });
+
+        it('a note with nothing decodable shows a hint and leaves the note untouched', async () => {
+            const el = createAnimationViewer();
+            document.body.appendChild(el);
+            const loaded = waitForEvent<{ pageCount: number }>(el, 'supernote-load');
+            el.noteData = readFixture('blank-a6x-3.26.40-two-pages.note');
+            await loaded;
+
+            vi.useFakeTimers();
+            el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Toggle write-on animation"]')!.click();
+            // Entry is async (microtasks only - a blank note never reaches
+            // the background-raster await); microtasks run under fake
+            // timers too, so flush a couple of them.
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(el.rasterizeBackgrounds).not.toHaveBeenCalled();
+            expect(el.shadowRoot!.querySelector('svg.stroke-animation-svg')).toBeNull();
+            expect(el.shadowRoot!.querySelector('.anim-controls')!.classList.contains('active')).toBe(false);
+            expect(el.shadowRoot!.querySelector('button[aria-label="Toggle write-on animation"]')!.getAttribute('aria-pressed')).toBe('false');
+            // The hint shows in the time label, and clears itself once its
+            // (now-faked) timeout elapses.
+            expect(el.shadowRoot!.querySelector('.anim-time')!.textContent).toMatch(/no animatable ink/i);
+            vi.advanceTimersByTime(3500);
+            vi.useRealTimers();
+            expect(el.shadowRoot!.querySelector('.anim-time')!.textContent).toBe('');
         });
     });
 });

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -16,16 +16,18 @@ import { WordOverlayEntry, buildWordOverlay, buildWordSearchText, repositionWord
 import { LinkOverlayEntry, bucketLinksByPage, buildLinkOverlay, repositionLinkOverlay } from '../render/linkOverlay';
 import { SidebarListItem, buildSidebarList, fillSidebarThumbnail, setupLazyListLoading } from '../render/sidebarList';
 import { svgIcon } from './icons';
+import { buildPageStrokeAnimation, StrokeAnimator } from './strokeAnimation';
+import type { PageStrokeAnimation } from './strokeAnimation';
 
 // How many pages either side of the currently-viewed page (see
-// setupPageLoadObserver()) get unconditionally preloaded, and protected from
+// startFullInkPageLoading()) get unconditionally preloaded, and protected from
 // eviction, regardless of exact scroll geometry - makes stepping through
 // nearby pages feel instant since the image is already decoded before it's
 // asked for.
 const PAGE_PRELOAD_DISTANCE = 2;
 
 // How far (as a percentage of the scroll container's own height) a page can
-// scroll out of view before its image is evicted (see setupPageLoadObserver()
+// scroll out of view before its image is evicted (see startFullInkPageLoading()
 // and evictPageImage()) - approximates "how many page-heights of scroll
 // buffer to hold onto" on the (usual) assumption that a page's rendered
 // height is roughly one viewport. Large enough that scrolling a handful of
@@ -72,7 +74,11 @@ type IconName =
     | 'zoom-out'
     | 'zoom-in'
     | 'rotate-ccw'
-    | 'stretch-horizontal';
+    | 'stretch-horizontal'
+    | 'pen'
+    | 'play'
+    | 'pause'
+    | 'repeat';
 
 const FALLBACK_ICONS: Record<IconName, () => SVGSVGElement> = {
     'layout-list': () => svgIcon([
@@ -106,6 +112,26 @@ const FALLBACK_ICONS: Record<IconName, () => SVGSVGElement> = {
         ['path', { d: 'M8 3 4 7l4 4' }],
         ['line', { x1: '4', y1: '7', x2: '20', y2: '7' }],
         ['path', { d: 'M16 3l4 4-4 4' }],
+    ]),
+    // Write-on animation (see src/webcomponent/strokeAnimation.ts): the pen
+    // enters/exits the mode, play/pause drive its animator, and repeat
+    // restarts the whole run.
+    'pen': () => svgIcon([
+        ['path', { d: 'M12 20h9' }],
+        ['path', { d: 'M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z' }],
+    ]),
+    'play': () => svgIcon([
+        ['path', { d: 'M6 3l14 9-14 9V3z' }],
+    ]),
+    'pause': () => svgIcon([
+        ['rect', { x: '6', y: '4', width: '4', height: '16', rx: '1' }],
+        ['rect', { x: '14', y: '4', width: '4', height: '16', rx: '1' }],
+    ]),
+    'repeat': () => svgIcon([
+        ['path', { d: 'm17 2 4 4-4 4' }],
+        ['path', { d: 'M3 11v-1a4 4 0 0 1 4-4h14' }],
+        ['path', { d: 'm7 22-4-4 4-4' }],
+        ['path', { d: 'M21 13v1a4 4 0 0 1-4 4H3' }],
     ]),
 };
 
@@ -352,6 +378,49 @@ button[aria-pressed="true"] {
 @media (max-width: 480px) {
     .page-jump-label,
     .zoom-step-btn {
+        display: none;
+    }
+}
+/* Write-on animation (prototype - see src/webcomponent/strokeAnimation.ts):
+   each animated page's stroke overlay is one absolutely-positioned <svg>
+   covering the page image's own box exactly - the container's aspect ratio
+   always equals the SVG's viewBox (both derive from the page's native
+   pixel size), so width/height: 100% with the default preserveAspectRatio
+   is an exact fit that tracks every zoom/fit-width resize the container
+   goes through. pointer-events: none so find-in-note's word spans and the
+   link rects (sibling elements) keep receiving their own clicks. */
+.pages .page-container > .stroke-animation-svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+}
+/* The play/pause + replay + speed + time group - hidden entirely until
+   write-on animation mode is active (see updateAnimControls()), since in
+   the static view only the pen button itself is meaningful. */
+.anim-controls {
+    display: none;
+    align-items: center;
+    gap: 0.5em;
+}
+.anim-controls.active {
+    display: inline-flex;
+}
+.anim-time {
+    min-width: 7.5em;
+    color: var(--supernote-viewer-muted);
+    font-size: 0.9em;
+    white-space: nowrap;
+}
+/* A fixed width keeps the button from jumping as its label changes
+   ("4×" → "1×" → "2×" → "½×"). */
+.anim-speed-btn {
+    min-width: 2.8em;
+    text-align: center;
+}
+@media (max-width: 480px) {
+    .anim-time {
         display: none;
     }
 }
@@ -702,6 +771,12 @@ button[aria-pressed="true"] {
 }
 `;
 
+// The public rendering contract. Set this before `noteData`/`src` to choose
+// the initial renderer, or change it after load to switch renderers.
+// `write-on-paused` is the old startBlank behavior: background only at 0:00.
+export type ViewerPresentation = 'static' | 'write-on-paused' | 'write-on-playing';
+type ActivePresentation = ViewerPresentation | 'write-on-preparing';
+
 export class SupernoteViewerElement extends HTMLElement {
     static get observedAttributes(): string[] {
         return ['src', 'page', 'single-page', 'invert-dark'];
@@ -726,6 +801,13 @@ export class SupernoteViewerElement extends HTMLElement {
     rasterizePage: (sn: SupernoteX, pageNumber: number) => Promise<string> = async (sn, pageNumber) => {
         const [imageDataUrl] = await new ImageConverter().convertToImages(sn, [pageNumber], undefined, this.vectorInk);
         return imageDataUrl;
+    };
+
+    // Overridable for the same reason rasterizePage is - the write-on
+    // animation's background-only base layers go through the same real
+    // ImageConverter/Worker pipeline via convertToBackgroundImages().
+    rasterizeBackgrounds: (sn: SupernoteX, pageNumbers: number[]) => Promise<string[]> = async (sn, pageNumbers) => {
+        return new ImageConverter().convertToBackgroundImages(sn, pageNumbers);
     };
 
     // Overridable hook applied to each page's raw recognized text before
@@ -767,7 +849,8 @@ export class SupernoteViewerElement extends HTMLElement {
     private pageJumpInputEl: HTMLInputElement | null = null;
     private modeToggleBtn: HTMLButtonElement | null = null;
     private pageLoadObserver: IntersectionObserver | null = null;
-    // Shared across every page - see setupPageLoadObserver()'s own comment
+    private pageLoadScrollHandler: (() => void) | null = null;
+    // Shared across every page - see startFullInkPageLoading()'s own comment
     // for why loading needs one debounce for "has scrolling settled" rather
     // than each page tracking its own independently.
     private loadCheckDebounceTimer?: number;
@@ -810,6 +893,21 @@ export class SupernoteViewerElement extends HTMLElement {
     private fitWidthEnabled = true;
     private zoomLabelEl: HTMLElement | null = null;
     private fitWidthBtn: HTMLButtonElement | null = null;
+    // Presentation owns page imagery. Static mode owns the normal lazy PNG
+    // loader; write-on owns background PNGs plus SVG overlays. Keeping this
+    // explicit prevents the two async renderers from competing for an img.
+    private requestedPresentation: ViewerPresentation = 'static';
+    private activePresentation: ActivePresentation = 'static';
+    private animation: StrokeAnimator | null = null;
+    private pageAnimations: (PageStrokeAnimation | null)[] = [];
+    private animSpeedMult = 4;
+    private animPenBtn: HTMLButtonElement | null = null;
+    private animControlsEl: HTMLElement | null = null;
+    private animPlayBtn: HTMLButtonElement | null = null;
+    private animReplayBtn: HTMLButtonElement | null = null;
+    private animSpeedBtn: HTMLButtonElement | null = null;
+    private animTimeEl: HTMLElement | null = null;
+    private lastAnimSecond = -1;
 
     constructor() {
         super();
@@ -847,12 +945,32 @@ export class SupernoteViewerElement extends HTMLElement {
         this.queueRender();
     }
 
+    // Selects who renders page images. Set before noteData/src to choose
+    // the initial renderer, or after load to switch immediately. The
+    // single-page presentation deliberately remains static because it has
+    // no write-on toolbar or page timeline.
+    get presentation(): ViewerPresentation {
+        return this.activePresentation === 'write-on-preparing'
+            ? this.requestedPresentation
+            : this.activePresentation;
+    }
+
+    set presentation(value: ViewerPresentation) {
+        if (value !== 'static' && value !== 'write-on-paused' && value !== 'write-on-playing') {
+            throw new TypeError(`Unknown supernote-viewer presentation: ${String(value)}`);
+        }
+        if (value === this.requestedPresentation && this.activePresentation !== 'write-on-preparing') return;
+        this.requestedPresentation = value;
+        this.applyRequestedPresentation();
+    }
+
     connectedCallback(): void {
         this.queueRender();
     }
 
     disconnectedCallback(): void {
-        this.pageLoadObserver?.disconnect();
+        this.animation?.destroy();
+        this.stopFullInkPageLoading();
         this.resizeObserver?.disconnect();
         this.thumbLoadObserver?.disconnect();
         window.clearTimeout(this.loadCheckDebounceTimer);
@@ -1093,8 +1211,7 @@ export class SupernoteViewerElement extends HTMLElement {
     }
 
     private teardownForRerender(): void {
-        this.pageLoadObserver?.disconnect();
-        this.pageLoadObserver = null;
+        this.stopFullInkPageLoading();
         this.resizeObserver?.disconnect();
         this.resizeObserver = null;
         this.thumbLoadObserver?.disconnect();
@@ -1128,6 +1245,18 @@ export class SupernoteViewerElement extends HTMLElement {
         this.fitWidthEnabled = true;
         this.zoomLabelEl = null;
         this.fitWidthBtn = null;
+        this.animation?.destroy();
+        this.animation = null;
+        this.activePresentation = 'static';
+        this.animSpeedMult = 4;
+        this.pageAnimations = [];
+        this.animPenBtn = null;
+        this.animControlsEl = null;
+        this.animPlayBtn = null;
+        this.animReplayBtn = null;
+        this.animSpeedBtn = null;
+        this.animTimeEl = null;
+        this.lastAnimSecond = -1;
         this.rootEl.innerHTML = '';
     }
 
@@ -1171,7 +1300,10 @@ export class SupernoteViewerElement extends HTMLElement {
             return { lower: text.toLowerCase(), entryAt, entriesInRange };
         });
 
-        this.setupPageLoadObserver(sn, states);
+        // Pick the renderer before any page image work begins. In
+        // particular, a write-on initial presentation never creates the
+        // static IntersectionObserver that could race its blank backgrounds.
+        if (this.requestedPresentation === 'static') this.startFullInkPageLoading(sn, states);
         if (pageCount > 1) {
             this.setupPageIndicatorTracking();
             this.buildThumbSidebar(sn, pageCount, invertColorsWhenDark);
@@ -1188,6 +1320,7 @@ export class SupernoteViewerElement extends HTMLElement {
         this.setupZoomTouchHandling();
         this.setupScrollBoundaryContainment();
         this.setupFitWidthResizing();
+        if (this.requestedPresentation !== 'static') this.applyRequestedPresentation();
     }
 
     // A single deep-linked page (the `page` attribute, clamped, defaulting
@@ -1225,6 +1358,8 @@ export class SupernoteViewerElement extends HTMLElement {
         // doesn't mistake this one-and-only page for one that's since
         // become irrelevant.
         state.visible = true;
+        // Single-page mode intentionally has no write-on controls/timeline.
+        this.activePresentation = 'static';
         void this.ensurePageImageLoaded(sn, state);
         this.setupScrollBoundaryContainment();
     }
@@ -1339,7 +1474,21 @@ export class SupernoteViewerElement extends HTMLElement {
     // document - exactly the memory-safety gap SupernoteView itself had
     // to fix once (issue #154) before this component existed, and would
     // otherwise silently reintroduce here.
-    private setupPageLoadObserver(sn: SupernoteX, states: ViewerPageState[]): void {
+    private stopFullInkPageLoading(): void {
+        this.pageLoadObserver?.disconnect();
+        this.pageLoadObserver = null;
+        window.clearTimeout(this.loadCheckDebounceTimer);
+        if (this.pagesEl && this.pageLoadScrollHandler) {
+            this.pagesEl.removeEventListener('scroll', this.pageLoadScrollHandler);
+        }
+        this.pageLoadScrollHandler = null;
+    }
+
+    // Full-ink image lifecycle: every static page, plus a write-on
+    // presentation's non-vector fallback pages. pageUsesFullInkRaster()
+    // decides ownership before this loader can begin a raster.
+    private startFullInkPageLoading(sn: SupernoteX, states: ViewerPageState[]): void {
+        this.stopFullInkPageLoading();
         const scheduleLoadCheck = () => {
             window.clearTimeout(this.loadCheckDebounceTimer);
             this.loadCheckDebounceTimer = window.setTimeout(() => {
@@ -1391,6 +1540,7 @@ export class SupernoteViewerElement extends HTMLElement {
         // long, unbroken scroll pass where nothing happens to enter/exit
         // the margin for a stretch could let the settle timer fire
         // mid-scroll instead of only once it actually stops.
+        this.pageLoadScrollHandler = scheduleLoadCheck;
         this.pagesEl?.addEventListener('scroll', scheduleLoadCheck, { passive: true });
     }
 
@@ -1399,7 +1549,7 @@ export class SupernoteViewerElement extends HTMLElement {
     // rootMargin (PAGE_EVICT_MARGIN_PERCENT% 0px), which deliberately pads a
     // much more generous zone around the real viewport just to decide when a
     // page is worth starting to watch, and how far it can scroll out before
-    // its image is evicted. See setupPageLoadObserver()'s own
+    // its image is evicted. See startFullInkPageLoading()'s own
     // comment for why the two need to be different checks.
     private isPageNearScreen(state: ViewerPageState, marginRatio: number): boolean {
         if (!this.pagesEl) return false;
@@ -1912,9 +2062,19 @@ export class SupernoteViewerElement extends HTMLElement {
         this.pagesResizeObserver.observe(this.pagesEl);
     }
 
+    // A write-on presentation still needs ordinary full-ink rasters for a
+    // page with no decodable vector timeline (e.g. a scanned/bitmap page in
+    // an otherwise handwritten note). Before the timeline map exists,
+    // write-on owns every page and no full-ink request may begin.
+    private pageUsesFullInkRaster(state: ViewerPageState): boolean {
+        return this.activePresentation === 'static'
+            || this.pageAnimations[state.pageNumber - 1] === null;
+    }
+
     // Idempotent and safe to call speculatively - `loaded` is set eagerly so
     // a slow rasterization can't be triggered twice for the same page.
     private async ensurePageImageLoaded(sn: SupernoteX, state: ViewerPageState): Promise<void> {
+        if (!this.pageUsesFullInkRaster(state)) return;
         state.loaded = true;
         console.debug(`supernote-viewer: loading page ${state.pageNumber}`);
         try {
@@ -1940,6 +2100,13 @@ export class SupernoteViewerElement extends HTMLElement {
                 console.debug(`supernote-viewer: discarding page ${state.pageNumber}'s load - scrolled away while rasterizing`);
                 return;
             }
+            // A full-ink raster can finish after write-on takes ownership
+            // of this page. Never let that stale result replace its
+            // background-only image.
+            if (!this.pageUsesFullInkRaster(state)) {
+                state.loaded = false;
+                return;
+            }
             fillNotePagePlaceholder(state, imageDataUrl);
             console.debug(`supernote-viewer: page ${state.pageNumber} loaded, img.src set (length ${imageDataUrl.length})`);
             // fillNotePagePlaceholder() clears this page's width overrides
@@ -1963,7 +2130,7 @@ export class SupernoteViewerElement extends HTMLElement {
     }
 
     // Releases a loaded page's image once it's scrolled out of the
-    // pageLoadObserver's own prefetch margin (see setupPageLoadObserver()) -
+    // pageLoadObserver's own prefetch margin (see startFullInkPageLoading()) -
     // the "evict" half of the lazy-load/evict cycle that bounds memory on a
     // long scroll, mirroring SupernoteView's own evictPageImage() (main.ts,
     // issue #154's fix). Safe to call speculatively: a no-op if nothing's
@@ -1971,6 +2138,9 @@ export class SupernoteViewerElement extends HTMLElement {
     // reports initial non-intersection for anything outside the viewport
     // at file-open time).
     private evictPageImage(sn: SupernoteX, state: ViewerPageState): void {
+        // Vector-timeline pages belong to write-on; static/fallback pages
+        // participate in the normal lazy image lifecycle.
+        if (!this.pageUsesFullInkRaster(state)) return;
         if (!state.loaded) return;
         console.debug(`supernote-viewer: evicting page ${state.pageNumber}`);
         evictNotePageImage(state, sn.pageWidth, sn.pageHeight);
@@ -2128,6 +2298,69 @@ export class SupernoteViewerElement extends HTMLElement {
         findBtn.addEventListener('click', () => this.toggleFindBar());
         toolbar.appendChild(findBtn);
         this.findToggleBtn = findBtn;
+
+        // Write-on animation (prototype - see src/webcomponent/
+        // strokeAnimation.ts): the pen button enters/exits the mode; the
+        // .anim-controls group (hidden until active - see its CSS rule) is
+        // where play/pause, replay, speed, and the time label live, so the
+        // static view only ever shows the one extra pen button.
+        const animPenBtn = document.createElement('button');
+        animPenBtn.type = 'button';
+        animPenBtn.setAttribute('part', 'button');
+        animPenBtn.setAttribute('aria-label', 'Toggle write-on animation');
+        animPenBtn.setAttribute('aria-pressed', 'false');
+        this.renderIcon('pen', animPenBtn);
+        animPenBtn.addEventListener('click', () => this.toggleAnimationMode());
+        toolbar.appendChild(animPenBtn);
+        this.animPenBtn = animPenBtn;
+
+        const animControls = document.createElement('div');
+        animControls.className = 'anim-controls';
+        animControls.setAttribute('part', 'anim-controls');
+
+        const animPlayBtn = document.createElement('button');
+        animPlayBtn.type = 'button';
+        animPlayBtn.setAttribute('part', 'button');
+        animPlayBtn.setAttribute('aria-label', 'Play write-on animation');
+        this.renderIcon('play', animPlayBtn);
+        animPlayBtn.addEventListener('click', () => {
+            this.presentation = this.presentation === 'write-on-playing'
+                ? 'write-on-paused'
+                : 'write-on-playing';
+        });
+        animControls.appendChild(animPlayBtn);
+        this.animPlayBtn = animPlayBtn;
+
+        const animReplayBtn = document.createElement('button');
+        animReplayBtn.type = 'button';
+        animReplayBtn.setAttribute('part', 'button');
+        animReplayBtn.setAttribute('aria-label', 'Replay write-on animation');
+        this.renderIcon('repeat', animReplayBtn);
+        animReplayBtn.addEventListener('click', () => {
+            this.animation?.reset();
+            this.presentation = 'write-on-playing';
+        });
+        animControls.appendChild(animReplayBtn);
+        this.animReplayBtn = animReplayBtn;
+
+        const animSpeedBtn = document.createElement('button');
+        animSpeedBtn.type = 'button';
+        animSpeedBtn.className = 'anim-speed-btn';
+        animSpeedBtn.setAttribute('part', 'button');
+        animSpeedBtn.setAttribute('aria-label', 'Cycle animation speed');
+        animSpeedBtn.textContent = '4×';
+        animSpeedBtn.addEventListener('click', () => this.cycleAnimSpeed());
+        animControls.appendChild(animSpeedBtn);
+        this.animSpeedBtn = animSpeedBtn;
+
+        const animTime = document.createElement('span');
+        animTime.className = 'anim-time';
+        animTime.setAttribute('part', 'anim-time');
+        animControls.appendChild(animTime);
+        this.animTimeEl = animTime;
+
+        toolbar.appendChild(animControls);
+        this.animControlsEl = animControls;
 
         // Lets a host add its own controls to this toolbar - e.g.
         // SupernoteView's "export current page as image" button in
@@ -2423,9 +2656,251 @@ export class SupernoteViewerElement extends HTMLElement {
     }
 
     private toggleMode(): void {
+        // Write-on animation is an image-mode feature (the strokes are laid
+        // over the page image's own box, which recognized-text mode hides
+        // entirely) - leave the mode first, so a switch to text restores
+        // the real ink rasters along with everything else the mode swapped.
+        if (this.activePresentation !== 'static') this.presentation = 'static';
         this.mode = this.mode === 'image' ? 'text' : 'image';
         this.pagesEl?.classList.toggle('mode-text', this.mode === 'text');
         this.modeToggleBtn?.setAttribute('aria-pressed', String(this.mode === 'text'));
+    }
+
+    // ------------------------------------------------------------------
+    // Write-on animation (prototype). The stroke decode, per-page SVG
+    // overlay, and timeline/player live in src/webcomponent/
+    // strokeAnimation.ts; this section is only the component wiring: the
+    // pen button, the background-layer swap, and the toolbar controls.
+    // ------------------------------------------------------------------
+
+    // Public convenience toggle for hosts with their own shortcut. The
+    // public `presentation` property is the declarative equivalent.
+    toggleAnimationMode(): void {
+        this.presentation = this.presentation === 'static'
+            ? 'write-on-playing'
+            : 'static';
+    }
+
+    private applyRequestedPresentation(): void {
+        if (!this.sn || !this.pagesEl || this.hasAttribute('single-page')) return;
+        if (this.requestedPresentation === 'static') {
+            this.activateStaticPresentation();
+            return;
+        }
+        if (this.activePresentation === 'static') {
+            void this.enterWriteOnPresentation();
+            return;
+        }
+        if (this.activePresentation === 'write-on-preparing') return;
+        this.setWriteOnPlayback(this.requestedPresentation);
+    }
+
+    private setWriteOnPlayback(presentation: Exclude<ViewerPresentation, 'static'>): void {
+        if (!this.animation) return;
+        if (presentation === 'write-on-playing') this.animation.play();
+        else this.animation.pause();
+        this.activePresentation = presentation;
+        this.updateAnimControls();
+    }
+
+    // Enters the write-on presentation. It claims page imagery and stops
+    // the static loader before any asynchronous work starts, so there is no
+    // intermediate state in which two renderers can write the same <img>.
+    private async enterWriteOnPresentation(): Promise<void> {
+        if (this.activePresentation !== 'static') return;
+        const sn = this.sn;
+        if (!sn || !this.pagesEl || this.pageStates.length === 0) return;
+        // Write-on is image-only. Do not call toggleMode(): it also changes
+        // presentation, whereas this transition merely leaves text mode.
+        if (this.mode === 'text') {
+            this.mode = 'image';
+            this.pagesEl.classList.remove('mode-text');
+            this.modeToggleBtn?.setAttribute('aria-pressed', 'false');
+        }
+
+        this.stopFullInkPageLoading();
+        this.activePresentation = 'write-on-preparing';
+        const token = this.renderToken;
+        try {
+            this.pageAnimations = this.pageStates.map((state) => buildPageStrokeAnimation(sn, state.pageNumber));
+            const animIndexes = this.pageAnimations.map((page, index) => (page ? index : -1)).filter((index) => index >= 0);
+            if (animIndexes.length === 0) {
+                // A bitmap/scanned note has no write timeline. Fall back to
+                // the static presentation instead of leaving page ownership
+                // in a half-prepared state.
+                this.requestedPresentation = 'static';
+                this.activePresentation = 'static';
+                this.pageAnimations = [];
+                this.startFullInkPageLoading(sn, this.pageStates);
+                this.animPenHint('No animatable ink on this note');
+                return;
+            }
+
+            // Blank any static images immediately. The page shells retain
+            // their known dimensions while background-only rasters arrive.
+            for (const index of animIndexes) {
+                const state = this.pageStates[index];
+                state.loaded = false;
+                evictNotePageImage(state, sn.pageWidth, sn.pageHeight);
+            }
+            // Mixed notes retain static rendering for their non-vector
+            // pages. The timeline map already exists, so the full-ink
+            // loader's page eligibility check cannot touch animated pages.
+            this.startFullInkPageLoading(sn, this.pageStates);
+
+            const backgroundUrls = await this.rasterizeBackgrounds(sn, animIndexes.map((index) => index + 1));
+            // A property change to static, a rerender, or disconnection
+            // cancels this transition without allowing stale URLs to land.
+            if (token !== this.renderToken || this.activePresentation !== 'write-on-preparing') return;
+
+            animIndexes.forEach((index, k) => {
+                const state = this.pageStates[index];
+                // This image now belongs to write-on presentation, not the
+                // static lazy-load/evict cycle.
+                state.loaded = true;
+                fillNotePagePlaceholder(state, backgroundUrls[k]);
+                state.containerEl.appendChild(this.pageAnimations[index]!.svg);
+            });
+            // fillNotePagePlaceholder() reset each page's container width -
+            // reapply whatever zoom/fit-width is currently active, exactly
+            // as ensurePageImageLoaded() does after its own fill.
+            this.applyZoomToPages();
+
+            this.animation = new StrokeAnimator(this.pageAnimations, {
+                onActivePage: (page) => this.scrollActiveAnimPageIntoView(page),
+                onTime: (timeMs) => this.updateAnimTimeLabel(timeMs),
+                onFinish: () => {
+                    this.requestedPresentation = 'write-on-paused';
+                    this.activePresentation = 'write-on-paused';
+                    this.updateAnimControls();
+                },
+            });
+            this.animation.speed = this.animSpeedMult;
+            this.lastAnimSecond = -1;
+            if (this.requestedPresentation !== 'static') this.setWriteOnPlayback(this.requestedPresentation);
+        } catch (err) {
+            // A partial failure always returns ownership to the static
+            // renderer; never leave pages between the two presentations.
+            console.error('supernote-viewer: write-on animation failed to start', err);
+            if (token === this.renderToken && this.activePresentation === 'write-on-preparing') {
+                this.requestedPresentation = 'static';
+                this.activateStaticPresentation();
+            }
+        }
+    }
+
+    // Transfers page imagery back to the static presentation. This is also
+    // the cancellation path for write-on-preparing: the awaited worker may
+    // still finish, but its active-presentation check prevents stale output
+    // from being installed.
+    private activateStaticPresentation(): void {
+        const wasWriteOn = this.activePresentation !== 'static';
+        this.activePresentation = 'static';
+        this.animation?.destroy();
+        this.animation = null;
+        const sn = this.sn;
+        this.pageStates.forEach((state, index) => {
+            const pageAnim = this.pageAnimations[index];
+            pageAnim?.svg.remove();
+            if (wasWriteOn && pageAnim && sn) {
+                state.loaded = false;
+                evictNotePageImage(state, sn.pageWidth, sn.pageHeight);
+            }
+        });
+        this.pageAnimations = [];
+        this.lastAnimSecond = -1;
+        if (sn) {
+            this.startFullInkPageLoading(sn, this.pageStates);
+            for (const state of this.pageStates) {
+                if (state.visible && !state.loaded) void this.ensurePageImageLoaded(sn, state);
+            }
+        }
+        this.updateAnimControls();
+    }
+
+    // Swaps the .anim-controls group in/out with the mode, and updates the
+    // play button's own glyph/label for the animator's state (playing →
+    // pause glyph, anything else → play).
+    private updateAnimControls(): void {
+        const writeOnActive = this.activePresentation !== 'static';
+        this.animPenBtn?.setAttribute('aria-pressed', String(writeOnActive));
+        this.animControlsEl?.classList.toggle('active', writeOnActive);
+        if (this.animPlayBtn) {
+            const playing = this.animation?.isPlaying ?? false;
+            this.setButtonIcon(this.animPlayBtn, playing ? 'pause' : 'play');
+            this.animPlayBtn.setAttribute('aria-label', playing ? 'Pause write-on animation' : 'Play write-on animation');
+        }
+        if (this.animTimeEl) {
+            this.animTimeEl.textContent = this.animation
+                ? `${this.formatAnimTime(this.animation.currentTime)} / ${this.formatAnimTime(this.animation.totalDuration)}`
+                : '';
+        }
+    }
+
+    // renderIcon() appends (it must - a host's own iconRenderer may not
+    // replace existing children), so an icon *swap* on a button that
+    // already carries one needs its children cleared first.
+    private setButtonIcon(btn: HTMLElement | null, name: IconName): void {
+        if (!btn) return;
+        btn.replaceChildren();
+        this.renderIcon(name, btn);
+    }
+
+    // 4× → 1× → 2× → ½× → 4× ... 4× is the default - at 1× a long
+    // handwritten note takes minutes, which is fine for a replay but not
+    // for a first look. The ½× step is for scrubbing back over a
+    // tricky stroke, not just going faster.
+    private static readonly ANIM_SPEEDS: number[] = [4, 1, 2, 0.5];
+
+    private cycleAnimSpeed(): void {
+        const speeds = SupernoteViewerElement.ANIM_SPEEDS;
+        const next = speeds[(speeds.indexOf(this.animSpeedMult) + 1) % speeds.length];
+        this.animSpeedMult = next;
+        if (this.animation) this.animation.speed = next;
+        if (this.animSpeedBtn) this.animSpeedBtn.textContent = next < 1 ? '½×' : `${next}×`;
+    }
+
+    // ~1 DOM write per second, not per animation frame.
+    private updateAnimTimeLabel(timeMs: number): void {
+        if (!this.animTimeEl || !this.animation) return;
+        const second = Math.floor(timeMs / 1000);
+        if (second === this.lastAnimSecond) return;
+        this.lastAnimSecond = second;
+        this.animTimeEl.textContent = `${this.formatAnimTime(timeMs)} / ${this.formatAnimTime(this.animation.totalDuration)}`;
+    }
+
+    private formatAnimTime(ms: number): string {
+        const totalSeconds = Math.max(0, Math.round(ms / 1000));
+        return `${Math.floor(totalSeconds / 60)}:${String(totalSeconds % 60).padStart(2, '0')}`;
+    }
+
+    // Short, self-clearing hint shown in the time label for an animation
+    // entry that produces nothing to play.
+    private animPenHint(message: string): void {
+        if (!this.animTimeEl) return;
+        this.animTimeEl.textContent = message;
+        window.setTimeout(() => {
+            if (this.animTimeEl && this.activePresentation === 'static') this.animTimeEl.textContent = '';
+        }, 3000);
+    }
+
+    // Follows the pen from page to page: when the active page *changes*
+    // and that page is entirely out of view, bring its top to ~10% below
+    // .pages' own top edge (writing flows downward from a page's top, so
+    // "near the top" keeps the in-progress stroke visible longest). A page
+    // the user has deliberately positioned elsewhere is left alone - this
+    // only fires on a page change, and only for a page actually off-screen
+    // (the overlap check below), so it never fights a manual mid-page
+    // scroll.
+    private scrollActiveAnimPageIntoView(page: number): void {
+        if (!this.pagesEl) return;
+        const state = this.pageStates[page];
+        if (!state) return;
+        const pagesRect = this.pagesEl.getBoundingClientRect();
+        const rect = state.containerEl.getBoundingClientRect();
+        if (rect.bottom >= pagesRect.top && rect.top <= pagesRect.bottom) return; // already in view
+        const targetTop = this.pagesEl.scrollTop + (rect.top - pagesRect.top) - pagesRect.height * 0.1;
+        this.pagesEl.scrollTo({ top: targetTop, behavior: 'smooth' });
     }
 
     private showStatus(message: string): void {

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -358,12 +358,6 @@ button[aria-pressed="true"] {
     border-radius: 4px;
     padding: 0.2em 0.3em;
 }
-.zoom-label {
-    min-width: 3.5em;
-    text-align: center;
-    color: var(--supernote-viewer-muted);
-    font-size: 0.9em;
-}
 /* Narrow phones (issue #202, reported on iOS 13) don't have room for every
    toolbar control at once - the full set (thumbnails, "Page" label + jump
    box + total, zoom out/in/reset + fit-width, mode toggle, find) reliably
@@ -891,7 +885,6 @@ export class SupernoteViewerElement extends HTMLElement {
     // mode - see the :host(:not([single-page])) CSS override above.
     private zoomScale = 1;
     private fitWidthEnabled = true;
-    private zoomLabelEl: HTMLElement | null = null;
     private fitWidthBtn: HTMLButtonElement | null = null;
     // Presentation owns page imagery. Static mode owns the normal lazy PNG
     // loader; write-on owns background PNGs plus SVG overlays. Keeping this
@@ -1243,7 +1236,6 @@ export class SupernoteViewerElement extends HTMLElement {
         this.thumbnailsVisible = false;
         this.zoomScale = 1;
         this.fitWidthEnabled = true;
-        this.zoomLabelEl = null;
         this.fitWidthBtn = null;
         this.animation?.destroy();
         this.animation = null;
@@ -1783,7 +1775,6 @@ export class SupernoteViewerElement extends HTMLElement {
             state.containerEl.style.width = width;
             state.imageEl.style.width = '100%';
         }
-        if (this.zoomLabelEl) this.zoomLabelEl.textContent = `${Math.round(this.zoomScale * 100)}%`;
     }
 
     // Scales every page so its rendered width matches however much
@@ -2240,13 +2231,6 @@ export class SupernoteViewerElement extends HTMLElement {
         this.renderIcon('zoom-out', zoomOutBtn);
         zoomOutBtn.addEventListener('click', () => this.setZoom(this.zoomScale / 1.25));
         toolbar.appendChild(zoomOutBtn);
-
-        const zoomLabel = document.createElement('span');
-        zoomLabel.className = 'zoom-label';
-        zoomLabel.setAttribute('part', 'zoom-label');
-        zoomLabel.textContent = '100%';
-        toolbar.appendChild(zoomLabel);
-        this.zoomLabelEl = zoomLabel;
 
         const zoomInBtn = document.createElement('button');
         zoomInBtn.type = 'button';

--- a/src/webcomponent/strokeAnimation.test.ts
+++ b/src/webcomponent/strokeAnimation.test.ts
@@ -140,35 +140,31 @@ describe('buildPageStrokeAnimation', () => {
         expect(anim.duration).toBeGreaterThan(0);
     });
 
-    it('emits masked contour strokes with a dash-ready reveal path, and centerline strokes as dash-ready open paths', () => {
+    it('uses a cheap centerline preview for contours, then retains their exact final fills', () => {
         const sn = new SupernoteX(readFixture('turkish-a6x-20230015-handwriting-erase.note'));
         const anim = buildPageStrokeAnimation(sn, 1)!;
-        const masked = anim.segments.filter((s) => s.revealEl);
+        const previews = anim.segments.filter((s) => s.swapOnComplete);
         const plainDraws = anim.segments.filter((s) => s.kind === 'draw' && !s.revealEl);
-        // This note is mostly pressure-varying contour fills (each revealed
-        // by a mask stroke along the record's own centerline) with one
-        // plain centerline stroke — and no fades at all.
-        expect(masked.length).toBeGreaterThan(0);
+        // This note is mostly pressure-varying contour fills. They get a
+        // normal dashed centerline during playback, not an SVG mask.
+        expect(previews.length).toBeGreaterThan(0);
         expect(plainDraws.length).toBeGreaterThan(0);
         expect(anim.segments.every((s) => s.kind === 'draw')).toBe(true);
+        expect(anim.svg.querySelector('mask')).toBeNull();
 
-        for (const { el, revealEl } of masked) {
-            // The visible element is the static render's filled ring.
+        for (const { el, revealEl } of previews) {
+            // The initially-hidden element is still the exact static fill.
             expect(tag(el)).toBe('path');
             expect(el.getAttribute('fill')!.startsWith('rgb(')).toBe(true);
             expect(el.getAttribute('d')!.includes('Z')).toBe(true);
-            // ...exposed by a dash-revealed mask stroke.
-            expect(el.getAttribute('mask')!.startsWith('url(#')).toBe(true);
-            const maskId = (el.getAttribute('mask') ?? '').replace(/^url\(#/, '').replace(/\)$/, '');
-            const mask = anim.svg.querySelector(`mask#${maskId}`);
-            expect(mask).not.toBeNull();
-            expect(mask!.getAttribute('maskUnits')).toBe('userSpaceOnUse');
+            expect(el.getAttribute('mask')).toBeNull();
+            expect(el.style.display).toBe('none');
+            // Its temporary visible preview is just a cheap dashed path.
             const reveal = revealEl!;
-            expect(mask!.firstElementChild).toBe(reveal);
             expect(tag(reveal)).toBe('path');
             expect(reveal.getAttribute('pathLength')).toBe('1');
             expect(reveal.getAttribute('fill')).toBe('none');
-            expect(reveal.getAttribute('stroke')).toBe('white');
+            expect(reveal.getAttribute('stroke')).toBe(el.getAttribute('fill'));
             expect(parseFloat(reveal.getAttribute('stroke-width') ?? '')).toBeGreaterThan(0);
             expect(reveal.style.strokeDasharray).toBe('1');
             expect(reveal.style.strokeDashoffset).toBe('1');
@@ -204,6 +200,9 @@ describe('StrokeAnimator', () => {
         expect(animator.isPlaying).toBe(false);
         expect(animator.currentTime).toBe(0);
         for (const seg of page.segments) expect(progressOf(seg)).toBe(0);
+        const contour = page.segments.find((seg) => seg.swapOnComplete)!;
+        expect(contour.el.style.display).toBe('none');
+        expect(contour.revealEl!.style.display).toBe('');
         expect(activePages).toEqual([]); // nothing has started; no page yet
 
         animator.play();
@@ -225,12 +224,16 @@ describe('StrokeAnimator', () => {
         expect(finished).toBe(1);
         expect(clock.frameQueued()).toBe(false);
         for (const seg of page.segments) expect(progressOf(seg)).toBe(1);
+        expect(contour.el.style.display).toBe('');
+        expect(contour.revealEl!.style.display).toBe('none');
 
         // Playing again from the finished state restarts the whole run.
         animator.play();
         expect(animator.isPlaying).toBe(true);
         expect(animator.currentTime).toBe(0);
         for (const seg of page.segments) expect(progressOf(seg)).toBe(0);
+        expect(contour.el.style.display).toBe('none');
+        expect(contour.revealEl!.style.display).toBe('');
         animator.pause();
     });
 
@@ -270,6 +273,25 @@ describe('StrokeAnimator', () => {
         animator.speed = 0.5;
         clock.tick(50);
         expect(animator.currentTime).toBe(125);
+        animator.pause();
+    });
+
+    it('limits visual updates to 30 FPS while retaining elapsed timeline time', () => {
+        const sn = new SupernoteX(readFixture('turkish-a6x-20230015-handwriting-erase.note'));
+        const page = buildPageStrokeAnimation(sn, 1)!;
+        const clock = makeFakeClock();
+        const animator = new StrokeAnimator([page], {}, clock.options);
+
+        animator.play();
+        clock.tick(20);
+        // A 20ms rAF is retained for the next visual update instead of
+        // changing an SVG dash offset immediately.
+        expect(animator.currentTime).toBe(0);
+        expect(clock.frameQueued()).toBe(true);
+        clock.tick(14);
+        // The following update absorbs all elapsed time; pacing has not
+        // slowed, only the number of expensive SVG paints.
+        expect(animator.currentTime).toBe(34);
         animator.pause();
     });
 

--- a/src/webcomponent/strokeAnimation.test.ts
+++ b/src/webcomponent/strokeAnimation.test.ts
@@ -1,0 +1,352 @@
+// @vitest-environment happy-dom
+//
+// Unit tests for the write-on animation prototype (strokeAnimation.ts):
+// the per-page overlay/timeline builder against real fixture notes, and
+// the StrokeAnimator driven by an injected fake clock (the exact reason
+// its clock is injectable — requestAnimationFrame timing is not
+// meaningfully testable under vitest).
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { SupernoteX, prepareVectorInkPages } from 'supernote-typescript';
+import { buildPageStrokeAnimation, StrokeAnimator } from './strokeAnimation';
+import type { StrokeAnimatorClock, StrokeSegment } from './strokeAnimation';
+
+const FIXTURES_DIR = path.join(import.meta.dirname, '..', '..', 'supernote-typescript', 'tests', 'input');
+
+function readFixture(name: string): Uint8Array {
+    const buf = fs.readFileSync(path.join(FIXTURES_DIR, name));
+    return new Uint8Array(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength));
+}
+
+// The injected clock: tick(dtMs) advances the fake "now" and runs the one
+// pending frame callback (the animator schedules exactly one per frame, so
+// one outstanding callback at a time is the whole protocol).
+function makeFakeClock(): {
+    tick: (dtMs: number) => void;
+    now: () => number;
+    frameQueued: () => boolean;
+    options: StrokeAnimatorClock;
+} {
+    let now = 0;
+    let frameCb: ((t: number) => void) | null = null;
+    let nextId = 1;
+    return {
+        tick: (dtMs: number) => {
+            now += dtMs;
+            const cb = frameCb;
+            frameCb = null;
+            cb?.(now);
+        },
+        now: () => now,
+        frameQueued: () => frameCb !== null,
+        options: {
+            now: () => now,
+            requestFrame: (cb) => { frameCb = cb; return nextId++; },
+            cancelFrame: () => { frameCb = null; },
+        },
+    };
+}
+
+function tag(el: Element): string {
+    return el.tagName.toLowerCase();
+}
+
+// 0 = fully hidden, 1 = fully revealed — read back off whichever element
+// the animator drives for that kind (a masked contour's reveal stroke,
+// its own path/element otherwise).
+function progressOf(seg: StrokeSegment): number {
+    const el = seg.revealEl ?? seg.el;
+    return seg.kind === 'draw' ? 1 - parseFloat(el.style.strokeDashoffset) : parseFloat(el.style.opacity);
+}
+
+// How many segments this page *should* produce, straight from the decoded
+// strokes (the same drawable rules the builder mirrors, applied here
+// independently of the builder's own code path).
+function expectedSegmentCount(sn: SupernoteX, pageNumber: number): number {
+    const vip = prepareVectorInkPages(sn, [pageNumber], 1)[0];
+    let count = 0;
+    vip.strokes.forEach((stroke, i) => {
+        const style = vip.styles[i];
+        if (!style || style.shape === 'skip') return;
+        if (style.shape === 'rect') {
+            if (stroke.points.length >= 2) count++;
+            return;
+        }
+        const rings = (stroke.contour ?? []).filter((ring) => ring.length >= 3);
+        if (rings.length > 0 || stroke.points.length > 0) count++;
+    });
+    return count;
+}
+
+describe('buildPageStrokeAnimation', () => {
+    it('returns null for a page with no decodable vector ink', () => {
+        const sn = new SupernoteX(readFixture('blank-a6x-3.26.40-two-pages.note'));
+        expect(buildPageStrokeAnimation(sn, 1)).toBeNull();
+        expect(buildPageStrokeAnimation(sn, 2)).toBeNull();
+    });
+
+    it('builds one element per surviving stroke, in the static render\'s DOM order but on a write-order timeline', () => {
+        // Heading page: 38 filled strokes, then 4 Heading rects (one
+        // hatched) written *after* the ink they back — the exact
+        // z-order-vs-time-order split this module exists to get right
+        // (the finished page must look like the static vector render:
+        // rects beneath the ink; the animation must reveal them at their
+        // own write position: after the ink).
+        const sn = new SupernoteX(readFixture('heading-n5-20260016-backgrounds-marker.note'));
+        const anim = buildPageStrokeAnimation(sn, 2);
+        expect(anim).not.toBeNull();
+        expect(anim!.pageNumber).toBe(2);
+        expect(anim!.svg.getAttribute('viewBox')).toBe(`0 0 ${sn.pageWidth} ${sn.pageHeight}`);
+        expect(anim!.segments).toHaveLength(expectedSegmentCount(sn, 2));
+        expect(anim!.segments).toHaveLength(42);
+        // Every element appears exactly once (across both orders).
+        expect(new Set(anim!.segments.map((s) => s.el)).size).toBe(42);
+
+        const children = Array.from(anim!.svg.children);
+        const rectEls = children.filter((el) => tag(el) === 'rect');
+        expect(rectEls).toHaveLength(4);
+        // DOM: all 4 rects before any of the 38 fill paths (a <defs> for
+        // the hatched rect may precede them - it holds no geometry).
+        const firstPathIndex = children.findIndex((el) => tag(el) === 'path');
+        for (const rectEl of rectEls) {
+            expect(children.indexOf(rectEl)).toBeLessThan(firstPathIndex);
+        }
+        // The hatched rect references its own unique pattern.
+        const hatched = rectEls.find((el) => (el.getAttribute('fill') ?? '').startsWith('url(#'));
+        expect(hatched).toBeTruthy();
+        const patternId = (hatched!.getAttribute('fill') ?? '').replace(/^url\(#/, '').replace(/\)$/, '');
+        expect(anim!.svg.querySelector(`pattern#${patternId}`)).not.toBeNull();
+
+        // Timeline: pure write order — the 4 rects (written last) sit at
+        // the *end* of the segment list, the 38 fills before them.
+        const segmentTags = anim!.segments.map((s) => tag(s.el));
+        expect(segmentTags.slice(0, 38).every((t) => t === 'path')).toBe(true);
+        expect(segmentTags.slice(38)).toEqual(['rect', 'rect', 'rect', 'rect']);
+    });
+
+    it('lays each page\'s timeline out from t=0, monotonically, with the page duration as the last stroke\'s end', () => {
+        const sn = new SupernoteX(readFixture('turkish-a6x-20230015-handwriting-erase.note'));
+        const anim = buildPageStrokeAnimation(sn, 1)!;
+        expect(anim.segments).toHaveLength(expectedSegmentCount(sn, 1));
+        expect(anim.segments[0].start).toBe(0);
+        for (let i = 1; i < anim.segments.length; i++) {
+            // Each stroke begins after the previous one finished (the pen
+            // lift gap is between strokes, not at the page's start).
+            expect(anim.segments[i].start).toBeGreaterThan(anim.segments[i - 1].start + anim.segments[i - 1].duration);
+        }
+        const last = anim.segments[anim.segments.length - 1];
+        expect(anim.duration).toBe(last.start + last.duration);
+        expect(anim.duration).toBeGreaterThan(0);
+    });
+
+    it('emits masked contour strokes with a dash-ready reveal path, and centerline strokes as dash-ready open paths', () => {
+        const sn = new SupernoteX(readFixture('turkish-a6x-20230015-handwriting-erase.note'));
+        const anim = buildPageStrokeAnimation(sn, 1)!;
+        const masked = anim.segments.filter((s) => s.revealEl);
+        const plainDraws = anim.segments.filter((s) => s.kind === 'draw' && !s.revealEl);
+        // This note is mostly pressure-varying contour fills (each revealed
+        // by a mask stroke along the record's own centerline) with one
+        // plain centerline stroke — and no fades at all.
+        expect(masked.length).toBeGreaterThan(0);
+        expect(plainDraws.length).toBeGreaterThan(0);
+        expect(anim.segments.every((s) => s.kind === 'draw')).toBe(true);
+
+        for (const { el, revealEl } of masked) {
+            // The visible element is the static render's filled ring.
+            expect(tag(el)).toBe('path');
+            expect(el.getAttribute('fill')!.startsWith('rgb(')).toBe(true);
+            expect(el.getAttribute('d')!.includes('Z')).toBe(true);
+            // ...exposed by a dash-revealed mask stroke.
+            expect(el.getAttribute('mask')!.startsWith('url(#')).toBe(true);
+            const maskId = (el.getAttribute('mask') ?? '').replace(/^url\(#/, '').replace(/\)$/, '');
+            const mask = anim.svg.querySelector(`mask#${maskId}`);
+            expect(mask).not.toBeNull();
+            expect(mask!.getAttribute('maskUnits')).toBe('userSpaceOnUse');
+            const reveal = revealEl!;
+            expect(mask!.firstElementChild).toBe(reveal);
+            expect(tag(reveal)).toBe('path');
+            expect(reveal.getAttribute('pathLength')).toBe('1');
+            expect(reveal.getAttribute('fill')).toBe('none');
+            expect(reveal.getAttribute('stroke')).toBe('white');
+            expect(parseFloat(reveal.getAttribute('stroke-width') ?? '')).toBeGreaterThan(0);
+            expect(reveal.style.strokeDasharray).toBe('1');
+            expect(reveal.style.strokeDashoffset).toBe('1');
+            expect(reveal.getAttribute('d')!.startsWith('M')).toBe(true);
+            expect(reveal.getAttribute('d')).not.toContain('Z');
+        }
+        for (const { el } of plainDraws) {
+            expect(tag(el)).toBe('path');
+            expect(el.getAttribute('pathLength')).toBe('1');
+            expect(el.getAttribute('fill')).toBe('none');
+            expect(el.getAttribute('stroke')).not.toBeNull();
+            expect(el.style.strokeDasharray).toBe('1');
+            expect(el.style.strokeDashoffset).toBe('1');
+            expect(el.getAttribute('d')!.startsWith('M')).toBe(true);
+            expect(el.getAttribute('d')).not.toContain('Z');
+        }
+    });
+});
+
+describe('StrokeAnimator', () => {
+    it('starts everything hidden, plays the whole timeline on the injected clock, and finishes', () => {
+        const sn = new SupernoteX(readFixture('turkish-a6x-20230015-handwriting-erase.note'));
+        const page = buildPageStrokeAnimation(sn, 1)!;
+        const clock = makeFakeClock();
+        const activePages: number[] = [];
+        let finished = 0;
+        const animator = new StrokeAnimator([page], {
+            onActivePage: (p) => activePages.push(p),
+            onFinish: () => { finished++; },
+        }, clock.options);
+
+        expect(animator.totalDuration).toBe(page.duration);
+        expect(animator.isPlaying).toBe(false);
+        expect(animator.currentTime).toBe(0);
+        for (const seg of page.segments) expect(progressOf(seg)).toBe(0);
+        expect(activePages).toEqual([]); // nothing has started; no page yet
+
+        animator.play();
+        expect(animator.isPlaying).toBe(true);
+        expect(clock.frameQueued()).toBe(true);
+        // The first animated page is reported as soon as playback starts.
+        expect(activePages).toEqual([0]);
+
+        clock.tick(100);
+        expect(animator.currentTime).toBe(100);
+        expect(finished).toBe(0);
+
+        // One big frame (a seek / fast-forward / coalesced background-tab
+        // rAF): everything lands at its end state in a single pass.
+        clock.tick(animator.totalDuration + 1000);
+        expect(animator.currentTime).toBe(animator.totalDuration);
+        expect(animator.isPlaying).toBe(false);
+        expect(animator.isFinished).toBe(true);
+        expect(finished).toBe(1);
+        expect(clock.frameQueued()).toBe(false);
+        for (const seg of page.segments) expect(progressOf(seg)).toBe(1);
+
+        // Playing again from the finished state restarts the whole run.
+        animator.play();
+        expect(animator.isPlaying).toBe(true);
+        expect(animator.currentTime).toBe(0);
+        for (const seg of page.segments) expect(progressOf(seg)).toBe(0);
+        animator.pause();
+    });
+
+    it('pausing stops the clock; resuming continues from the paused time', () => {
+        const sn = new SupernoteX(readFixture('turkish-a6x-20230015-handwriting-erase.note'));
+        const page = buildPageStrokeAnimation(sn, 1)!;
+        const clock = makeFakeClock();
+        const animator = new StrokeAnimator([page], {}, clock.options);
+
+        animator.play();
+        clock.tick(100);
+        expect(animator.currentTime).toBe(100);
+        animator.pause();
+        expect(clock.frameQueued()).toBe(false);
+
+        // No frame callback is pending, so advancing the clock does
+        // nothing while paused.
+        clock.tick(500);
+        expect(animator.currentTime).toBe(100);
+
+        animator.play();
+        clock.tick(50);
+        expect(animator.currentTime).toBe(150);
+        animator.pause();
+    });
+
+    it('speed multiplies real-time deltas (both faster and slower than 1×)', () => {
+        const sn = new SupernoteX(readFixture('turkish-a6x-20230015-handwriting-erase.note'));
+        const page = buildPageStrokeAnimation(sn, 1)!;
+        const clock = makeFakeClock();
+        const animator = new StrokeAnimator([page], {}, clock.options);
+
+        animator.play();
+        animator.speed = 2;
+        clock.tick(50);
+        expect(animator.currentTime).toBe(100);
+        animator.speed = 0.5;
+        clock.tick(50);
+        expect(animator.currentTime).toBe(125);
+        animator.pause();
+    });
+
+    it('seek applies every segment to its state at that instant — and seeking to the end does not claim "finished"', () => {
+        const sn = new SupernoteX(readFixture('turkish-a6x-20230015-handwriting-erase.note'));
+        const page = buildPageStrokeAnimation(sn, 1)!;
+        const clock = makeFakeClock();
+        let finished = 0;
+        const animator = new StrokeAnimator([page], { onFinish: () => { finished++; } }, clock.options);
+
+        const first = page.segments[0];
+        animator.seek(first.duration / 2);
+        expect(animator.currentTime).toBeCloseTo(first.duration / 2);
+        // A seek while not playing applies the in-flight segment partially
+        // and leaves everything after it untouched (still hidden).
+        expect(progressOf(first)).toBeCloseTo(0.5, 5);
+        expect(progressOf(page.segments[1])).toBe(0);
+        expect(finished).toBe(0);
+
+        animator.seek(animator.totalDuration);
+        expect(animator.isFinished).toBe(true);
+        expect(finished).toBe(0); // a seek lands the end state without firing onFinish
+        for (const seg of page.segments) expect(progressOf(seg)).toBe(1);
+
+        // reset() goes back to the blank page and stops.
+        animator.reset();
+        expect(animator.currentTime).toBe(0);
+        expect(animator.isPlaying).toBe(false);
+        for (const seg of page.segments) expect(progressOf(seg)).toBe(0);
+    });
+
+    it('stitches pages into one timeline in page order, skips null pages, and reports active page changes', () => {
+        const sn = new SupernoteX(readFixture('demo-a5x-20230015-1to10.note'));
+        const p1 = buildPageStrokeAnimation(sn, 1)!; // 2 strokes
+        const p3 = buildPageStrokeAnimation(sn, 3)!; // 1 stroke
+        expect(p1.segments).toHaveLength(2);
+        expect(p3.segments).toHaveLength(1);
+
+        const clock = makeFakeClock();
+        const activePages: number[] = [];
+        // Index 1 is a deliberately-null page: it must contribute nothing
+        // to the timeline and never be reported as active.
+        const animator = new StrokeAnimator([p1, null, p3], {
+            onActivePage: (p) => activePages.push(p),
+        }, clock.options);
+        expect(animator.totalDuration).toBe(p1.duration + p3.duration);
+
+        animator.play();
+        clock.tick(1);
+        expect(activePages).toEqual([0]);
+
+        // The page-3 stroke starts exactly where page 1's duration ends.
+        clock.tick(p1.duration + 1);
+        expect(activePages).toEqual([0, 2]);
+        expect(progressOf(p3.segments[0])).toBeGreaterThan(0);
+
+        clock.tick(animator.totalDuration + 1000);
+        expect(animator.isFinished).toBe(true);
+        expect(progressOf(p3.segments[0])).toBe(1);
+    });
+
+    it('reports the same active page across a page boundary gap without re-firing', () => {
+        const sn = new SupernoteX(readFixture('demo-a5x-20230015-1to10.note'));
+        const p1 = buildPageStrokeAnimation(sn, 1)!;
+        const clock = makeFakeClock();
+        const activePages: number[] = [];
+        const animator = new StrokeAnimator([p1], {
+            onActivePage: (p) => activePages.push(p),
+        }, clock.options);
+
+        animator.play();
+        clock.tick(1);
+        // Step through the whole page frame by frame: the page can only
+        // ever *change* to a different value, so the single page index is
+        // reported exactly once no matter how many frames pass.
+        for (let i = 0; i < 50; i++) clock.tick(10);
+        expect(activePages).toEqual([0]);
+        expect(activePages).toHaveLength(1);
+    });
+});

--- a/src/webcomponent/strokeAnimation.ts
+++ b/src/webcomponent/strokeAnimation.ts
@@ -1,0 +1,643 @@
+// Write-on stroke animation — the "Tom Riddle's diary / SwapNote" mode:
+// replay a note's handwriting as if someone is writing it, stroke by stroke,
+// in the order the pen actually moved.
+//
+// Built entirely on the same vector-ink decode the vectorInk display setting
+// already uses (prepareVectorInkPages): strokes arrive in TOTALPATH record
+// order, which is the device's own write order, with each stroke's real
+// color, tool, and thickness. Each stroke becomes an SVG element laid over
+// the page's background-only raster (the ink layers stripped, the same way
+// the vector-ink render path strips them — see rasterize.worker.ts), and a
+// StrokeAnimator below walks the per-page timelines with a single
+// requestAnimationFrame clock:
+//   - centerline strokes: the classic SVG dash-reveal (pathLength="1" +
+//     animated stroke-dashoffset), duration proportional to the stroke's
+//     own length so short ticks and long flourishes both read as writing
+//   - pressure-varying contour fills: a dash-revealed *mask* stroke that
+//     follows the record's own centerline, so the filled outline (the
+//     device's real pressure-varying shape) is exposed as the pen moves —
+//     falling back to a short fade-in only when the record carries no
+//     centerline to trace at all
+//   - filled Heading rects: a short fade-in at their write position
+//
+// Z-order vs. time order: the DOM (what covers what) follows
+// supernote-typescript's buildVectorInkPrimitives grouping — rects first,
+// highlighter passes second, the rest of the ink last, each group in write
+// order — so the *finished* page looks exactly like the static vector
+// render (a Heading's background behind its label, a highlighter wash
+// beneath the ink it crosses). The *timeline* (when each element reveals)
+// is pure write order instead, which is the whole point of the effect.
+//
+// The classification below deliberately mirrors buildVectorInkPrimitives'
+// logic stroke-by-stroke (it isn't imported: the submodule only exports it
+// pre-flattened, and this module needs each stroke's own index to keep the
+// two orders separate). If that function's rules change, change these too.
+//
+// Prototype-scope, deliberately: no per-stroke pressure/velocity
+// modulation (TOTALPATH stores no timestamps, only order), no audio, no
+// export. See SupernoteViewerElement.ts's animation-mode integration for
+// the toolbar controls (play/pause, replay, speed).
+import { SupernoteX, prepareVectorInkPages } from 'supernote-typescript';
+import type { IStroke, IStrokePoint, StrokeStyle } from 'supernote-typescript';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+// Pacing, in real milliseconds and page pixels (native note coordinates —
+// a page is 1404–1920px wide, and a typical handwriting stroke measures
+// 50–300px of that). Calibrated against the fixture corpus (median stroke
+// ~90–110px): at the default speed a median stroke takes ~400ms, which
+// reads as deliberate handwriting rather than a dash, and a dense page
+// (10k–20k total stroke pixels) plays in roughly 40s–2min at 1×.
+export const WRITE_SPEED_PX_PER_SEC = 250;
+// Dots and flicks mustn't vanish in a single frame; long flourishes
+// (measured up to ~2500px) mustn't hog a minute by themselves.
+const MIN_STROKE_MS = 80;
+const MAX_STROKE_MS = 1200;
+// The pen lifts between strokes. A flat gap (write order has no timing
+// data to vary it by) is enough to keep strokes from blurring into each
+// other; it lands between strokes, not at the start of the page.
+const STROKE_GAP_MS = 30;
+const CONTOUR_FADE_MS = 250;
+const RECT_FADE_MS = 350;
+
+// Rings shorter than this enclose no area (same constant and reasoning as
+// MIN_CONTOUR_RING_POINTS in the submodule's vector-ink.ts).
+const MIN_CONTOUR_RING_POINTS = 3;
+
+// Grey level of an `rgb(g,g,g)` ink color — every color parseStrokes
+// produces is a grey, so the red channel alone orders them (identical to
+// greyLevel in the submodule's vector-ink.ts, re-implemented here rather
+// than imported since it isn't part of the package's public API).
+function greyLevel(color: string): number {
+    return Number(/rgb\((\d+)/.exec(color)?.[1] ?? '0');
+}
+
+// Same threshold as the submodule's WHITE_INK_MIN_GREY: at or above this,
+// ink is the palette's white — a cover-up, never a highlighter pass.
+const WHITE_INK_MIN_GREY = 250;
+// Same as the submodule's SAME_GREY_TOLERANCE: how far apart two grey
+// levels must sit to count as different shades.
+const SAME_GREY_TOLERANCE = 16;
+
+interface StrokeBounds {
+    minX: number;
+    maxX: number;
+    minY: number;
+    maxY: number;
+}
+
+// A stroke's own extent from its sampled centerline or, for a record with
+// none, its rendered outline — mirrors strokeBounds in the submodule.
+function strokeBounds(stroke: IStroke): StrokeBounds | null {
+    const points = stroke.points.length > 0 ? stroke.points : (stroke.contour ?? []).flat();
+    if (points.length === 0) return null;
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minY = Infinity;
+    let maxY = -Infinity;
+    for (const point of points) {
+        if (point.x < minX) minX = point.x;
+        if (point.x > maxX) maxX = point.x;
+        if (point.y < minY) minY = point.y;
+        if (point.y > maxY) maxY = point.y;
+    }
+    return { minX, maxX, minY, maxY };
+}
+
+// Mirrors boundsOverlap in the submodule.
+function boundsOverlap(a: StrokeBounds, b: StrokeBounds): boolean {
+    return a.minX <= b.maxX && b.minX <= a.maxX && a.minY <= b.maxY && b.minY <= a.maxY;
+}
+
+// Mirrors isHighlighterPass in the submodule (same darkness rule, same
+// "only ink recorded before this stroke counts"): a marker stroke that
+// crosses ink at least as dark as itself is a wash the device paints
+// *beneath* that ink, and needs to sit beneath it here too — in the DOM,
+// not in the timeline (it still reveals at its own write position).
+function isHighlighterPass(
+    index: number,
+    boundsList: (StrokeBounds | null)[],
+    greys: number[],
+    drawable: boolean[],
+): boolean {
+    const bounds = boundsList[index];
+    if (!bounds) return false;
+    const grey = greys[index];
+    if (grey >= WHITE_INK_MIN_GREY) return false;
+    for (let i = 0; i < index; i++) {
+        const other = boundsList[i];
+        if (!other || !drawable[i]) continue;
+        if (greys[i] + SAME_GREY_TOLERANCE >= grey) continue;
+        if (boundsOverlap(bounds, other)) return true;
+    }
+    return false;
+}
+
+function polylineLength(points: IStrokePoint[]): number {
+    let total = 0;
+    for (let i = 1; i < points.length; i++) total += Math.hypot(points[i].x - points[i - 1].x, points[i].y - points[i - 1].y);
+    return total;
+}
+
+// Mask ids must be unique *document-wide* (inline SVGs share the document's
+// id namespace, and a note's pages all live in one document).
+let contourMaskCounter = 0;
+
+// Twice the largest distance from any ring point to the nearest centerline
+// point, plus a little slack — the width a mask stroke needs so that
+// sweeping it along the centerline fully exposes the ring everywhere, its
+// terminal caps included. The centerline is subsampled to at most
+// MAX_MASK_SAMPLES points first: the distance to the nearest *sample* is
+// always at least the distance to the nearest true point, so the result is
+// a safe overestimate (a slightly fatter mask) at O(rings × samples) cost.
+const MAX_MASK_SAMPLES = 500;
+function maskWidthForRings(rings: IStrokePoint[][], centerline: IStrokePoint[]): number {
+    const step = Math.max(1, Math.ceil(centerline.length / MAX_MASK_SAMPLES));
+    const samples: IStrokePoint[] = [];
+    for (let i = 0; i < centerline.length; i += step) samples.push(centerline[i]);
+    let maxSq = 0;
+    for (const ring of rings) {
+        for (const point of ring) {
+            // Width is derived from this point's *nearest* sampled
+            // centerline point, then maximized across the ring. Taking the
+            // farthest point instead would make a long stroke's mask span
+            // most of the page, exposing unrelated-looking ink as soon as
+            // even a tiny dash segment became visible.
+            let nearestSq = Infinity;
+            for (const sample of samples) {
+                const dx = point.x - sample.x;
+                const dy = point.y - sample.y;
+                nearestSq = Math.min(nearestSq, dx * dx + dy * dy);
+            }
+            maxSq = Math.max(maxSq, nearestSq);
+        }
+    }
+    return Math.sqrt(maxSq) * 2 + 2;
+}
+
+// `M x,y L x,y ...` — the same path data renderPrimitiveToSvg in the
+// submodule's svg.ts emits for a strokedPath, so the animated strokes are
+// geometrically identical to the static vector-ink render.
+function pointsToPath(points: IStrokePoint[]): string {
+    return points.map((point, i) => `${i === 0 ? 'M' : 'L'}${point.x.toFixed(2)},${point.y.toFixed(2)}`).join(' ');
+}
+
+// One closed ring per contour polygon, closed with Z — same as
+// renderPrimitiveToSvg's filledPath branch.
+function ringsToPath(rings: IStrokePoint[][]): string {
+    return rings
+        .map((ring) => ring.map((point, i) => `${i === 0 ? 'M' : 'L'}${point.x.toFixed(2)},${point.y.toFixed(2)}`).join(' ') + ' Z')
+        .join(' ');
+}
+
+// Hatch pattern ids must be unique *document-wide* (inline SVGs share the
+// document's id namespace, and a note's pages all live in one document),
+// so these come from a module-level counter, not a fixed string.
+let hatchPatternCounter = 0;
+
+// A 'rect' stroke with fill: 'hatch' — Heading backgrounds the device
+// renders as diagonal hatching, not a solid block (see the submodule's
+// buildHatchPatternDef for the source of these exact values). Returns the
+// pattern's unique id so the rect can reference it with fill: url(#id).
+function buildHatchPattern(color: string): { defs: SVGElement; id: string } {
+    const id = `supernote-viewer-hatch-${++hatchPatternCounter}`;
+    const pattern = document.createElementNS(SVG_NS, 'pattern');
+    pattern.setAttribute('id', id);
+    pattern.setAttribute('patternUnits', 'userSpaceOnUse');
+    pattern.setAttribute('width', '10');
+    pattern.setAttribute('height', '10');
+    pattern.setAttribute('patternTransform', 'rotate(45)');
+    const bg = document.createElementNS(SVG_NS, 'rect');
+    bg.setAttribute('width', '10');
+    bg.setAttribute('height', '10');
+    bg.setAttribute('fill', 'white');
+    pattern.appendChild(bg);
+    const line = document.createElementNS(SVG_NS, 'line');
+    line.setAttribute('x1', '0');
+    line.setAttribute('y1', '0');
+    line.setAttribute('x2', '0');
+    line.setAttribute('y2', '10');
+    line.setAttribute('stroke', color);
+    line.setAttribute('stroke-width', '5');
+    pattern.appendChild(line);
+    const defs = document.createElementNS(SVG_NS, 'defs');
+    defs.appendChild(pattern);
+    return { defs, id };
+}
+
+// How this stroke reveals. 'draw' = dash-reveal along a path — its own for
+// a centerline stroke, the mask's for a masked contour (see
+// StrokeSegment.revealEl); 'fade' = opacity-in (Heading rects and
+// centerline-less contour silhouettes).
+export type StrokeSegmentKind = 'draw' | 'fade';
+
+export interface StrokeSegment {
+    el: SVGElement;
+    // The element the animator actually drives, when that isn't the
+    // visible one: a masked contour's dash reveal lives on its mask's
+    // stroke, while el is the filled path that gets exposed by it.
+    revealEl?: SVGElement;
+    kind: StrokeSegmentKind;
+    // Page-local timeline offsets — the StrokeAnimator below stitches
+    // pages' segments into one global timeline in page order.
+    start: number;
+    duration: number;
+}
+
+export interface PageStrokeAnimation {
+    pageNumber: number;
+    // One <svg> per page, viewBox in native page pixels. Sized by the
+    // host (position: absolute, inset: 0, 100%/100% over the page image —
+    // see the .stroke-animation-svg rule in SupernoteViewerElement.ts);
+    // the container's aspect ratio matches the viewBox, so the default
+    // preserveAspectRatio is an exact fit.
+    svg: SVGSVGElement;
+    segments: StrokeSegment[];
+    // Sum of this page's own segment times + gaps.
+    duration: number;
+}
+
+/**
+ * Decodes `pageNumber`'s ink and builds its write-on overlay: an SVG with
+ * one element per surviving stroke, all hidden, plus the per-stroke
+ * timeline. Returns `null` when the page has no decodable strokes
+ * (prepareVectorInkPages's useVectorInk says the raster ink should stay as
+ * the page's ink source — there's nothing to animate there).
+ */
+export function buildPageStrokeAnimation(sn: SupernoteX, pageNumber: number): PageStrokeAnimation | null {
+    const vip = prepareVectorInkPages(sn, [pageNumber], 1)[0];
+    if (!vip || !vip.useVectorInk) return null;
+
+    const svg = document.createElementNS(SVG_NS, 'svg');
+    svg.setAttribute('viewBox', `0 0 ${sn.pageWidth} ${sn.pageHeight}`);
+    svg.classList.add('stroke-animation-svg');
+
+    // DOM order — the submodule's grouping, each group in write order:
+    // rects (Heading/badge backgrounds) first so the ink written on top of
+    // them stays visible even though the rect's own record often comes
+    // after it; highlighter passes next, beneath the rest of the ink; the
+    // remaining ink last.
+    const rects: { el: SVGElement; revealEl?: SVGElement; kind: StrokeSegmentKind; duration: number }[] = [];
+    const highlighters: { el: SVGElement; revealEl?: SVGElement; kind: StrokeSegmentKind; duration: number }[] = [];
+    const ink: { el: SVGElement; revealEl?: SVGElement; kind: StrokeSegmentKind; duration: number }[] = [];
+    // Write order (the strokes' own array order) → element, for the
+    // timeline below.
+    const byWriteOrder = new Map<number, { el: SVGElement; revealEl?: SVGElement; kind: StrokeSegmentKind; duration: number }>();
+
+    const boundsList = vip.strokes.map(strokeBounds);
+    const greys = vip.strokes.map((_, i) => {
+        const style = vip.styles[i];
+        return style && style.shape !== 'skip' ? greyLevel(style.color) : 0;
+    });
+    const drawable = vip.strokes.map((_, i) => vip.styles[i]?.shape === 'path');
+
+    vip.strokes.forEach((stroke, i) => {
+        const style: StrokeStyle | undefined = vip.styles[i];
+        if (!style || style.shape === 'skip') return;
+
+        if (style.shape === 'rect') {
+            // Same guard as buildVectorInkPrimitives: two points are
+            // opposite corners, and a rect missing either is nothing.
+            if (stroke.points.length < 2) return;
+            const [p0, p1] = stroke.points;
+            const rect = document.createElementNS(SVG_NS, 'rect');
+            rect.setAttribute('x', String(Math.min(p0.x, p1.x).toFixed(2)));
+            rect.setAttribute('y', String(Math.min(p0.y, p1.y).toFixed(2)));
+            rect.setAttribute('width', String(Math.abs(p1.x - p0.x).toFixed(2)));
+            rect.setAttribute('height', String(Math.abs(p1.y - p0.y).toFixed(2)));
+            if (style.fill === 'hatch') {
+                const { defs, id } = buildHatchPattern(style.color);
+                svg.appendChild(defs);
+                rect.setAttribute('fill', `url(#${id})`);
+            } else {
+                rect.setAttribute('fill', style.color);
+            }
+            const entry = { el: rect, kind: 'fade' as const, duration: RECT_FADE_MS };
+            rects.push(entry);
+            byWriteOrder.set(i, entry);
+            return;
+        }
+
+        const rings = (stroke.contour ?? []).filter((ring) => ring.length >= MIN_CONTOUR_RING_POINTS);
+        if (rings.length > 0) {
+            // The device's own rendered outline (pressure-varying width) —
+            // a filled region, exposed as the pen moves when the record
+            // carries a centerline to trace (masked branch below), or
+            // faded in at its write position otherwise.
+            const path = document.createElementNS(SVG_NS, 'path');
+            path.setAttribute('d', ringsToPath(rings));
+            path.setAttribute('fill', style.color);
+            const bucket =
+                style.tier === 'marker' && isHighlighterPass(i, boundsList, greys, drawable) ? highlighters : ink;
+            if (stroke.points.length >= 2) {
+                // The record carries its own centerline: instead of fading
+                // the filled ring in, expose it with a dash-revealed mask
+                // stroke that follows that centerline — the ink appears to
+                // be *written* with the device's own pressure-varying
+                // outline, and once fully revealed the element is exactly
+                // the static render's filled path. The mask stroke is what
+                // the animator drives (StrokeSegment.revealEl); the visible
+                // path itself never moves.
+                const maskId = `supernote-viewer-anim-mask-${++contourMaskCounter}`;
+                const mask = document.createElementNS(SVG_NS, 'mask');
+                mask.setAttribute('id', maskId);
+                // The default mask region is a percentage of the
+                // *referencing* element's bbox — a thin ring's box would
+                // clip the mask stroke's round caps, so use a full-page
+                // user-space region (browsers rasterize only the part the
+                // element actually draws).
+                mask.setAttribute('maskUnits', 'userSpaceOnUse');
+                mask.setAttribute('x', '0');
+                mask.setAttribute('y', '0');
+                mask.setAttribute('width', String(sn.pageWidth));
+                mask.setAttribute('height', String(sn.pageHeight));
+                const reveal = document.createElementNS(SVG_NS, 'path');
+                reveal.setAttribute('d', pointsToPath(stroke.points));
+                reveal.setAttribute('fill', 'none');
+                reveal.setAttribute('stroke', 'white');
+                reveal.setAttribute('stroke-width', String(maskWidthForRings(rings, stroke.points).toFixed(2)));
+                reveal.setAttribute('stroke-linecap', 'round');
+                reveal.setAttribute('stroke-linejoin', 'round');
+                // Same pathLength=1 normalization as the plain draw path
+                // below: one dash value reveals the whole trace without a
+                // per-element getTotalLength() measurement.
+                reveal.setAttribute('pathLength', '1');
+                reveal.style.strokeDasharray = '1';
+                reveal.style.strokeDashoffset = '1';
+                mask.appendChild(reveal);
+                svg.appendChild(mask);
+                path.setAttribute('mask', `url(#${maskId})`);
+                const length = polylineLength(stroke.points);
+                const duration = Math.min(MAX_STROKE_MS, Math.max(MIN_STROKE_MS, (length / WRITE_SPEED_PX_PER_SEC) * 1000));
+                const entry = { el: path, revealEl: reveal, kind: 'draw' as const, duration };
+                bucket.push(entry);
+                byWriteOrder.set(i, entry);
+                return;
+            }
+            // No centerline to trace (e.g. a sticker plugin's silhouette
+            // outline) — fall back to a short fade at the write position.
+            const entry = { el: path, kind: 'fade' as const, duration: CONTOUR_FADE_MS };
+            bucket.push(entry);
+            byWriteOrder.set(i, entry);
+            return;
+        }
+
+        if (stroke.points.length === 0) return;
+        const path = document.createElementNS(SVG_NS, 'path');
+        path.setAttribute('d', pointsToPath(stroke.points));
+        path.setAttribute('fill', 'none');
+        path.setAttribute('stroke', style.color);
+        path.setAttribute('stroke-width', String(style.width));
+        path.setAttribute('stroke-linecap', 'round');
+        path.setAttribute('stroke-linejoin', 'round');
+        // Normalize every path's length to 1 so one dash value
+        // (stroke-dasharray: 1, stroke-dashoffset: 1 → 0) reveals any
+        // stroke with no per-element getTotalLength() measurement —
+        // and works in test DOMs that don't implement it at all.
+        path.setAttribute('pathLength', '1');
+        path.style.strokeDasharray = '1';
+        path.style.strokeDashoffset = '1';
+        const length = polylineLength(stroke.points);
+        const duration = Math.min(MAX_STROKE_MS, Math.max(MIN_STROKE_MS, (length / WRITE_SPEED_PX_PER_SEC) * 1000));
+        const entry = { el: path, kind: 'draw' as const, duration };
+        (style.tier === 'marker' && isHighlighterPass(i, boundsList, greys, drawable) ? highlighters : ink).push(entry);
+        byWriteOrder.set(i, entry);
+    });
+
+    if (byWriteOrder.size === 0) return null;
+
+    for (const entry of [...rects, ...highlighters, ...ink]) svg.appendChild(entry.el);
+
+    // Timeline: pure write order (the strokes' own array order — Maps
+    // iterate in insertion order, so the index-keyed map above is the
+    // write-ordered list), each element revealing at the moment the pen
+    // made it.
+    const segments: StrokeSegment[] = [];
+    let t = 0;
+    for (const entry of byWriteOrder.values()) {
+        if (t > 0) t += STROKE_GAP_MS;
+        segments.push({ el: entry.el, revealEl: entry.revealEl, kind: entry.kind, start: t, duration: entry.duration });
+        t += entry.duration;
+    }
+
+    return { pageNumber, svg, segments, duration: t };
+}
+
+interface AnimatorEntry {
+    el: SVGElement;
+    revealEl?: SVGElement;
+    kind: StrokeSegmentKind;
+    page: number;
+    start: number; // global (across all pages)
+    duration: number;
+    lastApplied: number;
+}
+
+export interface StrokeAnimatorCallbacks {
+    // The page (index into the constructor's `pages`) the pen is currently
+    // on, fired once per change (the first call reports the first page as
+    // soon as playback starts) — for auto-scrolling the active page into
+    // view.
+    onActivePage?: (page: number) => void;
+    // Current global time (ms), once per animation frame — for a
+    // time-remaining label.
+    onTime?: (timeMs: number) => void;
+    onFinish?: () => void;
+}
+
+export interface StrokeAnimatorClock {
+    now?: () => number;
+    requestFrame?: (cb: (t: number) => void) => number;
+    cancelFrame?: (id: number) => void;
+}
+
+// One global clock over every page's segments, in page order. Deliberately
+// tiny: a monotonically-advancing pointer (strokes never overlap, so a
+// frame only ever touches the one in-flight segment plus whatever a large
+// delta — a seek, a fast-forward, a background tab's coalesced rAF — let
+// finish at once), and no per-segment timers.
+export class StrokeAnimator {
+    readonly totalDuration: number;
+    speed = 1;
+
+    private entries: AnimatorEntry[] = [];
+    private pointer = 0;
+    private time = 0;
+    private playing = false;
+    private lastActivePage = -1;
+    private rafId: number | undefined;
+    private lastNow = 0;
+    private callbacks: StrokeAnimatorCallbacks;
+    private clock: { now: () => number; frame: (cb: (t: number) => void) => number; unframe: (id: number) => void };
+
+    constructor(pages: (PageStrokeAnimation | null)[], callbacks: StrokeAnimatorCallbacks = {}, clock: StrokeAnimatorClock = {}) {
+        this.callbacks = callbacks;
+        this.clock = {
+            now: clock.now ?? (() => performance.now()),
+            frame: clock.requestFrame ?? ((cb) => window.requestAnimationFrame(cb)),
+            unframe: clock.cancelFrame ?? ((id) => window.cancelAnimationFrame(id)),
+        };
+
+        let offset = 0;
+        pages.forEach((page, pageIndex) => {
+            if (!page) return;
+            for (const segment of page.segments) {
+                this.entries.push({
+                    el: segment.el,
+                    revealEl: segment.revealEl,
+                    kind: segment.kind,
+                    page: pageIndex,
+                    start: offset + segment.start,
+                    duration: segment.duration,
+                    lastApplied: -1,
+                });
+            }
+            offset += page.duration;
+        });
+        this.totalDuration = offset;
+
+        // Everything starts hidden, regardless of what the host may have
+        // left the elements at (lastApplied -1 forces the initial apply).
+        for (const entry of this.entries) this.apply(entry, 0);
+    }
+
+    get currentTime(): number {
+        return this.time;
+    }
+
+    get isPlaying(): boolean {
+        return this.playing;
+    }
+
+    get isFinished(): boolean {
+        return this.entries.length > 0 && this.time >= this.totalDuration;
+    }
+
+    play(): void {
+        if (this.playing || this.entries.length === 0) return;
+        if (this.time >= this.totalDuration) this.seek(0);
+        this.playing = true;
+        this.lastNow = this.clock.now();
+        // Report the active page right away (a host auto-scrolls to the
+        // first page the moment the pen starts, not on the first frame).
+        // The replay-from-end case's seek(0) above already reported its
+        // page, so this only fires when the page actually changed.
+        this.updateState(this.time, false);
+        this.rafId = this.clock.frame(this.frame);
+    }
+
+    pause(): void {
+        if (!this.playing) return;
+        this.playing = false;
+        if (this.rafId !== undefined) this.clock.unframe(this.rafId);
+    }
+
+    toggle(): void {
+        if (this.playing) this.pause();
+        else this.play();
+    }
+
+    // Jumps to `time` (clamped), applying every segment to its state at
+    // that instant — including the ones after it, which must go back to
+    // hidden on a backward seek. O(n) attribute writes on a rare,
+    // deliberate action, which is fine.
+    seek(time: number): void {
+        const clamped = Math.max(0, Math.min(time, this.totalDuration));
+        let pointer = this.entries.length;
+        for (let i = 0; i < this.entries.length; i++) {
+            const entry = this.entries[i];
+            const progress =
+                clamped >= entry.start + entry.duration
+                    ? 1
+                    : clamped <= entry.start
+                        ? 0
+                        : (clamped - entry.start) / entry.duration;
+            this.apply(entry, progress);
+            // Strokes never overlap, so at most one is partially in flight;
+            // the first such segment is where the frame walk resumes.
+            if (pointer === this.entries.length && progress < 1) pointer = i;
+        }
+        this.pointer = pointer;
+        this.lastNow = this.clock.now();
+        this.updateState(clamped, false);
+    }
+
+    reset(): void {
+        this.pause();
+        this.seek(0);
+    }
+
+    destroy(): void {
+        this.pause();
+    }
+
+    private frame = (now: number): void => {
+        if (!this.playing) return;
+        const delta = (now - this.lastNow) * this.speed;
+        this.lastNow = now;
+        const time = Math.min(this.time + delta, this.totalDuration);
+        // updateState() owns the end-of-run transition: it stops playback
+        // and fires onFinish when the timeline is exhausted, so this frame
+        // handler only decides whether there is a next frame to ask for.
+        this.updateState(time, true);
+        if (this.playing) this.rafId = this.clock.frame(this.frame);
+    };
+
+    // Advances the pointer over everything finished by `time`, applies the
+    // one in-flight segment, and fires the page/time callbacks. `playing`
+    // only decides whether the end-of-run transition (stop + onFinish) can
+    // happen this pass (a seek to the end lands every segment at 1 without
+    // claiming "finished" to the UI).
+    private updateState(time: number, playing: boolean): void {
+        this.time = time;
+        for (let i = this.pointer; i < this.entries.length; i++) {
+            const entry = this.entries[i];
+            if (entry.start >= time) break;
+            const progress = Math.min(1, (time - entry.start) / entry.duration);
+            this.apply(entry, progress);
+            // A still-in-flight stroke keeps the pointer on itself so the
+            // next frame re-applies it at its new progress; only finished
+            // strokes are left behind, never touched again.
+            if (progress < 1) {
+                this.pointer = i;
+                break;
+            }
+            this.pointer = i + 1;
+        }
+
+        // The pen is "on" the page of the most recent stroke that has
+        // started — the in-flight stroke itself (sitting at `pointer`) as
+        // well as the last finished one (a stroke finishing mid-gap keeps
+        // its page active until the next one begins). Scanning from
+        // `pointer` down covers both, and entries before the pointer are
+        // finished, so one of them always starts at or before `time`
+        // (clamped: `pointer` can be one past the end once everything is
+        // finished).
+        let active: number | null = null;
+        for (let i = Math.min(this.pointer, this.entries.length - 1); i >= 0; i--) {
+            if (this.entries[i].start <= time) {
+                active = this.entries[i].page;
+                break;
+            }
+        }
+        if (active === null) active = this.entries.length > 0 ? this.entries[0].page : -1;
+        if (active !== this.lastActivePage) {
+            this.lastActivePage = active;
+            if (active >= 0) this.callbacks.onActivePage?.(active);
+        }
+
+        this.callbacks.onTime?.(time);
+        if (playing && time >= this.totalDuration) {
+            this.playing = false;
+            this.callbacks.onFinish?.();
+        }
+    }
+
+    private apply(entry: AnimatorEntry, progress: number): void {
+        if (progress === entry.lastApplied) return;
+        entry.lastApplied = progress;
+        const el = entry.revealEl ?? entry.el;
+        if (entry.kind === 'draw') el.style.strokeDashoffset = String(1 - progress);
+        else el.style.opacity = String(progress);
+    }
+}

--- a/src/webcomponent/strokeAnimation.ts
+++ b/src/webcomponent/strokeAnimation.ts
@@ -13,11 +13,10 @@
 //   - centerline strokes: the classic SVG dash-reveal (pathLength="1" +
 //     animated stroke-dashoffset), duration proportional to the stroke's
 //     own length so short ticks and long flourishes both read as writing
-//   - pressure-varying contour fills: a dash-revealed *mask* stroke that
-//     follows the record's own centerline, so the filled outline (the
-//     device's real pressure-varying shape) is exposed as the pen moves —
-//     falling back to a short fade-in only when the record carries no
-//     centerline to trace at all
+//   - pressure-varying contour fills: a cheap dashed centerline preview
+//     while writing, swapped for the device's exact filled contour when the
+//     stroke finishes — avoiding per-frame SVG mask rasterization; falling
+//     back to a short fade-in only with no centerline to trace at all
 //   - filled Heading rects: a short fade-in at their write position
 //
 // Z-order vs. time order: the DOM (what covers what) follows
@@ -59,6 +58,10 @@ const MAX_STROKE_MS = 1200;
 const STROKE_GAP_MS = 30;
 const CONTOUR_FADE_MS = 250;
 const RECT_FADE_MS = 350;
+// SVG stroke-dashoffset changes are paint work, not compositor-only work in
+// Chrome. Thirty visual updates per second remain smooth for handwriting,
+// including at the default 4× speed, and substantially reduce raster load.
+const MAX_ANIMATION_FPS = 30;
 
 // Rings shorter than this enclose no area (same constant and reasoning as
 // MIN_CONTOUR_RING_POINTS in the submodule's vector-ink.ts).
@@ -139,42 +142,6 @@ function polylineLength(points: IStrokePoint[]): number {
     return total;
 }
 
-// Mask ids must be unique *document-wide* (inline SVGs share the document's
-// id namespace, and a note's pages all live in one document).
-let contourMaskCounter = 0;
-
-// Twice the largest distance from any ring point to the nearest centerline
-// point, plus a little slack — the width a mask stroke needs so that
-// sweeping it along the centerline fully exposes the ring everywhere, its
-// terminal caps included. The centerline is subsampled to at most
-// MAX_MASK_SAMPLES points first: the distance to the nearest *sample* is
-// always at least the distance to the nearest true point, so the result is
-// a safe overestimate (a slightly fatter mask) at O(rings × samples) cost.
-const MAX_MASK_SAMPLES = 500;
-function maskWidthForRings(rings: IStrokePoint[][], centerline: IStrokePoint[]): number {
-    const step = Math.max(1, Math.ceil(centerline.length / MAX_MASK_SAMPLES));
-    const samples: IStrokePoint[] = [];
-    for (let i = 0; i < centerline.length; i += step) samples.push(centerline[i]);
-    let maxSq = 0;
-    for (const ring of rings) {
-        for (const point of ring) {
-            // Width is derived from this point's *nearest* sampled
-            // centerline point, then maximized across the ring. Taking the
-            // farthest point instead would make a long stroke's mask span
-            // most of the page, exposing unrelated-looking ink as soon as
-            // even a tiny dash segment became visible.
-            let nearestSq = Infinity;
-            for (const sample of samples) {
-                const dx = point.x - sample.x;
-                const dy = point.y - sample.y;
-                nearestSq = Math.min(nearestSq, dx * dx + dy * dy);
-            }
-            maxSq = Math.max(maxSq, nearestSq);
-        }
-    }
-    return Math.sqrt(maxSq) * 2 + 2;
-}
-
 // `M x,y L x,y ...` — the same path data renderPrimitiveToSvg in the
 // submodule's svg.ts emits for a strokedPath, so the animated strokes are
 // geometrically identical to the static vector-ink render.
@@ -226,17 +193,18 @@ function buildHatchPattern(color: string): { defs: SVGElement; id: string } {
 }
 
 // How this stroke reveals. 'draw' = dash-reveal along a path — its own for
-// a centerline stroke, the mask's for a masked contour (see
+// a centerline stroke, or a temporary centerline preview for a contour (see
 // StrokeSegment.revealEl); 'fade' = opacity-in (Heading rects and
 // centerline-less contour silhouettes).
 export type StrokeSegmentKind = 'draw' | 'fade';
 
 export interface StrokeSegment {
     el: SVGElement;
-    // The element the animator actually drives, when that isn't the
-    // visible one: a masked contour's dash reveal lives on its mask's
-    // stroke, while el is the filled path that gets exposed by it.
+    // The element the animator actually drives when this is a contour's
+    // temporary centerline preview. `el` is then the exact final contour.
     revealEl?: SVGElement;
+    // On a contour, hide the preview and reveal `el` once fully drawn.
+    swapOnComplete?: boolean;
     kind: StrokeSegmentKind;
     // Page-local timeline offsets — the StrokeAnimator below stitches
     // pages' segments into one global timeline in page order.
@@ -277,12 +245,19 @@ export function buildPageStrokeAnimation(sn: SupernoteX, pageNumber: number): Pa
     // them stays visible even though the rect's own record often comes
     // after it; highlighter passes next, beneath the rest of the ink; the
     // remaining ink last.
-    const rects: { el: SVGElement; revealEl?: SVGElement; kind: StrokeSegmentKind; duration: number }[] = [];
-    const highlighters: { el: SVGElement; revealEl?: SVGElement; kind: StrokeSegmentKind; duration: number }[] = [];
-    const ink: { el: SVGElement; revealEl?: SVGElement; kind: StrokeSegmentKind; duration: number }[] = [];
+    type BuildEntry = {
+        el: SVGElement;
+        revealEl?: SVGElement;
+        swapOnComplete?: boolean;
+        kind: StrokeSegmentKind;
+        duration: number;
+    };
+    const rects: BuildEntry[] = [];
+    const highlighters: BuildEntry[] = [];
+    const ink: BuildEntry[] = [];
     // Write order (the strokes' own array order) → element, for the
     // timeline below.
-    const byWriteOrder = new Map<number, { el: SVGElement; revealEl?: SVGElement; kind: StrokeSegmentKind; duration: number }>();
+    const byWriteOrder = new Map<number, BuildEntry>();
 
     const boundsList = vip.strokes.map(strokeBounds);
     const greys = vip.strokes.map((_, i) => {
@@ -320,56 +295,35 @@ export function buildPageStrokeAnimation(sn: SupernoteX, pageNumber: number): Pa
 
         const rings = (stroke.contour ?? []).filter((ring) => ring.length >= MIN_CONTOUR_RING_POINTS);
         if (rings.length > 0) {
-            // The device's own rendered outline (pressure-varying width) —
-            // a filled region, exposed as the pen moves when the record
-            // carries a centerline to trace (masked branch below), or
-            // faded in at its write position otherwise.
+            // The device's own rendered outline (pressure-varying width).
+            // Repainting that fill through an SVG mask every frame is very
+            // expensive in Chromium. Instead, write a plain centerline
+            // preview and swap in this exact final contour at completion.
             const path = document.createElementNS(SVG_NS, 'path');
             path.setAttribute('d', ringsToPath(rings));
             path.setAttribute('fill', style.color);
             const bucket =
                 style.tier === 'marker' && isHighlighterPass(i, boundsList, greys, drawable) ? highlighters : ink;
             if (stroke.points.length >= 2) {
-                // The record carries its own centerline: instead of fading
-                // the filled ring in, expose it with a dash-revealed mask
-                // stroke that follows that centerline — the ink appears to
-                // be *written* with the device's own pressure-varying
-                // outline, and once fully revealed the element is exactly
-                // the static render's filled path. The mask stroke is what
-                // the animator drives (StrokeSegment.revealEl); the visible
-                // path itself never moves.
-                const maskId = `supernote-viewer-anim-mask-${++contourMaskCounter}`;
-                const mask = document.createElementNS(SVG_NS, 'mask');
-                mask.setAttribute('id', maskId);
-                // The default mask region is a percentage of the
-                // *referencing* element's bbox — a thin ring's box would
-                // clip the mask stroke's round caps, so use a full-page
-                // user-space region (browsers rasterize only the part the
-                // element actually draws).
-                mask.setAttribute('maskUnits', 'userSpaceOnUse');
-                mask.setAttribute('x', '0');
-                mask.setAttribute('y', '0');
-                mask.setAttribute('width', String(sn.pageWidth));
-                mask.setAttribute('height', String(sn.pageHeight));
                 const reveal = document.createElementNS(SVG_NS, 'path');
                 reveal.setAttribute('d', pointsToPath(stroke.points));
                 reveal.setAttribute('fill', 'none');
-                reveal.setAttribute('stroke', 'white');
-                reveal.setAttribute('stroke-width', String(maskWidthForRings(rings, stroke.points).toFixed(2)));
+                reveal.setAttribute('stroke', style.color);
+                reveal.setAttribute('stroke-width', String(style.width));
                 reveal.setAttribute('stroke-linecap', 'round');
                 reveal.setAttribute('stroke-linejoin', 'round');
-                // Same pathLength=1 normalization as the plain draw path
-                // below: one dash value reveals the whole trace without a
-                // per-element getTotalLength() measurement.
+                // Normalize every preview to length 1. This avoids an
+                // expensive getTotalLength() per stroke and works in test
+                // DOMs too.
                 reveal.setAttribute('pathLength', '1');
                 reveal.style.strokeDasharray = '1';
                 reveal.style.strokeDashoffset = '1';
-                mask.appendChild(reveal);
-                svg.appendChild(mask);
-                path.setAttribute('mask', `url(#${maskId})`);
+                // The animator keeps the final contour display:none until
+                // the preview reaches its end.
+                path.style.display = 'none';
                 const length = polylineLength(stroke.points);
                 const duration = Math.min(MAX_STROKE_MS, Math.max(MIN_STROKE_MS, (length / WRITE_SPEED_PX_PER_SEC) * 1000));
-                const entry = { el: path, revealEl: reveal, kind: 'draw' as const, duration };
+                const entry = { el: path, revealEl: reveal, swapOnComplete: true, kind: 'draw' as const, duration };
                 bucket.push(entry);
                 byWriteOrder.set(i, entry);
                 return;
@@ -406,7 +360,12 @@ export function buildPageStrokeAnimation(sn: SupernoteX, pageNumber: number): Pa
 
     if (byWriteOrder.size === 0) return null;
 
-    for (const entry of [...rects, ...highlighters, ...ink]) svg.appendChild(entry.el);
+    for (const entry of [...rects, ...highlighters, ...ink]) {
+        svg.appendChild(entry.el);
+        // A contour's final path is in the static z-order; its temporary
+        // centerline sits immediately above it until the swap completes.
+        if (entry.revealEl) svg.appendChild(entry.revealEl);
+    }
 
     // Timeline: pure write order (the strokes' own array order — Maps
     // iterate in insertion order, so the index-keyed map above is the
@@ -416,7 +375,14 @@ export function buildPageStrokeAnimation(sn: SupernoteX, pageNumber: number): Pa
     let t = 0;
     for (const entry of byWriteOrder.values()) {
         if (t > 0) t += STROKE_GAP_MS;
-        segments.push({ el: entry.el, revealEl: entry.revealEl, kind: entry.kind, start: t, duration: entry.duration });
+        segments.push({
+            el: entry.el,
+            revealEl: entry.revealEl,
+            swapOnComplete: entry.swapOnComplete,
+            kind: entry.kind,
+            start: t,
+            duration: entry.duration,
+        });
         t += entry.duration;
     }
 
@@ -426,6 +392,7 @@ export function buildPageStrokeAnimation(sn: SupernoteX, pageNumber: number): Pa
 interface AnimatorEntry {
     el: SVGElement;
     revealEl?: SVGElement;
+    swapOnComplete?: boolean;
     kind: StrokeSegmentKind;
     page: number;
     start: number; // global (across all pages)
@@ -467,6 +434,7 @@ export class StrokeAnimator {
     private lastActivePage = -1;
     private rafId: number | undefined;
     private lastNow = 0;
+    private lastVisualUpdateNow = 0;
     private callbacks: StrokeAnimatorCallbacks;
     private clock: { now: () => number; frame: (cb: (t: number) => void) => number; unframe: (id: number) => void };
 
@@ -485,6 +453,7 @@ export class StrokeAnimator {
                 this.entries.push({
                     el: segment.el,
                     revealEl: segment.revealEl,
+                    swapOnComplete: segment.swapOnComplete,
                     kind: segment.kind,
                     page: pageIndex,
                     start: offset + segment.start,
@@ -518,6 +487,7 @@ export class StrokeAnimator {
         if (this.time >= this.totalDuration) this.seek(0);
         this.playing = true;
         this.lastNow = this.clock.now();
+        this.lastVisualUpdateNow = this.lastNow;
         // Report the active page right away (a host auto-scrolls to the
         // first page the moment the pen starts, not on the first frame).
         // The replay-from-end case's seek(0) above already reported its
@@ -559,6 +529,7 @@ export class StrokeAnimator {
         }
         this.pointer = pointer;
         this.lastNow = this.clock.now();
+        this.lastVisualUpdateNow = this.lastNow;
         this.updateState(clamped, false);
     }
 
@@ -573,8 +544,13 @@ export class StrokeAnimator {
 
     private frame = (now: number): void => {
         if (!this.playing) return;
+        if (now - this.lastVisualUpdateNow < 1000 / MAX_ANIMATION_FPS) {
+            this.rafId = this.clock.frame(this.frame);
+            return;
+        }
         const delta = (now - this.lastNow) * this.speed;
         this.lastNow = now;
+        this.lastVisualUpdateNow = now;
         const time = Math.min(this.time + delta, this.totalDuration);
         // updateState() owns the end-of-run transition: it stops playback
         // and fires onFinish when the timeline is exhausted, so this frame
@@ -636,6 +612,17 @@ export class StrokeAnimator {
     private apply(entry: AnimatorEntry, progress: number): void {
         if (progress === entry.lastApplied) return;
         entry.lastApplied = progress;
+        if (entry.swapOnComplete) {
+            // The centerline is the only SVG geometry Chrome needs to
+            // repaint during a contour's animation. Once complete, replace
+            // it atomically with the original pressure-varying fill.
+            const reveal = entry.revealEl!;
+            const complete = progress >= 1;
+            entry.el.style.display = complete ? '' : 'none';
+            reveal.style.display = complete ? 'none' : '';
+            reveal.style.strokeDashoffset = String(1 - progress);
+            return;
+        }
         const el = entry.revealEl ?? entry.el;
         if (entry.kind === 'draw') el.style.strokeDashoffset = String(1 - progress);
         else el.style.opacity = String(progress);

--- a/webcomponent-usage.md
+++ b/webcomponent-usage.md
@@ -72,6 +72,13 @@ System Access API handle) rather than a fetchable URL, use the `noteData` proper
 
 `noteData` takes priority over `src` when both are set.
 
+To open a note blank and let the user start its write-on replay explicitly:
+
+```js
+viewer.presentation = 'write-on-paused';
+viewer.noteData = bytes;
+```
+
 ## API reference
 
 ### Attributes / properties
@@ -85,11 +92,12 @@ System Access API handle) rather than a fetchable URL, use the `noteData` proper
 | `dark` | tri-state attribute | Overrides this element's own default guess (the OS-level `prefers-color-scheme: dark` media feature) for its default colours (border/background/text) and `invert-dark`'s filter. **Not a plain boolean** - three distinct states: attribute absent entirely → follow the OS-level guess; present with any value other than the string `"false"` (including with no value at all) → force dark; present with value exactly `"false"` → force light. Getting this wrong (treating it as an OR with the OS guess rather than an override) is a real bug this project hit: on a system whose OS-level scheme is dark, a host actually rendering *light* still had its images inverted underneath it. Only needed if your page's actual dark/light state doesn't reliably track the OS setting - which is exactly why Obsidian's `SupernoteEmbed` always explicitly sets `"true"` or `"false"` (never just adds/removes the attribute) from Obsidian's own theme, rather than relying on the OS guess in either direction. Pure CSS attribute selector - no rebuild needed to toggle it. |
 | `bare` | boolean attribute | Drops this element's own border/background/rounded corners - pure CSS, takes effect immediately, no rebuild. For embedding inside a host page/component that already provides its own frame around it (this is what Obsidian's `SupernoteEmbed` sets, since its container already has a border). |
 | `.noteData` | property, `ArrayBuffer \| Uint8Array \| null` | Set the file's bytes directly. JS-only - there's no string form of this, so it can't be set as an HTML attribute (see the framework note below). |
+| `.presentation` | property, `'static' \| 'write-on-paused' \| 'write-on-playing'` | Chooses the page-image renderer. Default `'static'` lazily loads ordinary full-ink PNGs. `'write-on-paused'` opens background-only at `0:00`, with hidden SVG ink until Play; `'write-on-playing'` does the same setup and begins playback. Set it before `src`/`noteData` for the initial renderer or after load to switch. `single-page` deliberately remains static. |
 
 Setting `src`/`page`/`noteData`/`single-page`/`invert-dark` after the element is already showing a note
 tears down and rebuilds the whole thing from scratch (a fresh fetch if using `src`) - there's no in-place
-diffing. `dark` and `bare` are the exception: both are applied via plain CSS attribute selectors
-internally, so toggling either live just restyles the existing content, no rebuild.
+diffing. `presentation` is different: changing it transfers the existing page shells between the static
+and write-on renderers without reparsing the note. `dark` and `bare` are also live CSS-only changes.
 
 ### Methods
 

--- a/webcomponent-usage.md
+++ b/webcomponent-usage.md
@@ -37,6 +37,15 @@ npm run build:webcomponent   # writes dist/supernote-viewer.js
 Copy `dist/supernote-viewer.js` into your own project and load it as an ES module — it's only ever built as
 ESM, so this needs `type="module"` and needs to be served over http(s), not opened as a `file://` URL:
 
+For a local Chromium smoke test of the standalone component, run the following (once per machine, install
+Playwright's browser first with `npx playwright install chromium`):
+
+```
+npm run test:webcomponent:playwright
+```
+
+It builds the bundle, serves the demo and opens a real `.note` fixture in paused write-on mode.
+
 ```html
 <script type="module" src="/path/to/supernote-viewer.js"></script>
 ```
@@ -54,7 +63,7 @@ call.
 
 `:host` has no default height - without one set (inline style, a CSS rule, or a flex/grid parent that
 gives it one), the element collapses to whatever its content naturally takes up. See
-[`demo/index.html`](demo/index.html) for a complete working page (it sets `height: 80vh`).
+[`demo/index.html`](demo/index.html) for a complete working page (it uses a portrait page aspect ratio with a `100vh` minimum height).
 
 If you have the file's bytes already (a `<input type="file">` picker, a `fetch()` you made yourself, a File
 System Access API handle) rather than a fetchable URL, use the `noteData` property instead of `src`:


### PR DESCRIPTION
## Summary
- add explicit static, paused write-on, and playing write-on presentations to `<supernote-viewer>`
- render write-on notes from background-only pages with SVG ink in device write order
- replace per-frame masked contour reveals with cheap dashed centerline previews, swapping to the exact final pressure contour at stroke completion
- cap visual SVG updates at 30 FPS
- add a reusable Playwright standalone-viewer smoke test and make the demo tall enough for a portrait note page

## Validation
- `npm test` (238 tests)
- `npm run lint` (existing Atelier sentence-case warning only)
- `npm run test:webcomponent:playwright`

## Follow-up
- #241: lazy write-on page preparation
- #242: optional Playwright diagnostics