### PR TITLE
Match write-on ink colors in dark mode

### DIFF
--- a/scripts/test-webcomponent-playwright.mjs
+++ b/scripts/test-webcomponent-playwright.mjs
@@ -57,6 +57,10 @@ try {
     page.on('pageerror', (error) => pageErrors.push(error));
 
     await page.goto(`http://127.0.0.1:${address.port}/demo/`, { waitUntil: 'networkidle' });
+    await page.locator('supernote-viewer').evaluate((element) => {
+        element.setAttribute('dark', '');
+        element.setAttribute('invert-dark', '');
+    });
     await page.locator('#start-blank').check();
     await page.locator('#file-input').setInputFiles(fixture);
     await page.waitForFunction(() => document.querySelector('supernote-viewer')?.shadowRoot?.querySelector('.anim-controls.active'));
@@ -64,17 +68,26 @@ try {
     const initial = await page.locator('supernote-viewer').evaluate((element) => {
         const root = element.shadowRoot;
         if (!root) throw new Error('Viewer has no shadow root');
+        const background = root.querySelector('.page-container > img');
+        const overlay = root.querySelector('.page-container > .stroke-animation-svg');
+        if (!(background instanceof HTMLImageElement) || !(overlay instanceof SVGSVGElement)) {
+            throw new Error('Write-on page layers missing');
+        }
         return {
             masks: root.querySelectorAll('mask').length,
             previews: root.querySelectorAll('svg path[pathLength="1"]').length,
             hiddenFinals: [...root.querySelectorAll('svg path[fill^="rgb"]')].filter((path) => path.style.display === 'none').length,
             hasPlay: !!root.querySelector('button[aria-label="Play write-on animation"]'),
+            backgroundFilter: getComputedStyle(background).filter,
+            overlayFilter: getComputedStyle(overlay).filter,
         };
     });
     assert.equal(initial.masks, 0, 'write-on playback must not use SVG masks');
     assert(initial.previews > 0, 'expected dashed centerline previews');
     assert(initial.hiddenFinals > 0, 'contours should be hidden before playback');
     assert(initial.hasPlay, 'paused presentation should expose Play');
+    assert.equal(initial.backgroundFilter, 'invert(1)', 'dark mode should invert the write-on background');
+    assert.equal(initial.overlayFilter, initial.backgroundFilter, 'dark mode must invert the SVG ink with its background');
 
     await page.locator('supernote-viewer').evaluate((element) => {
         const button = element.shadowRoot?.querySelector('button[aria-label="Play write-on animation"]');

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -743,14 +743,19 @@ button[aria-pressed="true"] {
    selector - confirmed as a real, reported bug (issue #192): a thumbnail's
    own <img> gets the same class (see sidebarList.ts's buildSidebarList())
    but this rule originally only ever matched .pages' own page images, so
-   thumbnails never inverted regardless of dark mode. */
+   thumbnails never inverted regardless of dark mode. The write-on overlay
+   is separate SVG over an otherwise identical background image, so it must
+   receive the same filter or its ink colors no longer match the inverted
+   page beneath it. */
 @media (prefers-color-scheme: dark) {
     :host(:not([dark])) .pages .page-container > img.supernote-invert-dark,
+    :host(:not([dark])) .pages .page-container > .stroke-animation-svg.supernote-invert-dark,
     :host(:not([dark])) .sidebar-list-thumb.supernote-invert-dark {
         filter: invert(1);
     }
 }
 :host([dark]:not([dark="false"])) .pages .page-container > img.supernote-invert-dark,
+:host([dark]:not([dark="false"])) .pages .page-container > .stroke-animation-svg.supernote-invert-dark,
 :host([dark]:not([dark="false"])) .sidebar-list-thumb.supernote-invert-dark {
     filter: invert(1);
 }
@@ -2743,7 +2748,14 @@ export class SupernoteViewerElement extends HTMLElement {
                 // static lazy-load/evict cycle.
                 state.loaded = true;
                 fillNotePagePlaceholder(state, backgroundUrls[k]);
-                state.containerEl.appendChild(this.pageAnimations[index]!.svg);
+                const svg = this.pageAnimations[index]!.svg;
+                // The worker background inherits this class from the page
+                // placeholder. Keep the separately-rendered animation ink
+                // in the same dark-mode color space.
+                if (state.imageEl.classList.contains('supernote-invert-dark')) {
+                    svg.classList.add('supernote-invert-dark');
+                }
+                state.containerEl.appendChild(svg);
             });
             // fillNotePagePlaceholder() reset each page's container width -
             // reapply whatever zoom/fit-width is currently active, exactly


### PR DESCRIPTION
## Summary
- apply dark-mode inversion to the write-on SVG overlay whenever its background image is configured with `invert-dark`
- keep dark mode without `invert-dark` unchanged
- exercise the dark/inverted write-on presentation in the Playwright smoke test

## Validation
- `npm run test:webcomponent:playwright`
- `npx vitest run src/webcomponent/SupernoteViewerElement.test.ts`
- `npm run lint` (existing Atelier sentence-case warning only)