### PR TITLE
Fix device sync for note filenames containing spaces

### DIFF
--- a/src/FileListModal.test.ts
+++ b/src/FileListModal.test.ts
@@ -65,6 +65,27 @@ describe('scanDeviceSupernoteTree entry trust (GHSA-3gx3-r874-5pp4 follow-up)', 
         expect(files.map((f) => f.name).sort()).toEqual(['diary.note', 'sketch.spd']);
     });
 
+    it('keeps entries whose uri percent-encodes spaces in the filename', async () => {
+        vi.mocked(fetchFromDevice).mockResolvedValue(mockListing([
+            { name: 'Work Journal.note', uri: '/Note/Work%20Journal.note' },
+            { name: 'Work Journal.note', uri: '/Note/Work Journal.note' },
+        ]));
+
+        const files = await scanDeviceSupernoteTree('192.168.1.50');
+
+        expect(files.map((f) => f.name).sort()).toEqual(['Work Journal.note', 'Work Journal.note']);
+    });
+
+    it('keeps entries whose uri uses plus signs for spaces in the filename', async () => {
+        vi.mocked(fetchFromDevice).mockResolvedValue(mockListing([
+            { name: 'Substack Notes.note', uri: '/Note/Substack+Notes.note' },
+        ]));
+
+        const files = await scanDeviceSupernoteTree('192.168.1.50');
+
+        expect(files.map((f) => f.name)).toEqual(['Substack Notes.note']);
+    });
+
     it('drops entries whose name and uri disagree on the filename', async () => {
         // name passes the .note filter; the uri it would actually be
         // downloaded from points elsewhere (e.g. carries traversal segments).

--- a/src/FileListModal.ts
+++ b/src/FileListModal.ts
@@ -3,6 +3,7 @@ import SupernotePlugin from './main';
 import { SupernotePluginSettings, IP_VALIDATION_PATTERN, FileBrowserSortOrder } from './settings';
 import { parseDeviceDate } from './deviceDate';
 import { fetchFromDevice, buildMultipartBody, DEVICE_TRANSFER_TIMEOUT_MS } from './deviceFetch';
+import { decodeDevicePathSegment, normalizeDeviceFileName } from './devicePath';
 import { ErrorModal } from './ErrorModal';
 
 export interface SupernoteFile {
@@ -75,7 +76,8 @@ export async function scanDeviceSupernoteTree(ip: string, path = '/', visited: S
 // same file.
 function uriMatchesName(uri: string, name: string): boolean {
     const segments = uri.split('/').filter((s) => s.length > 0);
-    return segments[segments.length - 1] === name;
+    if (segments.length === 0) return false;
+    return decodeDevicePathSegment(segments[segments.length - 1]) === normalizeDeviceFileName(name);
 }
 
 // A "plain" filename: non-empty, not a dot segment, and containing no path

--- a/src/deviceFetch.test.ts
+++ b/src/deviceFetch.test.ts
@@ -132,10 +132,9 @@ describe('fetchFromDevice', () => {
 
             await fetchFromDevice('192.168.1.50', '@evil.example/secret.note', 'Failed to download file');
 
-            // With the "/", "ip:8089" can only parse as the authority
-            // (host:port), never as userinfo of "evil.example".
+            // Leading "/" still pins the host; "@" in the segment is encoded.
             expect(requestUrl).toHaveBeenCalledWith(
-                expect.objectContaining({ url: 'http://192.168.1.50:8089/@evil.example/secret.note' }),
+                expect.objectContaining({ url: 'http://192.168.1.50:8089/%40evil.example/secret.note' }),
             );
         });
 
@@ -145,17 +144,37 @@ describe('fetchFromDevice', () => {
             await fetchFromDevice('192.168.1.50', '\\evil.example/x.note', 'Failed to download file');
 
             expect(requestUrl).toHaveBeenCalledWith(
-                expect.objectContaining({ url: 'http://192.168.1.50:8089/\\evil.example/x.note' }),
+                expect.objectContaining({ url: 'http://192.168.1.50:8089/%5Cevil.example/x.note' }),
             );
         });
 
-        it('leaves already-absolute paths untouched, including "@" in later segments', async () => {
+        it('leaves already-absolute paths on the device host, encoding special characters in segments', async () => {
             vi.mocked(requestUrl).mockResolvedValue(mockResponse());
 
             await fetchFromDevice('192.168.1.50', '/Note/@mentions/x.note', 'Failed to load file list');
 
             expect(requestUrl).toHaveBeenCalledWith(
-                expect.objectContaining({ url: 'http://192.168.1.50:8089/Note/@mentions/x.note' }),
+                expect.objectContaining({ url: 'http://192.168.1.50:8089/Note/%40mentions/x.note' }),
+            );
+        });
+
+        it('percent-encodes spaces and other special characters in path segments', async () => {
+            vi.mocked(requestUrl).mockResolvedValue(mockResponse());
+
+            await fetchFromDevice('192.168.1.50', '/Note/Work Journal.note', 'Failed to download file');
+
+            expect(requestUrl).toHaveBeenCalledWith(
+                expect.objectContaining({ url: 'http://192.168.1.50:8089/Note/Work%20Journal.note' }),
+            );
+        });
+
+        it('does not double-encode segments that are already percent-encoded', async () => {
+            vi.mocked(requestUrl).mockResolvedValue(mockResponse());
+
+            await fetchFromDevice('192.168.1.50', '/Note/Work%20Journal.note', 'Failed to download file');
+
+            expect(requestUrl).toHaveBeenCalledWith(
+                expect.objectContaining({ url: 'http://192.168.1.50:8089/Note/Work%20Journal.note' }),
             );
         });
     });

--- a/src/deviceFetch.ts
+++ b/src/deviceFetch.ts
@@ -1,4 +1,5 @@
 import { requestUrl, RequestUrlParam } from 'obsidian';
+import { encodeDeviceRequestPath } from './devicePath';
 
 // Wraps Obsidian's `requestUrl` for requests to the Supernote's local "Browse
 // and Access" HTTP server so every call site (listing, download, upload)
@@ -75,7 +76,7 @@ export async function fetchFromDevice(
     // A leading "/" terminates the authority right after the port, so the
     // host can never be escaped. Normalizing (prefixing) rather than
     // rejecting keeps odd-but-benign listings from real devices working.
-    const safePath = path.startsWith('/') ? path : `/${path}`;
+    const requestPath = encodeDeviceRequestPath(path);
 
     let timeoutHandle: ReturnType<typeof window.setTimeout>;
     const timeout = new Promise<never>((_, reject) => {
@@ -88,7 +89,7 @@ export async function fetchFromDevice(
     try {
         const response = await Promise.race([
             requestUrl({
-                url: `http://${ip}:8089${safePath}`,
+                url: `http://${ip}:8089${requestPath}`,
                 throw: false,
                 ...requestInit,
             }),

--- a/src/devicePath.test.ts
+++ b/src/devicePath.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { decodeDevicePathSegment, encodeDeviceRequestPath } from './devicePath';
+
+describe('decodeDevicePathSegment', () => {
+    it('decodes percent-encoded spaces', () => {
+        expect(decodeDevicePathSegment('Work%20Journal.note')).toBe('Work Journal.note');
+    });
+
+    it('treats plus signs as spaces', () => {
+        expect(decodeDevicePathSegment('Substack+Notes.note')).toBe('Substack Notes.note');
+    });
+
+    it('returns the segment unchanged when decoding fails', () => {
+        expect(decodeDevicePathSegment('%E0%A4%A')).toBe('%E0%A4%A');
+    });
+});
+
+describe('encodeDeviceRequestPath', () => {
+    it('prefixes a missing leading slash before encoding', () => {
+        expect(encodeDeviceRequestPath('Note/a b.note')).toBe('/Note/a%20b.note');
+    });
+
+    it('does not double-encode segments that are already percent-encoded', () => {
+        expect(encodeDeviceRequestPath('/Note/Work%20Journal.note')).toBe('/Note/Work%20Journal.note');
+    });
+});

--- a/src/devicePath.ts
+++ b/src/devicePath.ts
@@ -1,0 +1,29 @@
+/** Normalizes a device-side filename for comparison and vault paths. */
+export function normalizeDeviceFileName(name: string): string {
+    return name.normalize('NFC').replace(/\u00A0/g, ' ');
+}
+
+/** Decodes one URI path segment; treats '+' as space (some device listings use it). */
+export function decodeDevicePathSegment(segment: string): string {
+    const plusAsSpace = segment.replace(/\+/g, ' ');
+    try {
+        return normalizeDeviceFileName(decodeURIComponent(plusAsSpace));
+    } catch {
+        return normalizeDeviceFileName(plusAsSpace);
+    }
+}
+
+// Percent-encodes each path segment for HTTP requests. Device listings often
+// carry literal spaces in `uri` (or `%20` / `+` already); raw spaces in a URL
+// are invalid and break downloads unless encoded.
+export function encodeDeviceRequestPath(path: string): string {
+    const withLeadingSlash = path.startsWith('/') ? path : `/${path}`;
+    return withLeadingSlash
+        .split('/')
+        .map((segment, index) => {
+            if (index === 0 && segment === '') return '';
+            if (segment === '') return segment;
+            return encodeURIComponent(decodeDevicePathSegment(segment));
+        })
+        .join('/') || '/';
+}

--- a/src/deviceSync.test.ts
+++ b/src/deviceSync.test.ts
@@ -225,6 +225,18 @@ describe('deviceUriToVaultPath (safety: deterministic, collision-free naming —
         expect(deviceUriToVaultPath('Sync', '/Note/weird:name*?.note')).toBe('Sync/Note/weird_name__.note');
     });
 
+    it('decodes percent-encoded spaces in device URIs for vault filenames', () => {
+        expect(deviceUriToVaultPath('Supernote sync', '/Note/Work%20Journal.note')).toBe(
+            'Supernote sync/Note/Work Journal.note',
+        );
+    });
+
+    it('prefers the listing name for the vault leaf when provided', () => {
+        expect(deviceUriToVaultPath('Supernote sync', '/Note/Substack+Notes.note', 'Substack Notes.note')).toBe(
+            'Supernote sync/Note/Substack Notes.note',
+        );
+    });
+
     it('does not produce a doubled or leading slash when the sync folder is empty', () => {
         const path = deviceUriToVaultPath('', '/Diary/2026-07-25.note');
         expect(path).toBe('Diary/2026-07-25.note');

--- a/src/deviceSync.ts
+++ b/src/deviceSync.ts
@@ -1,3 +1,5 @@
+import { decodeDevicePathSegment, normalizeDeviceFileName } from './devicePath';
+
 // Pure planning/decision logic for mirroring .note/.spd files from a
 // Supernote device (over "Browse and Access") into the vault, unmodified —
 // see issue #119. Sync only ever copies the raw file; it never converts it
@@ -150,14 +152,20 @@ const INVALID_FILENAME_CHARS = /[\\:*?"<>|]/g;
 // (VaultWriter's existing writeMarkdownFile instead uniquifies on every
 // write — appropriate for a one-off manual "attach", wrong for something
 // that runs repeatedly.)
-export function deviceUriToVaultPath(syncFolder: string, deviceUri: string): string {
-    const segments = deviceUri
+export function deviceUriToVaultPath(syncFolder: string, deviceUri: string, fileName?: string): string {
+    const uriSegments = deviceUri
         .split('/')
-        .filter((s) => s.length > 0 && s !== '.' && s !== '..')
-        .map((s) => s.replace(INVALID_FILENAME_CHARS, '_'));
+        .filter((s) => s.length > 0 && s !== '.' && s !== '..');
+    const dirSegments = uriSegments.slice(0, -1)
+        .map((s) => decodeDevicePathSegment(s).replace(INVALID_FILENAME_CHARS, '_'));
+    const leaf = (fileName !== undefined
+        ? normalizeDeviceFileName(fileName)
+        : decodeDevicePathSegment(uriSegments[uriSegments.length - 1] ?? ''))
+        .replace(INVALID_FILENAME_CHARS, '_');
 
     const cleanRoot = syncFolder.replace(/^\/+|\/+$/g, '');
-    return cleanRoot ? `${cleanRoot}/${segments.join('/')}` : segments.join('/');
+    const parts = cleanRoot ? [cleanRoot, ...dirSegments, leaf] : [...dirSegments, leaf];
+    return parts.filter((s) => s.length > 0).join('/');
 }
 
 // ---------------------------------------------------------------------------

--- a/src/syncEngine.ts
+++ b/src/syncEngine.ts
@@ -125,7 +125,7 @@ export async function runDeviceSync(
             const deviceFile = deviceFiles.find((f) => f.uri === listing.uri);
             if (!deviceFile) continue; // Listing changed between the scan and here; pick it up next run.
 
-            const vaultPath = deviceUriToVaultPath(settings.syncFolder, listing.uri);
+            const vaultPath = deviceUriToVaultPath(settings.syncFolder, listing.uri, deviceFile.name);
 
             const response = await fetchFromDevice(ip, listing.uri, `Failed to download ${deviceFile.name}`, {
                 timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS,


### PR DESCRIPTION
## Summary
- Encode device URI path segments before HTTP requests so downloads work for filenames with spaces.
- Decode `%20`, `+`, and non-breaking spaces when matching device `uri` to `name` during sync scans.
- Write synced files using the listing `name` so vault paths match the human-readable Supernote filename.
## Test plan
- [x] `npm test` (249 tests pass)
- [x] Manual sync against a Supernote device with spaced filenames (e.g. `Substack Notes.note`, `Work Journal.note`)