### PR TITLE
Fix and harden encoded device sync paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"build:atelier-webcomponent": "tsc -noEmit -skipLibCheck && node esbuild.atelier-webcomponent.config.mjs production",
 		"lint": "eslint .",
 		"test": "vitest run",
+		"test:device-sync": "node scripts/test-device-sync.mjs",
 		"test:webcomponent:playwright": "npm run build:webcomponent && node scripts/test-webcomponent-playwright.mjs",
 		"version": "node version-bump.mjs && git add manifest.json versions.json",
 		"push-android": "adb push main.js /sdcard/Documents/SupernoteTest/.obsidian/plugins/supernote"

--- a/scripts/obsidian-device-test-stub.ts
+++ b/scripts/obsidian-device-test-stub.ts
@@ -1,0 +1,73 @@
+// Minimal Node-only Obsidian shim for scripts/test-device-sync.entry.ts.
+// It is only used by esbuild's integration-test bundle; the plugin itself
+// continues to import Obsidian's real API.
+
+export class App {}
+
+export class TFile {
+    path: string;
+
+    constructor(path: string) {
+        this.path = path;
+    }
+}
+
+export class SuggestModal<T> {
+    constructor(..._args: unknown[]) {}
+    open(): void {}
+    close(): void {}
+    setPlaceholder(_placeholder: string): void {}
+    setInstructions(_instructions: unknown[]): void {}
+}
+
+export class Modal {
+    contentEl = { empty: () => undefined };
+    constructor(..._args: unknown[]) {}
+    open(): void {}
+    close(): void {}
+}
+
+export class Notice {
+    constructor(..._args: unknown[]) {}
+}
+
+export class MarkdownView {}
+export class PluginSettingTab {
+    containerEl = { empty: () => undefined };
+    constructor(..._args: unknown[]) {}
+}
+export class Setting {
+    constructor(..._args: unknown[]) {}
+}
+export class ExtraButtonComponent {
+    constructor(..._args: unknown[]) {}
+}
+
+export function setIcon(..._args: unknown[]): void {}
+
+interface RequestUrlParam {
+    url: string;
+    method?: string;
+    body?: string | ArrayBuffer;
+    contentType?: string;
+    headers?: Record<string, string>;
+}
+
+export async function requestUrl(param: RequestUrlParam): Promise<{
+    status: number;
+    text: string;
+    arrayBuffer: ArrayBuffer;
+}> {
+    const headers = new Headers(param.headers);
+    if (param.contentType) headers.set('content-type', param.contentType);
+    const response = await fetch(param.url, {
+        method: param.method,
+        headers,
+        body: param.body,
+    });
+    const [text, arrayBuffer] = await Promise.all([
+        response.clone().text(),
+        response.arrayBuffer(),
+    ]);
+    return { status: response.status, text, arrayBuffer };
+}

--- a/scripts/test-device-sync.entry.ts
+++ b/scripts/test-device-sync.entry.ts
@@ -1,0 +1,162 @@
+// This entry is bundled only by test-device-sync.mjs with a tiny Node shim for
+// Obsidian. It deliberately imports the plugin's real Browse & Access and sync
+// modules, rather than reproducing their URI encoding or sync behavior here.
+
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { App, TFile } from 'obsidian';
+import { fetchSupernoteDirectory } from '../src/FileListModal';
+import { buildMultipartBody, DEVICE_TRANSFER_TIMEOUT_MS, fetchFromDevice } from '../src/deviceFetch';
+import { runDeviceSync } from '../src/syncEngine';
+import type { SupernotePluginSettings } from '../src/settings';
+
+const ip = process.env.SUPERNOTE_DEVICE_IP;
+const testDirectory = process.env.SUPERNOTE_TEST_DIR;
+const fixturePath = resolve('supernote-typescript/tests/input/blank-n5-20230015-manta.note');
+
+if (!ip || !/^(25[0-5]|2[0-4]\d|1?\d?\d)(\.(25[0-5]|2[0-4]\d|1?\d?\d)){3}$/.test(ip)) {
+    throw new Error('Set SUPERNOTE_DEVICE_IP to your device’s dotted-quad IP address.');
+}
+if (!testDirectory || !/^\/Note\/[^/]+(?:\/[^/]+)*$/.test(testDirectory) || testDirectory.includes('..')) {
+    throw new Error('Set SUPERNOTE_TEST_DIR to an existing dedicated subdirectory of /Note; it must not contain "..".');
+}
+
+// deviceFetch.ts uses the browser's window timer API. Node has the same timer
+// methods on globalThis, so the test shim only needs to expose it as window.
+Object.assign(globalThis, { window: globalThis });
+
+interface MemoryFile extends TFile {
+    bytes?: ArrayBuffer;
+    text?: string;
+}
+
+const folders = new Set<string>();
+const files = new Map<string, MemoryFile>();
+const vault = {
+    getAbstractFileByPath(path: string): MemoryFile | { path: string } | null {
+        return files.get(path) ?? (folders.has(path) ? { path } : null);
+    },
+    async createFolder(path: string): Promise<void> {
+        folders.add(path);
+    },
+    async createBinary(path: string, bytes: ArrayBuffer): Promise<MemoryFile> {
+        const file = new TFile(path) as MemoryFile;
+        file.bytes = bytes;
+        files.set(path, file);
+        return file;
+    },
+    async modifyBinary(file: MemoryFile, bytes: ArrayBuffer): Promise<void> {
+        file.bytes = bytes;
+    },
+    async readBinary(file: MemoryFile): Promise<ArrayBuffer> {
+        if (!file.bytes) throw new Error(`No bytes stored for ${file.path}`);
+        return file.bytes;
+    },
+    async create(path: string, text: string): Promise<MemoryFile> {
+        const file = new TFile(path) as MemoryFile;
+        file.text = text;
+        files.set(path, file);
+        return file;
+    },
+    async append(file: MemoryFile, text: string): Promise<void> {
+        file.text = (file.text ?? '') + text;
+    },
+};
+const app = { vault } as unknown as App;
+
+const fixture = await readFile(fixturePath);
+const directoryLeafName = testDirectory.split('/').at(-1);
+
+// Safe, syncable filename cases used by the path, fetch, listing, and sync
+// unit tests. The traversal/backslash examples in those tests deliberately
+// model malicious listings, not names a real device should be asked to store.
+const namingCases = [
+    'Work Journal.note',
+    'C++.note',
+    'Substack Notes.note',
+    'a b.note',
+    'a+b(1).note',
+];
+
+const parentDirectory = testDirectory.slice(0, testDirectory.lastIndexOf('/'));
+const parentLeafName = parentDirectory.split('/').at(-1);
+console.log(`Checking dedicated device directory ${testDirectory}…`);
+const parentEntries = await fetchSupernoteDirectory(ip, parentDirectory, parentLeafName);
+if (!parentEntries.some((entry) => entry.isDirectory && entry.name === directoryLeafName)) {
+    throw new Error(
+        `${testDirectory} does not exist on the device. Create this dedicated folder on the Supernote, then rerun with SUPERNOTE_TEST_DIR=${testDirectory}.`,
+    );
+}
+let listed = await fetchSupernoteDirectory(ip, testDirectory, directoryLeafName);
+const fixtureBuffer = fixture.buffer.slice(fixture.byteOffset, fixture.byteOffset + fixture.byteLength);
+
+for (const filename of namingCases) {
+    if (listed.some((file) => file.name === filename && !file.isDirectory)) {
+        console.log(`Keeping existing ${filename}; it will still be downloaded and synced.`);
+        continue;
+    }
+
+    const { body, contentType } = buildMultipartBody('file', filename, 'application/octet-stream', fixtureBuffer);
+    console.log(`Uploading ${filename} (${fixture.length} bytes) through src/deviceFetch.ts…`);
+    const uploadResponse = await fetchFromDevice(ip, testDirectory, `Failed to upload ${filename}`, {
+        method: 'POST',
+        body,
+        contentType,
+        timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS,
+        pathLeafName: directoryLeafName,
+    });
+    if (!uploadResponse.ok) throw new Error(`Upload failed with HTTP ${uploadResponse.status}`);
+    listed = await fetchSupernoteDirectory(ip, testDirectory, directoryLeafName);
+}
+
+const deviceFiles = namingCases.map((filename) => {
+    const file = listed.find((candidate) => candidate.name === filename && !candidate.isDirectory);
+    if (!file) throw new Error(`Upload succeeded but ${filename} was absent from the device listing.`);
+    console.log(`Device listed ${filename} as ${file.uri}`);
+    return file;
+});
+
+// Read each listing URI through the actual request helper before sync. This
+// gives the subsequent in-memory-vault assertion an independent byte source,
+// while exercising each encoded URI form on the real Browse & Access server.
+const deviceHashes = new Map<string, string>();
+for (const file of deviceFiles) {
+    const response = await fetchFromDevice(ip, file.uri, `Failed to download ${file.name}`, {
+        timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS,
+        pathLeafName: file.name,
+    });
+    if (!response.ok) throw new Error(`Download failed for ${file.name} with HTTP ${response.status}`);
+    deviceHashes.set(file.uri, createHash('sha256').update(new Uint8Array(await response.arrayBuffer())).digest('hex'));
+}
+
+const settings = {
+    directConnectIP: ip,
+    // Deliberately use the decoded directory name and a recursive wildcard:
+    // this is the real settings form for syncing a folder whose listing URI
+    // represents spaces as `+`.
+    syncPathFiltersRaw: `${testDirectory}/**`,
+    syncFolder: 'Supernote device integration test',
+    noteSyncState: {},
+} as SupernotePluginSettings;
+let saves = 0;
+console.log('Running src/syncEngine.ts against the device…');
+const result = await runDeviceSync(app, settings, async () => { saves++; });
+if (result.synced !== deviceFiles.length || result.failed.length !== 0 || saves !== 1) {
+    throw new Error(`Unexpected sync result: ${JSON.stringify({ result, saves })}`);
+}
+
+for (const file of deviceFiles) {
+    const record = settings.noteSyncState[file.uri];
+    if (!record) throw new Error(`Sync completed without recording ${file.uri}.`);
+    const synced = files.get(record.vaultPath);
+    if (!synced?.bytes) throw new Error(`Sync did not write ${record.vaultPath} to the in-memory vault.`);
+    const syncedHash = createHash('sha256').update(new Uint8Array(synced.bytes)).digest('hex');
+    if (syncedHash !== deviceHashes.get(file.uri)) {
+        throw new Error(`Synced bytes for ${file.name} differ from its direct device download.`);
+    }
+}
+
+console.log(`PASS: actual plugin upload, listing, filter, download, and sync code transferred ${deviceFiles.length} naming cases byte-for-byte.`);
+console.log(`The fixture files remain in ${testDirectory}; remove them manually when finished.`);

--- a/scripts/test-device-sync.mjs
+++ b/scripts/test-device-sync.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+// Builds and runs the real plugin sync modules in Node against a Browse &
+// Access server. This is intentionally opt-in: it uploads a fixture to the
+// configured test directory and leaves it there (the device API exposes no
+// documented delete endpoint). Use a dedicated device directory only.
+
+import { build } from 'esbuild';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const temporaryDirectory = await mkdtemp(`${tmpdir()}/supernote-device-sync-`);
+const outputFile = resolve(temporaryDirectory, 'test-device-sync.mjs');
+
+try {
+    await build({
+        entryPoints: [resolve('scripts/test-device-sync.entry.ts')],
+        outfile: outputFile,
+        bundle: true,
+        format: 'esm',
+        platform: 'node',
+        target: 'node22',
+        alias: {
+            // The test exercises plugin source in Node, so only its Obsidian
+            // boundary is replaced with the minimal requestUrl/Vault shim.
+            obsidian: resolve('scripts/obsidian-device-test-stub.ts'),
+            'supernote-typescript': resolve('supernote-typescript'),
+        },
+        logLevel: 'warning',
+    });
+    await import(pathToFileURL(outputFile).href);
+} finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+}

--- a/src/FileListModal.test.ts
+++ b/src/FileListModal.test.ts
@@ -86,6 +86,14 @@ describe('scanDeviceSupernoteTree entry trust (GHSA-3gx3-r874-5pp4 follow-up)', 
         expect(files.map((f) => f.name)).toEqual(['Substack Notes.note']);
     });
 
+    it('keeps entries whose filename contains literal plus signs', async () => {
+        vi.mocked(fetchFromDevice).mockResolvedValue(mockListing([
+            { name: 'C++.note', uri: '/Note/C++.note' },
+        ]));
+
+        expect((await scanDeviceSupernoteTree('192.168.1.50')).map((f) => f.name)).toEqual(['C++.note']);
+    });
+
     it('drops entries whose name and uri disagree on the filename', async () => {
         // name passes the .note filter; the uri it would actually be
         // downloaded from points elsewhere (e.g. carries traversal segments).

--- a/src/FileListModal.test.ts
+++ b/src/FileListModal.test.ts
@@ -65,6 +65,27 @@ describe('scanDeviceSupernoteTree entry trust (GHSA-3gx3-r874-5pp4 follow-up)', 
         expect(files.map((f) => f.name).sort()).toEqual(['diary.note', 'sketch.spd']);
     });
 
+    it('keeps entries whose uri percent-encodes spaces in the filename', async () => {
+        vi.mocked(fetchFromDevice).mockResolvedValue(mockListing([
+            { name: 'Work Journal.note', uri: '/Note/Work%20Journal.note' },
+            { name: 'Work Journal.note', uri: '/Note/Work Journal.note' },
+        ]));
+
+        const files = await scanDeviceSupernoteTree('192.168.1.50');
+
+        expect(files.map((f) => f.name).sort()).toEqual(['Work Journal.note', 'Work Journal.note']);
+    });
+
+    it('keeps entries whose uri uses plus signs for spaces in the filename', async () => {
+        vi.mocked(fetchFromDevice).mockResolvedValue(mockListing([
+            { name: 'Substack Notes.note', uri: '/Note/Substack+Notes.note' },
+        ]));
+
+        const files = await scanDeviceSupernoteTree('192.168.1.50');
+
+        expect(files.map((f) => f.name)).toEqual(['Substack Notes.note']);
+    });
+
     it('drops entries whose name and uri disagree on the filename', async () => {
         // name passes the .note filter; the uri it would actually be
         // downloaded from points elsewhere (e.g. carries traversal segments).

--- a/src/FileListModal.ts
+++ b/src/FileListModal.ts
@@ -3,7 +3,7 @@ import SupernotePlugin from './main';
 import { SupernotePluginSettings, IP_VALIDATION_PATTERN, FileBrowserSortOrder } from './settings';
 import { parseDeviceDate } from './deviceDate';
 import { fetchFromDevice, buildMultipartBody, DEVICE_TRANSFER_TIMEOUT_MS } from './deviceFetch';
-import { decodeDevicePathSegment, normalizeDeviceFileName } from './devicePath';
+import { decodeDeviceFormPathSegment, decodeDevicePathSegment, normalizeDeviceFileName } from './devicePath';
 import { ErrorModal } from './ErrorModal';
 
 export interface SupernoteFile {
@@ -27,8 +27,8 @@ interface SupernoteResponse {
 // Fetches and parses one directory listing from the Supernote "Browse and
 // Access" HTTP server. Shared by the file-browsing modals below and by
 // ImportTodayModal, which walks the whole tree looking for today's notes.
-export async function fetchSupernoteDirectory(ip: string, path: string): Promise<SupernoteFile[]> {
-    const response = await fetchFromDevice(ip, path, 'Failed to load file list');
+export async function fetchSupernoteDirectory(ip: string, path: string, pathLeafName?: string): Promise<SupernoteFile[]> {
+    const response = await fetchFromDevice(ip, path, 'Failed to load file list', { pathLeafName });
     if (!response.ok) {
         throw new Error(`Failed to load file list: Supernote responded with an error (status ${response.status}).`);
     }
@@ -51,16 +51,21 @@ const SYNCABLE_EXTENSION_PATTERN = /\.(note|spd)$/i;
 // filters by date) and the device auto-sync engine (which filters by the
 // configured path patterns) — both need the same "list everything once"
 // traversal, just with different downstream filtering.
-export async function scanDeviceSupernoteTree(ip: string, path = '/', visited: Set<string> = new Set()): Promise<SupernoteFile[]> {
+export async function scanDeviceSupernoteTree(
+    ip: string,
+    path = '/',
+    visited: Set<string> = new Set(),
+    pathLeafName?: string,
+): Promise<SupernoteFile[]> {
     if (visited.has(path)) return [];
     visited.add(path);
 
-    const entries = await fetchSupernoteDirectory(ip, path);
+    const entries = await fetchSupernoteDirectory(ip, path, pathLeafName);
     const results: SupernoteFile[] = [];
 
     for (const entry of entries) {
         if (entry.isDirectory) {
-            results.push(...await scanDeviceSupernoteTree(ip, entry.uri, visited));
+            results.push(...await scanDeviceSupernoteTree(ip, entry.uri, visited, entry.name));
         } else if (SYNCABLE_EXTENSION_PATTERN.test(entry.name) && isTrustedListingEntry(entry)) {
             results.push(entry);
         }
@@ -77,7 +82,10 @@ export async function scanDeviceSupernoteTree(ip: string, path = '/', visited: S
 function uriMatchesName(uri: string, name: string): boolean {
     const segments = uri.split('/').filter((s) => s.length > 0);
     if (segments.length === 0) return false;
-    return decodeDevicePathSegment(segments[segments.length - 1]) === normalizeDeviceFileName(name);
+    const leaf = segments[segments.length - 1];
+    const normalizedName = normalizeDeviceFileName(name);
+    return decodeDevicePathSegment(leaf) === normalizedName
+        || decodeDeviceFormPathSegment(leaf) === normalizedName;
 }
 
 // A "plain" filename: non-empty, not a dot segment, and containing no path
@@ -115,6 +123,7 @@ export abstract class FileListModal extends SuggestModal<SupernoteFile> {
     settings: SupernotePluginSettings;
     files: SupernoteFile[] = [];
     currentPath = '/';
+    protected currentPathLeafName: string | undefined;
     sortOrder: FileBrowserSortOrder;
     private nameSortButton!: HTMLButtonElement;
     private dateSortButton!: HTMLButtonElement;
@@ -196,7 +205,7 @@ export abstract class FileListModal extends SuggestModal<SupernoteFile> {
 
     async loadFiles() {
         try {
-            this.files = await fetchSupernoteDirectory(this.settings.directConnectIP, this.currentPath);
+            this.files = await fetchSupernoteDirectory(this.settings.directConnectIP, this.currentPath, this.currentPathLeafName);
             this.sortFiles();
         } catch (err) {
             this.close();
@@ -248,6 +257,7 @@ export abstract class FileListModal extends SuggestModal<SupernoteFile> {
             void (async () => {
                 // Navigate into directory
                 this.currentPath = file.uri;
+                this.currentPathLeafName = file.name;
                 await this.loadFiles();
                 // Reopen the modal to show new directory contents
                 this.open();
@@ -267,6 +277,7 @@ export class DownloadListModal extends FileListModal {
             if (file.isDirectory) {
                 // Navigate into directory
                 this.currentPath = file.uri;
+                this.currentPathLeafName = file.name;
                 await this.loadFiles();
                 // Reopen the modal to show new directory contents
                 this.open();
@@ -285,6 +296,7 @@ export class DownloadListModal extends FileListModal {
                     }
                     const fileResponse = await fetchFromDevice(this.settings.directConnectIP, file.uri, 'Failed to download file', {
                         timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS,
+                        pathLeafName: file.name,
                     });
                     if (!fileResponse.ok) {
                         throw new Error(`Failed to download file: Supernote responded with an error (status ${fileResponse.status}).`);
@@ -386,6 +398,7 @@ export class UploadListModal extends FileListModal {
                         contentType,
                         body,
                         timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS,
+                        pathLeafName: this.currentPathLeafName,
                     });
 
                     if (!response.ok) {

--- a/src/FileListModal.ts
+++ b/src/FileListModal.ts
@@ -3,6 +3,7 @@ import SupernotePlugin from './main';
 import { SupernotePluginSettings, IP_VALIDATION_PATTERN, FileBrowserSortOrder } from './settings';
 import { parseDeviceDate } from './deviceDate';
 import { fetchFromDevice, buildMultipartBody, DEVICE_TRANSFER_TIMEOUT_MS } from './deviceFetch';
+import { decodeDevicePathSegment, normalizeDeviceFileName } from './devicePath';
 import { ErrorModal } from './ErrorModal';
 
 export interface SupernoteFile {
@@ -75,7 +76,8 @@ export async function scanDeviceSupernoteTree(ip: string, path = '/', visited: S
 // same file.
 function uriMatchesName(uri: string, name: string): boolean {
     const segments = uri.split('/').filter((s) => s.length > 0);
-    return segments[segments.length - 1] === name;
+    if (segments.length === 0) return false;
+    return decodeDevicePathSegment(segments[segments.length - 1]) === normalizeDeviceFileName(name);
 }
 
 // A "plain" filename: non-empty, not a dot segment, and containing no path

--- a/src/ImportTodayModal.ts
+++ b/src/ImportTodayModal.ts
@@ -169,6 +169,7 @@ export class ImportTodayModal extends Modal {
             for (const file of chosen) {
                 const response = await fetchFromDevice(ip, file.uri, `Failed to download ${file.name}`, {
                     timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS,
+                    pathLeafName: file.name,
                 });
                 if (!response.ok) {
                     throw new Error(`Failed to download ${file.name}: Supernote responded with an error (status ${response.status}).`);

--- a/src/deviceFetch.test.ts
+++ b/src/deviceFetch.test.ts
@@ -177,6 +177,24 @@ describe('fetchFromDevice', () => {
                 expect.objectContaining({ url: 'http://192.168.1.50:8089/Note/Work%20Journal.note' }),
             );
         });
+
+        it('uses the listing name to distinguish literal pluses from form-style spaces', async () => {
+            vi.mocked(requestUrl).mockResolvedValue(mockResponse());
+
+            await fetchFromDevice('192.168.1.50', '/Note/C++.note', 'Failed to download file', {
+                pathLeafName: 'C++.note',
+            });
+            expect(requestUrl).toHaveBeenLastCalledWith(
+                expect.objectContaining({ url: 'http://192.168.1.50:8089/Note/C%2B%2B.note' }),
+            );
+
+            await fetchFromDevice('192.168.1.50', '/Note/Substack+Notes.note', 'Failed to download file', {
+                pathLeafName: 'Substack Notes.note',
+            });
+            expect(requestUrl).toHaveBeenLastCalledWith(
+                expect.objectContaining({ url: 'http://192.168.1.50:8089/Note/Substack%20Notes.note' }),
+            );
+        });
     });
 });
 

--- a/src/deviceFetch.test.ts
+++ b/src/deviceFetch.test.ts
@@ -132,10 +132,9 @@ describe('fetchFromDevice', () => {
 
             await fetchFromDevice('192.168.1.50', '@evil.example/secret.note', 'Failed to download file');
 
-            // With the "/", "ip:8089" can only parse as the authority
-            // (host:port), never as userinfo of "evil.example".
+            // Leading "/" still pins the host; "@" in the segment is encoded.
             expect(requestUrl).toHaveBeenCalledWith(
-                expect.objectContaining({ url: 'http://192.168.1.50:8089/@evil.example/secret.note' }),
+                expect.objectContaining({ url: 'http://192.168.1.50:8089/%40evil.example/secret.note' }),
             );
         });
 
@@ -145,17 +144,37 @@ describe('fetchFromDevice', () => {
             await fetchFromDevice('192.168.1.50', '\\evil.example/x.note', 'Failed to download file');
 
             expect(requestUrl).toHaveBeenCalledWith(
-                expect.objectContaining({ url: 'http://192.168.1.50:8089/\\evil.example/x.note' }),
+                expect.objectContaining({ url: 'http://192.168.1.50:8089/%5Cevil.example/x.note' }),
             );
         });
 
-        it('leaves already-absolute paths untouched, including "@" in later segments', async () => {
+        it('leaves already-absolute paths on the device host, encoding special characters in segments', async () => {
             vi.mocked(requestUrl).mockResolvedValue(mockResponse());
 
             await fetchFromDevice('192.168.1.50', '/Note/@mentions/x.note', 'Failed to load file list');
 
             expect(requestUrl).toHaveBeenCalledWith(
-                expect.objectContaining({ url: 'http://192.168.1.50:8089/Note/@mentions/x.note' }),
+                expect.objectContaining({ url: 'http://192.168.1.50:8089/Note/%40mentions/x.note' }),
+            );
+        });
+
+        it('percent-encodes spaces and other special characters in path segments', async () => {
+            vi.mocked(requestUrl).mockResolvedValue(mockResponse());
+
+            await fetchFromDevice('192.168.1.50', '/Note/Work Journal.note', 'Failed to download file');
+
+            expect(requestUrl).toHaveBeenCalledWith(
+                expect.objectContaining({ url: 'http://192.168.1.50:8089/Note/Work%20Journal.note' }),
+            );
+        });
+
+        it('does not double-encode segments that are already percent-encoded', async () => {
+            vi.mocked(requestUrl).mockResolvedValue(mockResponse());
+
+            await fetchFromDevice('192.168.1.50', '/Note/Work%20Journal.note', 'Failed to download file');
+
+            expect(requestUrl).toHaveBeenCalledWith(
+                expect.objectContaining({ url: 'http://192.168.1.50:8089/Note/Work%20Journal.note' }),
             );
         });
     });

--- a/src/deviceFetch.ts
+++ b/src/deviceFetch.ts
@@ -1,4 +1,5 @@
 import { requestUrl, RequestUrlParam } from 'obsidian';
+import { encodeDeviceRequestPath } from './devicePath';
 
 // Wraps Obsidian's `requestUrl` for requests to the Supernote's local "Browse
 // and Access" HTTP server so every call site (listing, download, upload)
@@ -75,7 +76,7 @@ export async function fetchFromDevice(
     // A leading "/" terminates the authority right after the port, so the
     // host can never be escaped. Normalizing (prefixing) rather than
     // rejecting keeps odd-but-benign listings from real devices working.
-    const safePath = path.startsWith('/') ? path : `/${path}`;
+    const requestPath = encodeDeviceRequestPath(path);
 
     let timeoutHandle: ReturnType<typeof window.setTimeout>;
     const timeout = new Promise<never>((_, reject) => {
@@ -88,7 +89,7 @@ export async function fetchFromDevice(
     try {
         const response = await Promise.race([
             requestUrl({
-                url: `http://${ip}:8089${safePath}`,
+                url: `http://${ip}:8089${requestPath}`,
                 throw: false,
                 ...requestInit,
             }),

--- a/src/deviceFetch.ts
+++ b/src/deviceFetch.ts
@@ -31,6 +31,8 @@ export interface DeviceResponse {
 
 export type DeviceRequestInit = Pick<RequestUrlParam, 'method' | 'body' | 'contentType' | 'headers'> & {
     timeoutMs?: number;
+    /** Display name from the listing, used to distinguish literal `+` from a space. */
+    pathLeafName?: string;
 };
 
 // `requestUrl`'s body can only be a string or ArrayBuffer (no FormData/Blob
@@ -65,7 +67,7 @@ export async function fetchFromDevice(
     context: string,
     init: DeviceRequestInit = {},
 ): Promise<DeviceResponse> {
-    const { timeoutMs = DEVICE_REQUEST_TIMEOUT_MS, ...requestInit } = init;
+    const { timeoutMs = DEVICE_REQUEST_TIMEOUT_MS, pathLeafName, ...requestInit } = init;
 
     // Pin the request to the device host: `path` comes from parsed device
     // directory listings, so a hostile or impersonating device controls its
@@ -76,7 +78,7 @@ export async function fetchFromDevice(
     // A leading "/" terminates the authority right after the port, so the
     // host can never be escaped. Normalizing (prefixing) rather than
     // rejecting keeps odd-but-benign listings from real devices working.
-    const requestPath = encodeDeviceRequestPath(path);
+    const requestPath = encodeDeviceRequestPath(path, pathLeafName);
 
     let timeoutHandle: ReturnType<typeof window.setTimeout>;
     const timeout = new Promise<never>((_, reject) => {

--- a/src/devicePath.test.ts
+++ b/src/devicePath.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { decodeDevicePathSegment, encodeDeviceRequestPath } from './devicePath';
+
+describe('decodeDevicePathSegment', () => {
+    it('decodes percent-encoded spaces', () => {
+        expect(decodeDevicePathSegment('Work%20Journal.note')).toBe('Work Journal.note');
+    });
+
+    it('treats plus signs as spaces', () => {
+        expect(decodeDevicePathSegment('Substack+Notes.note')).toBe('Substack Notes.note');
+    });
+
+    it('returns the segment unchanged when decoding fails', () => {
+        expect(decodeDevicePathSegment('%E0%A4%A')).toBe('%E0%A4%A');
+    });
+});
+
+describe('encodeDeviceRequestPath', () => {
+    it('prefixes a missing leading slash before encoding', () => {
+        expect(encodeDeviceRequestPath('Note/a b.note')).toBe('/Note/a%20b.note');
+    });
+
+    it('does not double-encode segments that are already percent-encoded', () => {
+        expect(encodeDeviceRequestPath('/Note/Work%20Journal.note')).toBe('/Note/Work%20Journal.note');
+    });
+});

--- a/src/devicePath.test.ts
+++ b/src/devicePath.test.ts
@@ -1,13 +1,26 @@
 import { describe, it, expect } from 'vitest';
-import { decodeDevicePathSegment, encodeDeviceRequestPath } from './devicePath';
+import {
+    decodeDeviceFormPathSegment,
+    decodeDevicePathSegment,
+    decodeDevicePathVariants,
+    encodeDeviceRequestPath,
+} from './devicePath';
 
-describe('decodeDevicePathSegment', () => {
+describe('device path decoding', () => {
     it('decodes percent-encoded spaces', () => {
         expect(decodeDevicePathSegment('Work%20Journal.note')).toBe('Work Journal.note');
     });
 
-    it('treats plus signs as spaces', () => {
-        expect(decodeDevicePathSegment('Substack+Notes.note')).toBe('Substack Notes.note');
+    it('keeps literal plus signs in URI path segments', () => {
+        expect(decodeDevicePathSegment('C++.note')).toBe('C++.note');
+    });
+
+    it('offers the Supernote form-style plus-as-space form separately', () => {
+        expect(decodeDeviceFormPathSegment('Substack+Notes.note')).toBe('Substack Notes.note');
+        expect(decodeDevicePathVariants('/Note/Substack+Notes.note')).toEqual([
+            '/Note/Substack+Notes.note',
+            '/Note/Substack Notes.note',
+        ]);
     });
 
     it('returns the segment unchanged when decoding fails', () => {
@@ -22,5 +35,10 @@ describe('encodeDeviceRequestPath', () => {
 
     it('does not double-encode segments that are already percent-encoded', () => {
         expect(encodeDeviceRequestPath('/Note/Work%20Journal.note')).toBe('/Note/Work%20Journal.note');
+    });
+
+    it('uses the listing name to distinguish literal plus from a space', () => {
+        expect(encodeDeviceRequestPath('/Note/C++.note', 'C++.note')).toBe('/Note/C%2B%2B.note');
+        expect(encodeDeviceRequestPath('/Note/Substack+Notes.note', 'Substack Notes.note')).toBe('/Note/Substack%20Notes.note');
     });
 });

--- a/src/devicePath.ts
+++ b/src/devicePath.ts
@@ -3,27 +3,55 @@ export function normalizeDeviceFileName(name: string): string {
     return name.normalize('NFC').replace(/\u00A0/g, ' ');
 }
 
-/** Decodes one URI path segment; treats '+' as space (some device listings use it). */
+// URI path segments are not form fields: a literal `+` is a literal plus.
+// Supernote's Browse and Access listings nevertheless sometimes use form-style
+// `+` for a space, so callers that have the listing's display name can use the
+// form-style variant as a fallback.
 export function decodeDevicePathSegment(segment: string): string {
-    const plusAsSpace = segment.replace(/\+/g, ' ');
     try {
-        return normalizeDeviceFileName(decodeURIComponent(plusAsSpace));
+        return normalizeDeviceFileName(decodeURIComponent(segment));
     } catch {
-        return normalizeDeviceFileName(plusAsSpace);
+        return normalizeDeviceFileName(segment);
     }
 }
 
-// Percent-encodes each path segment for HTTP requests. Device listings often
-// carry literal spaces in `uri` (or `%20` / `+` already); raw spaces in a URL
-// are invalid and break downloads unless encoded.
-export function encodeDeviceRequestPath(path: string): string {
-    const withLeadingSlash = path.startsWith('/') ? path : `/${path}`;
-    return withLeadingSlash
+export function decodeDeviceFormPathSegment(segment: string): string {
+    return decodeDevicePathSegment(segment.replace(/\+/g, ' '));
+}
+
+/** Returns the URI path's standards-compliant and Supernote form-style forms. */
+export function decodeDevicePathVariants(path: string): string[] {
+    const decodePath = (decodeSegment: (segment: string) => string) => path
         .split('/')
+        .map(decodeSegment)
+        .join('/');
+    return [...new Set([
+        decodePath(decodeDevicePathSegment),
+        decodePath(decodeDeviceFormPathSegment),
+    ])];
+}
+
+/**
+ * Percent-encodes every path segment for an HTTP request. `expectedLeafName`,
+ * when available from a directory listing, disambiguates a literal `+` from
+ * the Supernote server's non-standard `+`-for-space form.
+ */
+export function encodeDeviceRequestPath(path: string, expectedLeafName?: string): string {
+    const withLeadingSlash = path.startsWith('/') ? path : `/${path}`;
+    const segments = withLeadingSlash.split('/');
+    return segments
         .map((segment, index) => {
             if (index === 0 && segment === '') return '';
             if (segment === '') return segment;
-            return encodeURIComponent(decodeDevicePathSegment(segment));
+
+            const standard = decodeDevicePathSegment(segment);
+            const formStyle = decodeDeviceFormPathSegment(segment);
+            const isLeaf = index === segments.length - 1;
+            const expected = expectedLeafName === undefined ? undefined : normalizeDeviceFileName(expectedLeafName);
+            const decoded = isLeaf && expected !== undefined && formStyle === expected && standard !== expected
+                ? formStyle
+                : standard;
+            return encodeURIComponent(decoded);
         })
         .join('/') || '/';
 }

--- a/src/devicePath.ts
+++ b/src/devicePath.ts
@@ -1,0 +1,29 @@
+/** Normalizes a device-side filename for comparison and vault paths. */
+export function normalizeDeviceFileName(name: string): string {
+    return name.normalize('NFC').replace(/\u00A0/g, ' ');
+}
+
+/** Decodes one URI path segment; treats '+' as space (some device listings use it). */
+export function decodeDevicePathSegment(segment: string): string {
+    const plusAsSpace = segment.replace(/\+/g, ' ');
+    try {
+        return normalizeDeviceFileName(decodeURIComponent(plusAsSpace));
+    } catch {
+        return normalizeDeviceFileName(plusAsSpace);
+    }
+}
+
+// Percent-encodes each path segment for HTTP requests. Device listings often
+// carry literal spaces in `uri` (or `%20` / `+` already); raw spaces in a URL
+// are invalid and break downloads unless encoded.
+export function encodeDeviceRequestPath(path: string): string {
+    const withLeadingSlash = path.startsWith('/') ? path : `/${path}`;
+    return withLeadingSlash
+        .split('/')
+        .map((segment, index) => {
+            if (index === 0 && segment === '') return '';
+            if (segment === '') return segment;
+            return encodeURIComponent(decodeDevicePathSegment(segment));
+        })
+        .join('/') || '/';
+}

--- a/src/deviceSync.test.ts
+++ b/src/deviceSync.test.ts
@@ -81,6 +81,12 @@ describe('globToRegExp / matchesAnyPattern', () => {
         expect(matchesAnyPattern('/Diary/today.note', patterns)).toBe(true);
         expect(matchesAnyPattern('/Personal/today.note', patterns)).toBe(false);
     });
+
+    it('matches human-readable filters against percent-encoded and form-style device paths', () => {
+        expect(matchesAnyPattern('/Note/Work%20Journal.note', ['/Note/Work Journal.note'])).toBe(true);
+        expect(matchesAnyPattern('/Note/Substack+Notes.note', ['/Note/Substack Notes.note'])).toBe(true);
+        expect(matchesAnyPattern('/Note/C++.note', ['/Note/C++.note'])).toBe(true);
+    });
 });
 
 describe('parsePathFilters', () => {
@@ -234,6 +240,15 @@ describe('deviceUriToVaultPath (safety: deterministic, collision-free naming —
     it('prefers the listing name for the vault leaf when provided', () => {
         expect(deviceUriToVaultPath('Supernote sync', '/Note/Substack+Notes.note', 'Substack Notes.note')).toBe(
             'Supernote sync/Note/Substack Notes.note',
+        );
+    });
+
+    it('cannot escape the sync folder through percent-encoded dot or slash segments', () => {
+        expect(deviceUriToVaultPath('Supernote sync', '/%2e%2e/escaped.note')).toBe(
+            'Supernote sync/escaped.note',
+        );
+        expect(deviceUriToVaultPath('Supernote sync', '/Note%2Foutside/escaped.note')).toBe(
+            'Supernote sync/Note_outside/escaped.note',
         );
     });
 

--- a/src/deviceSync.test.ts
+++ b/src/deviceSync.test.ts
@@ -225,6 +225,18 @@ describe('deviceUriToVaultPath (safety: deterministic, collision-free naming —
         expect(deviceUriToVaultPath('Sync', '/Note/weird:name*?.note')).toBe('Sync/Note/weird_name__.note');
     });
 
+    it('decodes percent-encoded spaces in device URIs for vault filenames', () => {
+        expect(deviceUriToVaultPath('Supernote sync', '/Note/Work%20Journal.note')).toBe(
+            'Supernote sync/Note/Work Journal.note',
+        );
+    });
+
+    it('prefers the listing name for the vault leaf when provided', () => {
+        expect(deviceUriToVaultPath('Supernote sync', '/Note/Substack+Notes.note', 'Substack Notes.note')).toBe(
+            'Supernote sync/Note/Substack Notes.note',
+        );
+    });
+
     it('does not produce a doubled or leading slash when the sync folder is empty', () => {
         const path = deviceUriToVaultPath('', '/Diary/2026-07-25.note');
         expect(path).toBe('Diary/2026-07-25.note');

--- a/src/deviceSync.ts
+++ b/src/deviceSync.ts
@@ -1,3 +1,5 @@
+import { decodeDevicePathSegment, normalizeDeviceFileName } from './devicePath';
+
 // Pure planning/decision logic for mirroring .note/.spd files from a
 // Supernote device (over "Browse and Access") into the vault, unmodified —
 // see issue #119. Sync only ever copies the raw file; it never converts it
@@ -150,14 +152,20 @@ const INVALID_FILENAME_CHARS = /[\\:*?"<>|]/g;
 // (VaultWriter's existing writeMarkdownFile instead uniquifies on every
 // write — appropriate for a one-off manual "attach", wrong for something
 // that runs repeatedly.)
-export function deviceUriToVaultPath(syncFolder: string, deviceUri: string): string {
-    const segments = deviceUri
+export function deviceUriToVaultPath(syncFolder: string, deviceUri: string, fileName?: string): string {
+    const uriSegments = deviceUri
         .split('/')
-        .filter((s) => s.length > 0 && s !== '.' && s !== '..')
-        .map((s) => s.replace(INVALID_FILENAME_CHARS, '_'));
+        .filter((s) => s.length > 0 && s !== '.' && s !== '..');
+    const dirSegments = uriSegments.slice(0, -1)
+        .map((s) => decodeDevicePathSegment(s).replace(INVALID_FILENAME_CHARS, '_'));
+    const leaf = (fileName !== undefined
+        ? normalizeDeviceFileName(fileName)
+        : decodeDevicePathSegment(uriSegments[uriSegments.length - 1] ?? ''))
+        .replace(INVALID_FILENAME_CHARS, '_');
 
     const cleanRoot = syncFolder.replace(/^\/+|\/+$/g, '');
-    return cleanRoot ? `${cleanRoot}/${segments.join('/')}` : segments.join('/');
+    const parts = cleanRoot ? [cleanRoot, ...dirSegments, leaf] : [...dirSegments, leaf];
+    return parts.filter((s) => s.length > 0).join('/');
 }
 
 // ---------------------------------------------------------------------------

--- a/src/deviceSync.ts
+++ b/src/deviceSync.ts
@@ -1,4 +1,4 @@
-import { decodeDevicePathSegment, normalizeDeviceFileName } from './devicePath';
+import { decodeDevicePathSegment, decodeDevicePathVariants, normalizeDeviceFileName } from './devicePath';
 
 // Pure planning/decision logic for mirroring .note/.spd files from a
 // Supernote device (over "Browse and Access") into the vault, unmodified —
@@ -71,7 +71,11 @@ export function globToRegExp(pattern: string): RegExp {
 // returns).
 export function matchesAnyPattern(deviceUri: string, patterns: string[]): boolean {
     if (patterns.length === 0) return true;
-    return patterns.some((p) => globToRegExp(p).test(deviceUri));
+    const pathVariants = decodeDevicePathVariants(deviceUri);
+    return patterns.some((p) => {
+        const re = globToRegExp(p);
+        return pathVariants.some((path) => re.test(path));
+    });
 }
 
 // Settings store path filters as one text field (newline- or comma-separated)
@@ -143,7 +147,18 @@ export function planSync(files: DeviceNoteListing[], manifest: SyncManifest, pat
 // instead of piling up "Note 2.md"-style duplicates)
 // ---------------------------------------------------------------------------
 
-const INVALID_FILENAME_CHARS = /[\\:*?"<>|]/g;
+// URI components are decoded before reaching this sanitizer, so `/` must be
+// included alongside the filesystem-invalid characters: `%2F` is otherwise a
+// path separator after decoding.
+const INVALID_FILENAME_CHARS = /[\\/:*?"<>|]/g;
+
+function isSafePathSegment(segment: string): boolean {
+    return segment.length > 0 && segment !== '.' && segment !== '..';
+}
+
+function sanitizePathSegment(segment: string): string {
+    return isSafePathSegment(segment) ? segment.replace(INVALID_FILENAME_CHARS, '_') : '';
+}
 
 // Maps a device note to a stable vault path that mirrors the device's own
 // folder structure and filename (extension included — sync only ever copies
@@ -153,15 +168,16 @@ const INVALID_FILENAME_CHARS = /[\\:*?"<>|]/g;
 // write — appropriate for a one-off manual "attach", wrong for something
 // that runs repeatedly.)
 export function deviceUriToVaultPath(syncFolder: string, deviceUri: string, fileName?: string): string {
+    // Decode before rejecting dot segments. Filtering only raw `..` leaves
+    // `%2e%2e` as a traversal segment after decoding.
     const uriSegments = deviceUri
         .split('/')
-        .filter((s) => s.length > 0 && s !== '.' && s !== '..');
-    const dirSegments = uriSegments.slice(0, -1)
-        .map((s) => decodeDevicePathSegment(s).replace(INVALID_FILENAME_CHARS, '_'));
-    const leaf = (fileName !== undefined
+        .filter((s) => s.length > 0)
+        .map(decodeDevicePathSegment);
+    const dirSegments = uriSegments.slice(0, -1).map(sanitizePathSegment);
+    const leaf = sanitizePathSegment(fileName !== undefined
         ? normalizeDeviceFileName(fileName)
-        : decodeDevicePathSegment(uriSegments[uriSegments.length - 1] ?? ''))
-        .replace(INVALID_FILENAME_CHARS, '_');
+        : uriSegments[uriSegments.length - 1] ?? '');
 
     const cleanRoot = syncFolder.replace(/^\/+|\/+$/g, '');
     const parts = cleanRoot ? [cleanRoot, ...dirSegments, leaf] : [...dirSegments, leaf];

--- a/src/syncEngine.ts
+++ b/src/syncEngine.ts
@@ -129,6 +129,7 @@ export async function runDeviceSync(
 
             const response = await fetchFromDevice(ip, listing.uri, `Failed to download ${deviceFile.name}`, {
                 timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS,
+                pathLeafName: deviceFile.name,
             });
             if (!response.ok) {
                 throw new Error(`Supernote responded with status ${response.status}`);

--- a/src/syncEngine.ts
+++ b/src/syncEngine.ts
@@ -125,7 +125,7 @@ export async function runDeviceSync(
             const deviceFile = deviceFiles.find((f) => f.uri === listing.uri);
             if (!deviceFile) continue; // Listing changed between the scan and here; pick it up next run.
 
-            const vaultPath = deviceUriToVaultPath(settings.syncFolder, listing.uri);
+            const vaultPath = deviceUriToVaultPath(settings.syncFolder, listing.uri, deviceFile.name);
 
             const response = await fetchFromDevice(ip, listing.uri, `Failed to download ${deviceFile.name}`, {
                 timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS,


### PR DESCRIPTION
Supersedes #247 with its filename-space fix plus follow-up hardening.

- Encode device URI path segments so spaced filenames download reliably.
- Preserve literal `+` in device path segments; use the listing name only to recognize Supernote’s non-standard `+`-for-space encoding.
- Match user-entered sync filters against decoded device paths.
- Prevent percent-encoded dot and slash segments from escaping the configured sync folder.
- Cover encoded traversal, literal plus filenames, form-style space paths, and decoded filter matching with regression tests.

## Verification
- `npm run build`
- `npm test` (255 passing)
- `npm run lint` (0 errors; one existing warning in `src/atelierView.ts`)