### PR TITLE
Preserve Supernote directory display names in sync

### DIFF
--- a/scripts/test-device-sync.entry.ts
+++ b/scripts/test-device-sync.entry.ts
@@ -150,6 +150,10 @@ if (result.synced !== deviceFiles.length || result.failed.length !== 0 || saves 
 for (const file of deviceFiles) {
     const record = settings.noteSyncState[file.uri];
     if (!record) throw new Error(`Sync completed without recording ${file.uri}.`);
+    const expectedVaultPath = `${settings.syncFolder}/${testDirectory.slice(1)}/${file.name}`;
+    if (record.vaultPath !== expectedVaultPath) {
+        throw new Error(`Expected ${expectedVaultPath}, got ${record.vaultPath}.`);
+    }
     const synced = files.get(record.vaultPath);
     if (!synced?.bytes) throw new Error(`Sync did not write ${record.vaultPath} to the in-memory vault.`);
     const syncedHash = createHash('sha256').update(new Uint8Array(synced.bytes)).digest('hex');

--- a/src/FileListModal.test.ts
+++ b/src/FileListModal.test.ts
@@ -145,5 +145,22 @@ describe('scanDeviceSupernoteTree entry trust (GHSA-3gx3-r874-5pp4 follow-up)', 
         const files = await scanDeviceSupernoteTree('192.168.1.50');
 
         expect(files.map((f) => f.name)).toEqual(['inside.note']);
+        expect(files[0].directoryNames).toEqual(['EXPORT']);
+    });
+
+    it('uses display names from the URI hierarchy when a listing jumps through a route alias', async () => {
+        // The real server can reach /Note through a virtual route such as
+        // /EXPORT/Home Books/Art, while the Note entry's URI remains /Note.
+        vi.mocked(fetchFromDevice)
+            .mockResolvedValueOnce(mockListing([{ name: 'EXPORT', isDirectory: true, uri: '/EXPORT' }]))
+            .mockResolvedValueOnce(mockListing([{ name: 'Note', isDirectory: true, uri: '/Note' }]))
+            .mockResolvedValueOnce(mockListing([{ name: 'test dir', isDirectory: true, uri: '/Note/test+dir' }]))
+            .mockResolvedValueOnce(mockListing([
+                { name: 'Work Journal.note', uri: '/Note/test+dir/Work+Journal.note' },
+            ]));
+
+        const files = await scanDeviceSupernoteTree('192.168.1.50');
+
+        expect(files[0].directoryNames).toEqual(['Note', 'test dir']);
     });
 });

--- a/src/FileListModal.ts
+++ b/src/FileListModal.ts
@@ -13,6 +13,8 @@ export interface SupernoteFile {
     uri: string;
     extension: string;
     isDirectory: boolean;
+    /** Display names of the file's containing folders, from the device root. */
+    directoryNames?: string[];
 }
 
 interface SupernoteResponse {
@@ -56,21 +58,47 @@ export async function scanDeviceSupernoteTree(
     path = '/',
     visited: Set<string> = new Set(),
     pathLeafName?: string,
+    directoryNames: string[] = [],
+    directoryNamesByUri: Map<string, string[]> = new Map(),
 ): Promise<SupernoteFile[]> {
     if (visited.has(path)) return [];
     visited.add(path);
+    if (!directoryNamesByUri.has(path)) directoryNamesByUri.set(path, directoryNames);
 
     const entries = await fetchSupernoteDirectory(ip, path, pathLeafName);
     const results: SupernoteFile[] = [];
 
     for (const entry of entries) {
+        const parentNames = directoryNamesByUri.get(parentUri(entry.uri))
+            ?? decodeUriDirectorySegments(entry.uri);
         if (entry.isDirectory) {
-            results.push(...await scanDeviceSupernoteTree(ip, entry.uri, visited, entry.name));
+            const entryDirectoryNames = [...parentNames, entry.name];
+            directoryNamesByUri.set(entry.uri, entryDirectoryNames);
+            results.push(...await scanDeviceSupernoteTree(
+                ip,
+                entry.uri,
+                visited,
+                entry.name,
+                entryDirectoryNames,
+                directoryNamesByUri,
+            ));
         } else if (SYNCABLE_EXTENSION_PATTERN.test(entry.name) && isTrustedListingEntry(entry)) {
-            results.push(entry);
+            results.push({ ...entry, directoryNames: parentNames });
         }
     }
     return results;
+}
+
+function parentUri(uri: string): string {
+    const lastSlash = uri.lastIndexOf('/');
+    return lastSlash <= 0 ? '/' : uri.slice(0, lastSlash);
+}
+
+// Fallback for malformed/non-hierarchical listings: a normal scan has display
+// names for every parent in directoryNamesByUri, which is required to tell a
+// literal `+` from Supernote's `+`-for-space representation.
+function decodeUriDirectorySegments(uri: string): string[] {
+    return uri.split('/').filter((segment) => segment.length > 0).slice(0, -1).map(decodeDevicePathSegment);
 }
 
 // Defense in depth against a device listing whose `name` and `uri` fields

--- a/src/deviceSync.test.ts
+++ b/src/deviceSync.test.ts
@@ -243,6 +243,15 @@ describe('deviceUriToVaultPath (safety: deterministic, collision-free naming —
         );
     });
 
+    it('uses listing directory names for form-style spaces in URI paths', () => {
+        expect(deviceUriToVaultPath(
+            'Supernote sync',
+            '/Note/test+dir/Work+Journal.note',
+            'Work Journal.note',
+            ['Note', 'test dir'],
+        )).toBe('Supernote sync/Note/test dir/Work Journal.note');
+    });
+
     it('cannot escape the sync folder through percent-encoded dot or slash segments', () => {
         expect(deviceUriToVaultPath('Supernote sync', '/%2e%2e/escaped.note')).toBe(
             'Supernote sync/escaped.note',

--- a/src/deviceSync.ts
+++ b/src/deviceSync.ts
@@ -167,14 +167,27 @@ function sanitizePathSegment(segment: string): string {
 // (VaultWriter's existing writeMarkdownFile instead uniquifies on every
 // write — appropriate for a one-off manual "attach", wrong for something
 // that runs repeatedly.)
-export function deviceUriToVaultPath(syncFolder: string, deviceUri: string, fileName?: string): string {
+export function deviceUriToVaultPath(
+    syncFolder: string,
+    deviceUri: string,
+    fileName?: string,
+    directoryNames?: string[],
+): string {
     // Decode before rejecting dot segments. Filtering only raw `..` leaves
     // `%2e%2e` as a traversal segment after decoding.
     const uriSegments = deviceUri
         .split('/')
         .filter((s) => s.length > 0)
         .map(decodeDevicePathSegment);
-    const dirSegments = uriSegments.slice(0, -1).map(sanitizePathSegment);
+    const uriDirectorySegments = uriSegments.slice(0, -1);
+    // Supernote commonly represents spaces as `+` in listing URIs. Unlike a
+    // file leaf, a URI alone cannot distinguish that form from a literal plus;
+    // use the containing directories' display names collected during the tree
+    // walk when they line up with the URI depth.
+    const sourceDirectories = directoryNames?.length === uriDirectorySegments.length
+        ? directoryNames.map(normalizeDeviceFileName)
+        : uriDirectorySegments;
+    const dirSegments = sourceDirectories.map(sanitizePathSegment);
     const leaf = sanitizePathSegment(fileName !== undefined
         ? normalizeDeviceFileName(fileName)
         : uriSegments[uriSegments.length - 1] ?? '');

--- a/src/syncEngine.ts
+++ b/src/syncEngine.ts
@@ -125,7 +125,12 @@ export async function runDeviceSync(
             const deviceFile = deviceFiles.find((f) => f.uri === listing.uri);
             if (!deviceFile) continue; // Listing changed between the scan and here; pick it up next run.
 
-            const vaultPath = deviceUriToVaultPath(settings.syncFolder, listing.uri, deviceFile.name);
+            const vaultPath = deviceUriToVaultPath(
+                settings.syncFolder,
+                listing.uri,
+                deviceFile.name,
+                deviceFile.directoryNames,
+            );
 
             const response = await fetchFromDevice(ip, listing.uri, `Failed to download ${deviceFile.name}`, {
                 timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS,


### PR DESCRIPTION
Fixes sync vault paths for folders whose Browse & Access URI uses `+` for spaces.

For example, Supernote lists the display folder `test dir` as `/Note/test+dir`. The previous sync code used URI segments for ancestor folders, so it wrote `test+dir` in the vault. The scanner now retains listing display names for each URI directory and sync uses them when constructing vault paths.

Includes regression coverage for virtual route aliases and real-device validation against `/Note/test dir`.

## Verification
- `SUPERNOTE_DEVICE_IP=100.103.149.40 SUPERNOTE_TEST_DIR="/Note/test dir" npm run test:device-sync`
- `npm run build`
- `npm test` (257 passing)
- `npm run lint` (0 errors; one existing warning in `src/atelierView.ts`)