### PR TITLE
Encode display names in parent device paths

### DIFF
--- a/scripts/test-device-sync.entry.ts
+++ b/scripts/test-device-sync.entry.ts
@@ -11,7 +11,7 @@ import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import process from 'node:process';
 import { App, TFile } from 'obsidian';
-import { fetchSupernoteDirectory } from '../src/FileListModal';
+import { fetchSupernoteDirectory, scanDeviceSupernoteTree } from '../src/FileListModal';
 import { buildMultipartBody, DEVICE_TRANSFER_TIMEOUT_MS, fetchFromDevice } from '../src/deviceFetch';
 import { runDeviceSync } from '../src/syncEngine';
 import type { SupernotePluginSettings } from '../src/settings';
@@ -118,11 +118,19 @@ for (const filename of namingCases) {
     listed = await fetchSupernoteDirectory(ip, testDirectory, directoryLeafName);
 }
 
-const deviceFiles = namingCases.map((filename) => {
+const listedDeviceFiles = namingCases.map((filename) => {
     const file = listed.find((candidate) => candidate.name === filename && !candidate.isDirectory);
     if (!file) throw new Error(`Upload succeeded but ${filename} was absent from the device listing.`);
     console.log(`Device listed ${filename} as ${file.uri}`);
     return file;
+});
+// Use the actual recursive scanner's entries below so direct pre-sync downloads
+// get the same parent-directory display names that runDeviceSync receives.
+const scannedFiles = await scanDeviceSupernoteTree(ip);
+const deviceFiles = listedDeviceFiles.map((listedFile) => {
+    const scannedFile = scannedFiles.find((file) => file.uri === listedFile.uri);
+    if (!scannedFile) throw new Error(`Recursive scan did not find ${listedFile.uri}.`);
+    return scannedFile;
 });
 
 // Read each listing URI through the actual request helper before sync. This
@@ -133,9 +141,14 @@ for (const file of deviceFiles) {
     const response = await fetchFromDevice(ip, file.uri, `Failed to download ${file.name}`, {
         timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS,
         pathLeafName: file.name,
+        pathDirectoryNames: file.directoryNames,
     });
     if (!response.ok) throw new Error(`Download failed for ${file.name} with HTTP ${response.status}`);
-    const deviceHash = createHash('sha256').update(new Uint8Array(await response.arrayBuffer())).digest('hex');
+    const deviceBytes = new Uint8Array(await response.arrayBuffer());
+    if (!/^(?:mark|note)SN_FILE_VER_\d{8}/.test(new TextDecoder().decode(deviceBytes.subarray(0, 24)))) {
+        throw new Error(`Download for ${file.name} is not a Supernote file; check encoded parent directory paths.`);
+    }
+    const deviceHash = createHash('sha256').update(deviceBytes).digest('hex');
     if (uploadedNames.has(file.name) && deviceHash !== fixtureHash) {
         console.log(`Device migrated ${file.name} during import; syncing its device-served bytes.`);
     }

--- a/scripts/test-device-sync.entry.ts
+++ b/scripts/test-device-sync.entry.ts
@@ -1,6 +1,10 @@
 // This entry is bundled only by test-device-sync.mjs with a tiny Node shim for
 // Obsidian. It deliberately imports the plugin's real Browse & Access and sync
 // modules, rather than reproducing their URI encoding or sync behavior here.
+//
+// Supernote may migrate an uploaded .note to its current on-device format.
+// Therefore this test checks that sync mirrors the bytes subsequently served
+// by the device, not that an older fixture remains byte-identical after import.
 
 import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
@@ -91,6 +95,8 @@ if (!parentEntries.some((entry) => entry.isDirectory && entry.name === directory
 }
 let listed = await fetchSupernoteDirectory(ip, testDirectory, directoryLeafName);
 const fixtureBuffer = fixture.buffer.slice(fixture.byteOffset, fixture.byteOffset + fixture.byteLength);
+const fixtureHash = createHash('sha256').update(fixture).digest('hex');
+const uploadedNames = new Set<string>();
 
 for (const filename of namingCases) {
     if (listed.some((file) => file.name === filename && !file.isDirectory)) {
@@ -108,6 +114,7 @@ for (const filename of namingCases) {
         pathLeafName: directoryLeafName,
     });
     if (!uploadResponse.ok) throw new Error(`Upload failed with HTTP ${uploadResponse.status}`);
+    uploadedNames.add(filename);
     listed = await fetchSupernoteDirectory(ip, testDirectory, directoryLeafName);
 }
 
@@ -128,7 +135,11 @@ for (const file of deviceFiles) {
         pathLeafName: file.name,
     });
     if (!response.ok) throw new Error(`Download failed for ${file.name} with HTTP ${response.status}`);
-    deviceHashes.set(file.uri, createHash('sha256').update(new Uint8Array(await response.arrayBuffer())).digest('hex'));
+    const deviceHash = createHash('sha256').update(new Uint8Array(await response.arrayBuffer())).digest('hex');
+    if (uploadedNames.has(file.name) && deviceHash !== fixtureHash) {
+        console.log(`Device migrated ${file.name} during import; syncing its device-served bytes.`);
+    }
+    deviceHashes.set(file.uri, deviceHash);
 }
 
 const settings = {
@@ -162,5 +173,5 @@ for (const file of deviceFiles) {
     }
 }
 
-console.log(`PASS: actual plugin upload, listing, filter, download, and sync code transferred ${deviceFiles.length} naming cases byte-for-byte.`);
+console.log(`PASS: actual plugin upload, listing, filter, download, and sync code mirrored ${deviceFiles.length} device-served naming cases byte-for-byte.`);
 console.log(`The fixture files remain in ${testDirectory}; remove them manually when finished.`);

--- a/src/FileListModal.test.ts
+++ b/src/FileListModal.test.ts
@@ -162,5 +162,11 @@ describe('scanDeviceSupernoteTree entry trust (GHSA-3gx3-r874-5pp4 follow-up)', 
         const files = await scanDeviceSupernoteTree('192.168.1.50');
 
         expect(files[0].directoryNames).toEqual(['Note', 'test dir']);
+        expect(fetchFromDevice).toHaveBeenLastCalledWith(
+            '192.168.1.50',
+            '/Note/test+dir',
+            'Failed to load file list',
+            { pathLeafName: 'test dir', pathDirectoryNames: ['Note'] },
+        );
     });
 });

--- a/src/FileListModal.ts
+++ b/src/FileListModal.ts
@@ -29,8 +29,13 @@ interface SupernoteResponse {
 // Fetches and parses one directory listing from the Supernote "Browse and
 // Access" HTTP server. Shared by the file-browsing modals below and by
 // ImportTodayModal, which walks the whole tree looking for today's notes.
-export async function fetchSupernoteDirectory(ip: string, path: string, pathLeafName?: string): Promise<SupernoteFile[]> {
-    const response = await fetchFromDevice(ip, path, 'Failed to load file list', { pathLeafName });
+export async function fetchSupernoteDirectory(
+    ip: string,
+    path: string,
+    pathLeafName?: string,
+    pathDirectoryNames?: readonly string[],
+): Promise<SupernoteFile[]> {
+    const response = await fetchFromDevice(ip, path, 'Failed to load file list', { pathLeafName, pathDirectoryNames });
     if (!response.ok) {
         throw new Error(`Failed to load file list: Supernote responded with an error (status ${response.status}).`);
     }
@@ -65,7 +70,12 @@ export async function scanDeviceSupernoteTree(
     visited.add(path);
     if (!directoryNamesByUri.has(path)) directoryNamesByUri.set(path, directoryNames);
 
-    const entries = await fetchSupernoteDirectory(ip, path, pathLeafName);
+    const entries = await fetchSupernoteDirectory(
+        ip,
+        path,
+        pathLeafName,
+        directoryNames.length > 0 ? directoryNames.slice(0, -1) : undefined,
+    );
     const results: SupernoteFile[] = [];
 
     for (const entry of entries) {

--- a/src/ImportTodayModal.ts
+++ b/src/ImportTodayModal.ts
@@ -170,6 +170,7 @@ export class ImportTodayModal extends Modal {
                 const response = await fetchFromDevice(ip, file.uri, `Failed to download ${file.name}`, {
                     timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS,
                     pathLeafName: file.name,
+                    pathDirectoryNames: file.directoryNames,
                 });
                 if (!response.ok) {
                     throw new Error(`Failed to download ${file.name}: Supernote responded with an error (status ${response.status}).`);

--- a/src/deviceFetch.test.ts
+++ b/src/deviceFetch.test.ts
@@ -194,6 +194,14 @@ describe('fetchFromDevice', () => {
             expect(requestUrl).toHaveBeenLastCalledWith(
                 expect.objectContaining({ url: 'http://192.168.1.50:8089/Note/Substack%20Notes.note' }),
             );
+
+            await fetchFromDevice('192.168.1.50', '/Note/test+dir/a+b.note', 'Failed to download file', {
+                pathLeafName: 'a b.note',
+                pathDirectoryNames: ['Note', 'test dir'],
+            });
+            expect(requestUrl).toHaveBeenLastCalledWith(
+                expect.objectContaining({ url: 'http://192.168.1.50:8089/Note/test%20dir/a%20b.note' }),
+            );
         });
     });
 });

--- a/src/deviceFetch.ts
+++ b/src/deviceFetch.ts
@@ -33,6 +33,8 @@ export type DeviceRequestInit = Pick<RequestUrlParam, 'method' | 'body' | 'conte
     timeoutMs?: number;
     /** Display name from the listing, used to distinguish literal `+` from a space. */
     pathLeafName?: string;
+    /** Listing display names for every parent directory of the requested path. */
+    pathDirectoryNames?: readonly string[];
 };
 
 // `requestUrl`'s body can only be a string or ArrayBuffer (no FormData/Blob
@@ -67,7 +69,7 @@ export async function fetchFromDevice(
     context: string,
     init: DeviceRequestInit = {},
 ): Promise<DeviceResponse> {
-    const { timeoutMs = DEVICE_REQUEST_TIMEOUT_MS, pathLeafName, ...requestInit } = init;
+    const { timeoutMs = DEVICE_REQUEST_TIMEOUT_MS, pathLeafName, pathDirectoryNames, ...requestInit } = init;
 
     // Pin the request to the device host: `path` comes from parsed device
     // directory listings, so a hostile or impersonating device controls its
@@ -78,7 +80,7 @@ export async function fetchFromDevice(
     // A leading "/" terminates the authority right after the port, so the
     // host can never be escaped. Normalizing (prefixing) rather than
     // rejecting keeps odd-but-benign listings from real devices working.
-    const requestPath = encodeDeviceRequestPath(path, pathLeafName);
+    const requestPath = encodeDeviceRequestPath(path, pathLeafName, pathDirectoryNames);
 
     let timeoutHandle: ReturnType<typeof window.setTimeout>;
     const timeout = new Promise<never>((_, reject) => {

--- a/src/devicePath.test.ts
+++ b/src/devicePath.test.ts
@@ -41,4 +41,12 @@ describe('encodeDeviceRequestPath', () => {
         expect(encodeDeviceRequestPath('/Note/C++.note', 'C++.note')).toBe('/Note/C%2B%2B.note');
         expect(encodeDeviceRequestPath('/Note/Substack+Notes.note', 'Substack Notes.note')).toBe('/Note/Substack%20Notes.note');
     });
+
+    it('uses display names for form-style spaces in parent directories', () => {
+        expect(encodeDeviceRequestPath(
+            '/Note/test+dir/a+b.note',
+            'a b.note',
+            ['Note', 'test dir'],
+        )).toBe('/Note/test%20dir/a%20b.note');
+    });
 });

--- a/src/devicePath.ts
+++ b/src/devicePath.ts
@@ -32,13 +32,22 @@ export function decodeDevicePathVariants(path: string): string[] {
 }
 
 /**
- * Percent-encodes every path segment for an HTTP request. `expectedLeafName`,
- * when available from a directory listing, disambiguates a literal `+` from
- * the Supernote server's non-standard `+`-for-space form.
+ * Percent-encodes every path segment for an HTTP request. Listing display
+ * names, when available, disambiguate a literal `+` from the Supernote
+ * server's non-standard `+`-for-space form.
  */
-export function encodeDeviceRequestPath(path: string, expectedLeafName?: string): string {
+export function encodeDeviceRequestPath(
+    path: string,
+    expectedLeafName?: string,
+    expectedDirectoryNames?: readonly string[],
+): string {
     const withLeadingSlash = path.startsWith('/') ? path : `/${path}`;
     const segments = withLeadingSlash.split('/');
+    // Directory display names must describe every non-leaf segment. Applying a
+    // partial list at the wrong depth could turn a literal `+` into a space.
+    const directoryNames = expectedDirectoryNames?.length === segments.length - 2
+        ? expectedDirectoryNames.map(normalizeDeviceFileName)
+        : undefined;
     return segments
         .map((segment, index) => {
             if (index === 0 && segment === '') return '';
@@ -47,8 +56,10 @@ export function encodeDeviceRequestPath(path: string, expectedLeafName?: string)
             const standard = decodeDevicePathSegment(segment);
             const formStyle = decodeDeviceFormPathSegment(segment);
             const isLeaf = index === segments.length - 1;
-            const expected = expectedLeafName === undefined ? undefined : normalizeDeviceFileName(expectedLeafName);
-            const decoded = isLeaf && expected !== undefined && formStyle === expected && standard !== expected
+            const expected = isLeaf
+                ? expectedLeafName === undefined ? undefined : normalizeDeviceFileName(expectedLeafName)
+                : directoryNames?.[index - 1];
+            const decoded = expected !== undefined && formStyle === expected && standard !== expected
                 ? formStyle
                 : standard;
             return encodeURIComponent(decoded);

--- a/src/syncEngine.ts
+++ b/src/syncEngine.ts
@@ -135,6 +135,7 @@ export async function runDeviceSync(
             const response = await fetchFromDevice(ip, listing.uri, `Failed to download ${deviceFile.name}`, {
                 timeoutMs: DEVICE_TRANSFER_TIMEOUT_MS,
                 pathLeafName: deviceFile.name,
+                pathDirectoryNames: deviceFile.directoryNames,
             });
             if (!response.ok) {
                 throw new Error(`Supernote responded with status ${response.status}`);


### PR DESCRIPTION
Fixes sync downloads from device folders whose listing URI represents spaces as `+`.

For `/Note/test+dir/a+b.note`, the listing names establish the intended path as `test dir/a b.note`. Previously only the leaf name was used, producing `/Note/test%2Bdir/a%20b.note`; the device returned HTTP 200 with an empty body, which was written to the vault and later failed to parse with `Signature doesn’t match`.

The scanner now supplies display names for every parent directory to request-path encoding. The real-device test checks that every downloaded fixture starts with a valid Supernote signature, preventing empty-response false positives.

## Verified
- Real device: `SUPERNOTE_DEVICE_IP=100.103.149.40 SUPERNOTE_TEST_DIR="/Note/test dir" npm run test:device-sync`
- `npm test` — 258 passing
- `npm run build`
- `npm run lint` — 0 errors; existing warning in `src/atelierView.ts`