### PR TITLE
Preserve raster text overlays in worker renderers

### DIFF
--- a/plans/raster-overlay-worker-integration.md
+++ b/plans/raster-overlay-worker-integration.md
@@ -1,0 +1,159 @@
+# Raster-overlay worker integration plan
+
+## Goal
+
+Adopt `supernote-typescript` PR #118 (`5a07da8`,
+`fix/raster-text-overlay-api`) in the plugin's worker render pipelines. When
+vector ink replaces ordinary raster ink, preserve `DISABLE` text-box and Digest
+regions as a transparent raster overlay painted **after** the vector paths.
+
+This must apply to every plugin presentation that currently replaces bitmap ink
+with vectors:
+
+1. normal on-screen/image-export SVG rendering (`rasterize.worker.ts`),
+2. PDF export (`pdfBuild.worker.ts`), and
+3. write-on playback, whose background-only renderer currently removes the
+   bitmap-only regions altogether.
+
+Pages which remain raster (vector ink disabled or an unsuccessful vector decode)
+must retain their existing single-raster rendering unchanged. Do not render or
+transfer an overlay for ordinary vector pages with no `DISABLE` data.
+
+## Upstream dependency
+
+- Advance the `supernote-typescript` gitlink to PR #118's merged commit.
+- Replace the legacy `buildRenderNoteForVectorInk()` use in worker preparation
+  with the public pair:
+  - `buildVectorInkBackgroundNote(note, vectorInkPages)` for the raster below
+    paths; and
+  - `buildRasterInkOverlayNote(note, vectorInkPages)` for text-box/Digest-only
+    pixels above paths.
+- Keep `prepareVectorInkPages()` on the main thread. Worker slices deliberately
+  omit `TOTALPATH` and note titles, so decoding there is invalid.
+
+## Raster/SVG worker path
+
+### `src/render/imageConverter.ts`
+
+1. Generalize the worker-pool input from `SupernoteX` where necessary to the
+   structural note type accepted by `extractPageRenderData()`, so it can slice
+   the derived background and overlay notes without reconstructing a parsed
+   note instance.
+2. In `convertToImages(..., vectorInk: true)`, prepare per-page vector data as
+   today, derive a background note, and pass that background note to the pool.
+   The background helper, unlike the legacy helper, removes even retained
+   `DISABLE` pixels from the base image.
+3. Detect the small subset of requested vectorized pages whose source `DISABLE`
+   field can require a bitmap overlay. Only for that subset, derive the raster
+   overlay note and extract matching worker-safe page slices. Preserve both the
+   original requested-page order and local chunk indexes so a returned overlay
+   cannot be applied to the wrong page.
+4. Extend `processPages()`/`processChunk()` and `RasterizeWorkerMessage` with an
+   optional overlay payload containing (a) the sliced overlay note and (b) the
+   indexes of its pages in the base chunk. This avoids cloning or rasterizing a
+   transparent full-page overlay for every normal handwritten page.
+5. Retire the worker's hand-written `INK_LAYER_NAMES` mutation for vector
+   rendering: the main-thread background note is now the authoritative,
+   PR-#118-defined split. The worker rasterizes the supplied base slice; when
+   an overlay payload exists, it rasterizes that smaller note once and maps the
+   images back to their base-page indexes.
+6. For `useVectorInk` pages, pass the base image, strokes/styles, and mapped
+   `overlayImage` to `addSvgPage(..., { includeText: false, ... })`. This keeps
+   SVG order as background `<image>` → vector paths →
+   `data-raster-ink-overlay` `<image>`. Raster fallback pages continue to
+   return a PNG data URL.
+
+## PDF worker path
+
+### `src/main.ts`
+
+1. In `buildPdfInWorker()`, derive background slices from
+   `buildVectorInkBackgroundNote()` instead of the legacy render note.
+2. Build and slice the raster-overlay note only for vectorized `DISABLE` pages.
+   Add the overlay pages plus their original global page indexes to the PDF
+   worker message, alongside the existing parallel strokes/style arrays.
+3. Leave non-vector and vector-disabled exports on their current raster path;
+   omit the optional overlay payload when no page needs it.
+
+### `src/pdfBuild.worker.ts`
+
+1. Extend `PdfBuildWorkerMessage` with the optional overlay page slices and
+   their global indexes. Define/document that both arrays are parallel.
+2. For each bounded assembly batch, select only overlay slices belonging to
+   that batch, rasterize them as a compact overlay note, and map their images
+   back to the batch's global page indexes.
+3. Continue flattening only the opaque background image for `addPdfPage()`.
+   Pass the transparent overlay image separately as `overlayImage`; flattening
+   it would destroy its alpha and cover the page.
+4. Call `addPdfPage()` with its existing vector strokes/styles and the mapped
+   overlay. Its established draw order is base raster → vector primitives →
+   overlay → invisible recognition text.
+
+## Write-on playback
+
+### Worker/image-converter contract
+
+1. Add a dedicated animation-layer conversion method (or equivalent typed
+   result) which returns an ordered `{ backgroundUrl, overlayUrl? }` pair for
+   each requested animatable page. Keep the existing simple background-only
+   method if other callers require its `string[]` contract.
+2. Use the same vector-page preparation and PR-#118 background/filtered-overlay
+   note split as static SVG rendering. Mark the base pages `backgroundOnly` so
+   the raster worker returns PNG bases instead of constructing static SVGs.
+3. Extend `RasterizeWorkerResponse` to return optional overlay data aligned to
+   the requested page indexes. It must omit absent overlays rather than return
+   a transparent image for every page.
+
+### `src/webcomponent/SupernoteViewerElement.ts`
+
+1. Change the overridable write-on rasterizer hook and its tests to consume the
+   background/overlay pairs.
+2. Keep the background in the existing page `<img>`, append the animated SVG,
+   then append an optional raster-overlay `<img>` above that SVG. Give the
+   overlay the same absolute sizing, `pointer-events: none`, and dark-mode
+   inversion class behavior as the stroke SVG.
+3. Bitmap-only text/Digest content is static rather than time-addressable, so
+   show it from playback start. Its position above the SVG preserves the
+   device's layering when an animated marker/highlighter passes behind it.
+4. Track and remove these overlay elements when switching back to static mode,
+   rerendering, or cancelling write-on preparation so the normal lazy image
+   lifecycle remains the sole owner in static presentation.
+
+## Tests
+
+Use the upstream `textbox-n5-20260016-digest.note` fixture, especially page 4
+(the large text box) and page 5 (Digest rectangles), in addition to the
+existing ordinary vector-ink fixture.
+
+1. Update `src/rasterizeVectorInk.test.ts` to replay the new worker contract:
+   derive the background and overlay notes, rasterize slices, and pass both to
+   `addSvgPage()`. Assert the page vectorizes, contains paths and
+   `data-raster-ink-overlay="true"`, and emits the overlay after the paths.
+   Retain the vector-off/fallback assertions to prove the ordinary raster path
+   did not change.
+2. Update `src/pdfBuild.test.ts` to verify derived background slices remove
+   vectorizable ink while the overlay slice retains the `DISABLE` region, and
+   that worker-bound strokes/styles and overlay indexes stay aligned. Include a
+   no-overlay vector fixture assertion so normal pages do not opt into the
+   second render.
+3. Extend the web-component write-on tests with a fake layer result containing
+   an overlay URL. Assert DOM order (base image, animation SVG, overlay image),
+   dark-mode tagging, and cleanup after returning to static presentation. Keep
+   existing no-overlay assertions working with no extra `<img>`.
+4. Run the plugin suite (`npm test`), typecheck/bundles (`npm run build` and
+   `npm run build:webcomponent`), and `npm run lint`. Run the submodule suite
+   at the pinned commit before recording its gitlink update.
+5. Manually inspect the textbox/Digest fixture in normal vector mode, exported
+   PDF, and write-on mode: text must remain visible, vector highlighter/ink
+   must stay crisp, and the text must sit above any crossing vector path.
+
+## Completion criteria
+
+- The outer repository pins the PR #118 commit.
+- Static SVG and PDF workers use the public background/overlay builders, not
+  ad-hoc bitmap-layer clearing.
+- Overlay work is conditional and index-safe across worker chunks/batches.
+- A `DISABLE` text box/Digest survives static vector rendering, PDF export,
+  and write-on playback in the correct paint order.
+- Existing raster fallback, thumbnail/downsample, and vector-disabled behavior
+  remains byte-for-byte/functionally unchanged.

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import { ImportTodayModal } from './ImportTodayModal';
 import { ErrorModal } from './ErrorModal';
 import { PdfBuildWorkerMessage, PdfBuildWorkerResponse } from './pdfBuild.worker';
 import PdfBuildWorker from 'pdfBuild.worker';
-import { ImageConverter, terminateSharedWorkerPool } from './render/imageConverter';
+import { ImageConverter, pageMayNeedRasterOverlay, terminateSharedWorkerPool } from './render/imageConverter';
 // Side-effect import: registers <supernote-viewer> (customElements.define)
 // - see SupernoteEmbed below, which is now a thin wrapper around it rather
 // than its own separate rendering implementation.
@@ -125,10 +125,9 @@ async function buildPdfInWorker(sn: SupernoteX, vectorInk: boolean): Promise<Uin
     // parallel/Worker path".
     const vectorInkPages = vectorInk ? prepareVectorInkPages(sn, pageNumbers, 1) : [];
     const backgroundNote = vectorInk ? buildVectorInkBackgroundNote(sn, vectorInkPages) : sn;
-    const overlayPageIndexes = vectorInkPages.flatMap((vip, index) => {
-        const disable = sn.pages[vip.pageNumber - 1]?.DISABLE;
-        return vip.useVectorInk && disable !== undefined && disable !== '' && disable !== 'none' ? [index] : [];
-    });
+    const overlayPageIndexes = vectorInkPages.flatMap((vip, index) =>
+        pageMayNeedRasterOverlay(sn, vip) ? [index] : [],
+    );
     const rasterOverlayNote = overlayPageIndexes.length > 0
         ? buildRasterInkOverlayNote(sn, vectorInkPages)
         : undefined;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { installAtPolyfill } from './polyfills';
 import { App, Modal, Notice, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, Component, Scope, Platform, setIcon } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS, ImportFormat, PageExportImageFormat } from './settings';
-import { SupernoteX, ILink, RecognitionStatuses, fetchMirrorFrame, extractPdfPageData, addSvgPage, prepareVectorInkPages, buildRenderNoteForVectorInk, toSvg } from 'supernote-typescript';
+import { SupernoteX, ILink, RecognitionStatuses, fetchMirrorFrame, extractPdfPageData, addSvgPage, prepareVectorInkPages, buildVectorInkBackgroundNote, buildRasterInkOverlayNote, toSvg } from 'supernote-typescript';
 import { encode } from 'image-js';
 import { DownloadListModal, UploadListModal } from './FileListModal';
 import { ImportTodayModal } from './ImportTodayModal';
@@ -117,17 +117,27 @@ async function buildPdfInWorker(sn: SupernoteX, vectorInk: boolean): Promise<Uin
     // When vectorInk is on, prepare the per-page vector strokes/styles on the
     // main thread: the worker only receives structured-clone-safe IPdfPage
     // slices (extractPdfPageData), which don't carry the TOTALPATH buffer or
-    // note.titles the vector-ink decode reads. buildRenderNoteForVectorInk
-    // returns a copy of `sn` with the bitmap ink layers stripped from every
-    // page whose ink the vectors replace, so extractPdfPageData slices that
-    // stripped note and the worker's toImage() rasterizes only the
-    // background for those pages - addPdfPage() then draws the strokes on top.
+    // note.titles the vector-ink decode reads. The upstream background/overlay
+    // pair leaves templates below the vector paths and keeps bitmap-only
+    // DISABLE text boxes/Digests for a transparent image painted afterward.
     // Coordinates share toImage()'s native page-pixel space (this export never
     // upscales). See supernote-typescript's README, "Vector ink from the
     // parallel/Worker path".
     const vectorInkPages = vectorInk ? prepareVectorInkPages(sn, pageNumbers, 1) : [];
-    const renderNote = vectorInk ? buildRenderNoteForVectorInk(sn, vectorInkPages) : sn;
-    const pages = pageNumbers.map((n) => extractPdfPageData(renderNote, n).pages[0]);
+    const backgroundNote = vectorInk ? buildVectorInkBackgroundNote(sn, vectorInkPages) : sn;
+    const overlayPageIndexes = vectorInkPages.flatMap((vip, index) => {
+        const disable = sn.pages[vip.pageNumber - 1]?.DISABLE;
+        return vip.useVectorInk && disable !== undefined && disable !== '' && disable !== 'none' ? [index] : [];
+    });
+    const rasterOverlayNote = overlayPageIndexes.length > 0
+        ? buildRasterInkOverlayNote(sn, vectorInkPages)
+        : undefined;
+    const pages = pageNumbers.map((n) => extractPdfPageData(backgroundNote, n).pages[0]);
+    // Sent as compact, global-indexed slices rather than a transparent overlay
+    // for every vector page. The worker maps them back into its 8-page batches.
+    const rasterOverlayPages = rasterOverlayNote
+        ? overlayPageIndexes.map((index) => extractPdfPageData(rasterOverlayNote, pageNumbers[index]).pages[0])
+        : undefined;
     // Parallel to `pages` by position; undefined entries fall back to the
     // raster the worker already embedded (addPdfPage no-ops on empty/absent
     // strokes), so a page whose ink didn't decode keeps its rasterized ink.
@@ -149,6 +159,8 @@ async function buildPdfInWorker(sn: SupernoteX, vectorInk: boolean): Promise<Uin
                 pages,
                 strokes,
                 strokeStyles,
+                rasterOverlayPages,
+                rasterOverlayPageIndexes: rasterOverlayPages ? overlayPageIndexes : undefined,
                 // The note's device family + native pageWidth drive the
                 // recognition-coordinate scale of the invisible text layer
                 // (N6/A6X use their own pageWidth as the recognition canvas,

--- a/src/pdfBuild.test.ts
+++ b/src/pdfBuild.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 //
 // Verifies the vectorInk wiring in buildPdfInWorker() - that the main-thread
-// prep (prepareVectorInkPages + buildRenderNoteForVectorInk) actually strips
+// prep (prepareVectorInkPages + buildVectorInkBackgroundNote) actually strips
 // the bitmap ink layers from vector-replaced pages and produces non-empty
 // strokes/styles for exactly those pages, and that the off path leaves the
 // note untouched.
@@ -23,7 +23,8 @@ import * as path from 'path';
 import {
     SupernoteX,
     prepareVectorInkPages,
-    buildRenderNoteForVectorInk,
+    buildVectorInkBackgroundNote,
+    buildRasterInkOverlayNote,
 } from 'supernote-typescript';
 
 // One '..' (not two like src/render/* and src/webcomponent/* tests use): this
@@ -57,7 +58,7 @@ describe('buildPdfInWorker vectorInk wiring', () => {
         const pageNumbers = Array.from({ length: sn.pages.length }, (_, i) => i + 1);
 
         const vectorInkPages = prepareVectorInkPages(sn, pageNumbers, 1);
-        const renderNote = buildRenderNoteForVectorInk(sn, vectorInkPages);
+        const renderNote = buildVectorInkBackgroundNote(sn, vectorInkPages);
 
         // At least one page must have decided to use vector ink for the
         // rest of this test to mean anything.
@@ -88,6 +89,28 @@ describe('buildPdfInWorker vectorInk wiring', () => {
                 }
             }
         }
+    });
+
+    it('keeps bitmap-only DISABLE pixels in an overlay above the PDF vectors', () => {
+        const sn = new SupernoteX(readFixture('textbox-n5-20260016-digest.note'));
+        const pageNumber = 4;
+        const vectorInkPages = prepareVectorInkPages(sn, [pageNumber], 1);
+        const vip = vectorInkPages[0];
+        expect(vip.useVectorInk).toBe(true);
+
+        const background = buildVectorInkBackgroundNote(sn, vectorInkPages);
+        const overlay = buildRasterInkOverlayNote(sn, vectorInkPages);
+        // The vector background has no ordinary bitmap ink. The separately
+        // sent overlay retains the text-box pixels from MAINLAYER so the PDF
+        // worker can hand it to addPdfPage() after the vector primitives.
+        expect(background.pages[pageNumber - 1].MAINLAYER.bitmapBuffer).toBeNull();
+        expect(overlay.pages[pageNumber - 1].MAINLAYER.bitmapBuffer).not.toBeNull();
+
+        const overlayPageIndexes = vectorInkPages.flatMap((page, index) => {
+            const disable = sn.pages[page.pageNumber - 1].DISABLE;
+            return page.useVectorInk && disable !== undefined && disable !== '' && disable !== 'none' ? [index] : [];
+        });
+        expect(overlayPageIndexes).toEqual([0]);
     });
 
     it('builds non-empty strokes/strokeStyles for exactly the useVectorInk pages', () => {
@@ -128,7 +151,7 @@ describe('buildPdfInWorker vectorInk wiring', () => {
         for (const page of sn.pages) {
             for (const layerName of INK_LAYERS) {
                 // Whatever the note carries, the off path carries it too:
-                // buildRenderNoteForVectorInk is never called, so nothing
+                // buildVectorInkBackgroundNote is never called, so nothing
                 // is nulled. Only assert for layers the note actually has.
                 const buf = page[layerName]?.bitmapBuffer;
                 if (buf) {

--- a/src/pdfBuild.worker.ts
+++ b/src/pdfBuild.worker.ts
@@ -33,6 +33,11 @@ export type PdfBuildWorkerMessage =
         pages: IPdfPage[];
         strokes?: (IStroke[] | undefined)[];
         strokeStyles?: (StrokeStyle[] | undefined)[];
+        // The small subset of transparent text-box/Digest overlay pages.
+        // These are parallel: each page belongs at the corresponding global
+        // index in rasterOverlayPageIndexes, not at this array's own index.
+        rasterOverlayPages?: IPdfPage[];
+        rasterOverlayPageIndexes?: number[];
         // Device family (`header.APPLY_EQUIPMENT`) and native pageWidth for
         // the invisible recognition-text layer's coordinate scale — see
         // recognitionCoordinateScale in supernote-typescript. N6/A6X use
@@ -98,6 +103,28 @@ self.onmessage = async (e: MessageEvent<PdfBuildWorkerMessage>) => {
             const batch = data.pages.slice(start, start + PDF_ASSEMBLY_BATCH_SIZE);
             const note: IRenderableNote = { pageWidth: data.pageWidth, pageHeight: data.pageHeight, pages: batch };
             const images = await toImage(note);
+            // The main thread sends only pages that actually carry a
+            // bitmap-only DISABLE overlay. Select this batch's compact subset
+            // and retain its global indexes so an overlay never drifts to a
+            // neighboring PDF page.
+            const overlayEntries = data.rasterOverlayPages?.flatMap((page, i) => {
+                const pageIndex = data.rasterOverlayPageIndexes?.[i];
+                return pageIndex !== undefined && pageIndex >= start && pageIndex < start + batch.length
+                    ? [{ page, pageIndex }]
+                    : [];
+            }) ?? [];
+            const overlayImages = overlayEntries.length > 0
+                ? await toImage({
+                    pageWidth: data.pageWidth,
+                    pageHeight: data.pageHeight,
+                    pages: overlayEntries.map((entry) => entry.page),
+                })
+                : [];
+            const overlayByPageIndex = new Map<number, NonNullable<typeof overlayImages>[number]>();
+            overlayEntries.forEach((entry, i) => {
+                const image = overlayImages[i];
+                if (image) overlayByPageIndex.set(entry.pageIndex, image);
+            });
             for (let i = 0; i < batch.length; i++) {
                 // flattenToWhite(), not just discarding the alpha
                 // channel: background/unwritten pixels are packed with
@@ -118,6 +145,10 @@ self.onmessage = async (e: MessageEvent<PdfBuildWorkerMessage>) => {
                     // no-ops on empty/absent strokes either way.
                     strokes: data.strokes?.[start + i],
                     strokeStyles: data.strokeStyles?.[start + i],
+                    // Deliberately not flattenToWhite(): this PNG is
+                    // transparent outside DISABLE regions and must remain so
+                    // when addPdfPage paints it after the vector primitives.
+                    overlayImage: overlayByPageIndex.get(start + i),
                     equipment: data.equipment,
                     nativePageWidth: data.nativePageWidth,
                 });

--- a/src/rasterize.worker.ts
+++ b/src/rasterize.worker.ts
@@ -12,18 +12,25 @@ export { };
 // component (see src/render/imageConverter.ts, which is what actually talks
 // to this worker). Split out from what used to be one combined
 // myworker.worker.ts specifically so none of these consumers pull in pdf-lib
-// just because they used to share a Worker script with the plugin's
-// PDF export feature - confirmed via a real esbuild bundle-size check
-// (issue #183's standalone bundle) that they previously did, unconditionally,
-// even though the web component never sends the other worker's 'buildPdf'
-// message at all. See pdfBuild.worker.ts for that separate, plugin-only
-// concern.
+// just because they used to share a Worker script with the plugin's PDF export
+// feature - confirmed via a real esbuild bundle-size check (issue #183's
+// standalone bundle) that they previously did, unconditionally, even though
+// the web component never sends the other worker's 'buildPdf' message at all.
+// See pdfBuild.worker.ts for that separate, plugin-only concern.
 
-// The ink layers withoutInkLayers/buildRenderNoteForVectorInk null on the
-// full note; here, on the per-page slice, the same names. BGLAYER
-// (background) is deliberately not in this list — it's what toImage
-// rasterizes to sit beneath the vector strokes.
+// Kept only for the legacy backgroundOnly-only request. Vector-ink requests
+// now arrive as the public buildVectorInkBackgroundNote() output, rather than
+// reimplementing that split by mutating worker-local slices.
 const INK_LAYER_NAMES = ['MAINLAYER', 'LAYER1', 'LAYER2', 'LAYER3'] as const;
+
+export interface RasterOverlayPages {
+    // Contains only the pages with a bitmap-only text-box/Digest overlay,
+    // rather than a transparent full-page image for every vectorized page.
+    note: IRenderableNote;
+    // Indexes into the enclosing convert message's note.pages array; aligned
+    // with note.pages above.
+    pageIndexes: number[];
+}
 
 export type RasterizeWorkerMessage =
     // `note` is always the minimal per-page slice built by
@@ -34,27 +41,31 @@ export type RasterizeWorkerMessage =
     // page in the given note, which here is exactly the ones asked for.
     //
     // `vectorInk`, when present, is a parallel array aligned by index with
-    // note.pages. For a page whose entry has useVectorInk true, the worker
-    // nulls that page's bitmap ink layers (so toImage rasterizes only the
-    // background) and assembles an SVG via addSvgPage with the entry's
-    // strokes/strokeStyles drawn as vector paths on top, returned as an
-    // image/svg+xml data URL. A page with useVectorInk false (or no entry)
-    // returns a PNG data URL as before. Only sent for full-res renders
-    // (scale undefined) — downsampled thumbnails keep the raster path since
-    // vector coordinates don't survive a downsample.
+    // note.pages. imageConverter prepares the background note on the main
+    // thread with buildVectorInkBackgroundNote(), because the worker slices
+    // lack the TOTALPATH/title data needed to do that safely. For a page whose
+    // entry has useVectorInk true, this worker assembles an SVG with the
+    // background raster and vector paths. `rasterOverlay`, if present, holds
+    // only the matching text-box/Digest rasters, which addSvgPage paints after
+    // the paths. A fallback page still returns a PNG as before.
     //
-    // `backgroundOnly`, when present, is a parallel boolean array aligned
-    // by index with note.pages. A page whose entry is true has its bitmap
-    // ink layers nulled exactly as above but returns a plain PNG data URL
-    // (no addSvgPage) — the bare paper/ruling/background with the ink
-    // stripped, for callers that supply their own ink. That's the
-    // web component's write-on stroke animation mode (see
-    // src/webcomponent/strokeAnimation.ts), which draws the strokes itself,
-    // one at a time, over the returned base layer.
-    { type: 'convert'; note: IRenderableNote; scale?: number; vectorInk?: VectorInkPage[]; backgroundOnly?: boolean[] };
+    // `backgroundOnly` requests plain PNG bases for write-on playback. Its
+    // vector pages are likewise already pre-split by imageConverter; the
+    // response carries their optional overlay data URLs separately so the
+    // component can position them above the animated SVG. The no-vectorInk
+    // variant retains the historical "strip all bitmap ink" behavior used by
+    // convertToBackgroundImages().
+    {
+        type: 'convert';
+        note: IRenderableNote;
+        scale?: number;
+        vectorInk?: VectorInkPage[];
+        backgroundOnly?: boolean[];
+        rasterOverlay?: RasterOverlayPages;
+    };
 
 export type RasterizeWorkerResponse =
-    | { type: 'result'; images: string[] }
+    | { type: 'result'; images: string[]; rasterOverlays?: (string | undefined)[] }
     | { type: 'error'; error: string };
 
 self.onmessage = async (e: MessageEvent<RasterizeWorkerMessage>) => {
@@ -63,34 +74,38 @@ self.onmessage = async (e: MessageEvent<RasterizeWorkerMessage>) => {
         const vectorInk = data.vectorInk;
         const backgroundOnly = data.backgroundOnly;
 
-        // Strip the bitmap ink layers from each vector-ink page (and each
-        // background-only page — same strip, plain-PNG result, see the
-        // `backgroundOnly` comment on the message type) *before* toImage,
-        // so the raster it produces for those pages is the background only —
-        // the vector strokes (carried alongside in the VectorInkPage entry)
-        // are drawn on top by addSvgPage below. Doing this on the slice
-        // (rather than via buildRenderNoteForVectorInk on the whole note)
-        // keeps the sliced-send memory model from imageConverter.ts intact:
-        // the worker never sees the full SupernoteX.
-        if (vectorInk || backgroundOnly) {
+        // Compatibility path for callers asking for a bare background without
+        // vector page metadata. Vector-ink callers receive a pre-split
+        // background note instead, which is essential to keep DISABLE pixels
+        // out of the base raster and available for the later overlay.
+        if (backgroundOnly && !vectorInk) {
             for (let i = 0; i < data.note.pages.length; i++) {
-                if (!vectorInk?.[i]?.useVectorInk && !backgroundOnly?.[i]) continue;
+                if (!backgroundOnly[i]) continue;
                 const page = data.note.pages[i];
                 for (const name of INK_LAYER_NAMES) {
                     const layer = page[name];
-                    if (layer) {
-                        page[name] = { ...layer, bitmapBuffer: null };
-                    }
+                    if (layer) page[name] = { ...layer, bitmapBuffer: null };
                 }
             }
         }
 
         const results = await toImage(data.note, undefined, { scale: data.scale });
+        const overlayResults = data.rasterOverlay
+            ? await toImage(data.rasterOverlay.note, undefined, { scale: data.scale })
+            : undefined;
+        const overlayByPageIndex = new Map<number, NonNullable<typeof overlayResults>[number]>();
+        if (overlayResults && data.rasterOverlay) {
+            data.rasterOverlay.pageIndexes.forEach((pageIndex, i) => {
+                const overlay = overlayResults[i];
+                if (overlay) overlayByPageIndex.set(pageIndex, overlay);
+            });
+        }
+
         const images = results.map((result, i) => {
             const vip = vectorInk?.[i];
-            if (vip?.useVectorInk) {
-                // addSvgPage embeds the background PNG as a base64 <image>
-                // and draws the strokes as vector <path>s on top.
+            // A write-on page owns its vector SVG separately, so its worker
+            // result remains the plain pre-split background PNG.
+            if (vip?.useVectorInk && !backgroundOnly?.[i]) {
                 // includeText: false — this plugin's find-in-note uses its
                 // own wordOverlay (src/render/wordOverlay.ts), not an SVG
                 // text layer, so the bytes would be dead weight here.
@@ -103,7 +118,12 @@ self.onmessage = async (e: MessageEvent<RasterizeWorkerMessage>) => {
                     result,
                     data.note.pageWidth,
                     data.note.pageHeight,
-                    { strokes: vip.strokes, strokeStyles: vip.styles, includeText: false },
+                    {
+                        strokes: vip.strokes,
+                        strokeStyles: vip.styles,
+                        overlayImage: overlayByPageIndex.get(i),
+                        includeText: false,
+                    },
                 );
                 // addSvgPage returns a raw SVG string; wrap it as a data
                 // URL so it drops into an <img src> the same way the PNG
@@ -114,7 +134,13 @@ self.onmessage = async (e: MessageEvent<RasterizeWorkerMessage>) => {
             }
             return encodeDataURL(result);
         });
-        const response: RasterizeWorkerResponse = { type: 'result', images };
+        const rasterOverlays = overlayResults
+            ? results.map((_, i) => {
+                const overlay = overlayByPageIndex.get(i);
+                return overlay ? encodeDataURL(overlay) : undefined;
+            })
+            : undefined;
+        const response: RasterizeWorkerResponse = { type: 'result', images, rasterOverlays };
         self.postMessage(response);
     } catch (error) {
         const response: RasterizeWorkerResponse = {

--- a/src/rasterizeVectorInk.test.ts
+++ b/src/rasterizeVectorInk.test.ts
@@ -16,6 +16,7 @@
 // feeds the on-screen note view and image export.
 import { describe, expect, it } from 'vitest';
 import * as fs from 'fs';
+import { pageMayNeedRasterOverlay } from './render/imageConverter';
 import * as path from 'path';
 import {
     SupernoteX,
@@ -102,6 +103,21 @@ describe('rasterize worker vectorInk wiring', () => {
         expect(svg).toContain('data-raster-ink-overlay="true"');
         expect(svg.indexOf('<path')).toBeLessThan(svg.indexOf('data-raster-ink-overlay="true"'));
     }, 30000);
+
+    it('routes a typeset PDF-link label to the overlay without a DISABLE rectangle', () => {
+        const sn = new SupernoteX(readFixture('textbox-n5-20260016-digest.note'));
+        const pageNumber = 5;
+        // This makes the routing decision depend only on the FONTSIZE > 0
+        // label. The upstream builder derives its retained rectangle from
+        // note.links, not from this page's Digest DISABLE metadata.
+        sn.pages[pageNumber - 1].DISABLE = 'none';
+        const vip = prepareVectorInkPages(sn, [pageNumber], 1)[0];
+
+        expect(vip.useVectorInk).toBe(true);
+        expect(pageMayNeedRasterOverlay(sn, vip)).toBe(true);
+        const overlay = buildRasterInkOverlayNote(sn, [vip]);
+        expect(overlay.pages[pageNumber - 1].MAINLAYER.bitmapBuffer).not.toBeNull();
+    });
 
     it('leaves ink as a plain raster image (no vector <path>) when vectorInk is off', async () => {
         const sn = new SupernoteX(readFixture(VECTOR_INK_FIXTURE));

--- a/src/rasterizeVectorInk.test.ts
+++ b/src/rasterizeVectorInk.test.ts
@@ -21,6 +21,8 @@ import {
     SupernoteX,
     extractPageRenderData,
     prepareVectorInkPages,
+    buildVectorInkBackgroundNote,
+    buildRasterInkOverlayNote,
     toImage,
     addSvgPage,
 } from 'supernote-typescript';
@@ -38,29 +40,29 @@ function readFixture(name: string): Uint8Array {
     return new Uint8Array(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer);
 }
 
-// The ink layers the worker nulls on a vector-ink page's slice before
-// rasterizing — matches INK_LAYER_NAMES in rasterize.worker.ts.
-const INK_LAYER_NAMES = ['MAINLAYER', 'LAYER1', 'LAYER2', 'LAYER3'] as const;
-
-// Replays the worker's per-page logic: slice the page, strip ink layers if
-// vectorInk, rasterize, then assemble (SVG for vector pages, raw image for
-// the fallback). Returns the SVG string from addSvgPage (the meaningful
-// artifact; the btoa data-URL wrapping the worker does is trivial).
+// Replays the worker's per-page logic: derive the public vector background
+// and optional compact raster-overlay notes on the full parsed note, slice
+// them for the worker, rasterize, then assemble. Returns the SVG string from
+// addSvgPage (the meaningful artifact; the btoa data-URL wrapping the worker
+// does is trivial).
 async function renderPage(sn: SupernoteX, pageNumber: number, vectorInk: boolean): Promise<{ svg: string; strippedInk: boolean }> {
-    const slice = extractPageRenderData(sn, pageNumber).pages[0];
     const vip = vectorInk ? prepareVectorInkPages(sn, [pageNumber], 1)[0] : undefined;
     const useVector = vip?.useVectorInk ?? false;
-    if (useVector) {
-        for (const name of INK_LAYER_NAMES) {
-            const layer = slice[name];
-            if (layer) slice[name] = { ...layer, bitmapBuffer: null };
-        }
-    }
+    const vectorPages = vip ? [vip] : [];
+    const backgroundNote = useVector ? buildVectorInkBackgroundNote(sn, vectorPages) : sn;
+    const disable = sn.pages[pageNumber - 1].DISABLE;
+    const overlayNote = useVector && disable !== undefined && disable !== '' && disable !== 'none'
+        ? buildRasterInkOverlayNote(sn, vectorPages)
+        : undefined;
+    const slice = extractPageRenderData(backgroundNote, pageNumber).pages[0];
     const [image] = await toImage({
         pageWidth: sn.pageWidth,
         pageHeight: sn.pageHeight,
         pages: [slice],
     });
+    const [overlayImage] = overlayNote
+        ? await toImage(extractPageRenderData(overlayNote, pageNumber))
+        : [];
     const svg = addSvgPage(
         { ...slice, recognitionElements: [] },
         image,
@@ -69,6 +71,7 @@ async function renderPage(sn: SupernoteX, pageNumber: number, vectorInk: boolean
         {
             strokes: useVector ? vip!.strokes : undefined,
             strokeStyles: useVector ? vip!.styles : undefined,
+            overlayImage,
             includeText: false,
         },
     );
@@ -87,7 +90,18 @@ describe('rasterize worker vectorInk wiring', () => {
         // And the background <image> is still there beneath them.
         expect(svg).toContain('<image');
         expect(svg).toContain('</svg>');
+        expect(svg).not.toContain('data-raster-ink-overlay="true"');
     });
+
+    it('keeps bitmap-only text boxes above vector paths', async () => {
+        const sn = new SupernoteX(readFixture('textbox-n5-20260016-digest.note'));
+        const { svg, strippedInk } = await renderPage(sn, 4, true);
+
+        expect(strippedInk).toBe(true);
+        expect(svg).toContain('<path');
+        expect(svg).toContain('data-raster-ink-overlay="true"');
+        expect(svg.indexOf('<path')).toBeLessThan(svg.indexOf('data-raster-ink-overlay="true"'));
+    }, 30000);
 
     it('leaves ink as a plain raster image (no vector <path>) when vectorInk is off', async () => {
         const sn = new SupernoteX(readFixture(VECTOR_INK_FIXTURE));

--- a/src/render/imageConverter.ts
+++ b/src/render/imageConverter.ts
@@ -4,7 +4,14 @@
 // into a standalone web component). SupernoteEmbed/SupernoteView (main.ts)
 // are the Obsidian-side callers; this module itself only ever touches
 // standard Worker/DOM globals and supernote-typescript.
-import { SupernoteX, IRenderableNote, extractPageRenderData, prepareVectorInkPages } from 'supernote-typescript';
+import {
+    SupernoteX,
+    IRenderableNote,
+    extractPageRenderData,
+    prepareVectorInkPages,
+    buildVectorInkBackgroundNote,
+    buildRasterInkOverlayNote,
+} from 'supernote-typescript';
 import type { VectorInkPage } from 'supernote-typescript';
 import { RasterizeWorkerMessage, RasterizeWorkerResponse } from '../rasterize.worker';
 import Worker from 'rasterize.worker';
@@ -51,7 +58,12 @@ function chunkPageNumbers(pageNumbers: number[]): number[][] {
 // that neither DPR capping nor zoom-aware rasterization could ever have
 // addressed, since neither touches what gets sent to a Worker in the first
 // place.
-function extractPagesRenderData(note: SupernoteX, pageNumbers: number[]): IRenderableNote {
+// The public vector-ink builders return a structural note copy rather than a
+// SupernoteX instance, but extractPageRenderData() accepts that same full
+// parsed-note shape.
+type VectorInkRenderNote = ReturnType<typeof buildVectorInkBackgroundNote>;
+
+function extractPagesRenderData(note: VectorInkRenderNote, pageNumbers: number[]): IRenderableNote {
     return {
         pageWidth: note.pageWidth,
         pageHeight: note.pageHeight,
@@ -123,7 +135,15 @@ export class WorkerPool {
     // request in flight) and round-robining across every call (so
     // concurrent single-page requests still spread across every worker,
     // instead of piling onto worker 0) fixes both.
-    private processChunk(note: SupernoteX, pageNumbers: number[], scale?: number, vectorInkPages?: VectorInkPage[], backgroundOnly?: boolean[]): Promise<string[]> {
+    private processChunk(
+        note: VectorInkRenderNote,
+        pageNumbers: number[],
+        scale?: number,
+        vectorInkPages?: VectorInkPage[],
+        backgroundOnly?: boolean[],
+        rasterOverlayNote?: VectorInkRenderNote,
+        rasterOverlayPageNumbers?: ReadonlySet<number>,
+    ): Promise<RasterizedPageImage[]> {
         const workerIndex = this.nextWorker % this.workers.length;
         this.nextWorker++;
         const worker = this.workers[workerIndex];
@@ -132,13 +152,29 @@ export class WorkerPool {
         // extractPagesRenderData()'s comment for why sending the whole
         // `note` here was a real, serious memory bug (issue #154).
         const renderableNote = extractPagesRenderData(note, pageNumbers);
+        const overlayPageIndexes = rasterOverlayNote && rasterOverlayPageNumbers
+            ? pageNumbers.flatMap((pageNumber, index) => rasterOverlayPageNumbers.has(pageNumber) ? [index] : [])
+            : [];
+        const rasterOverlay = rasterOverlayNote && overlayPageIndexes.length > 0
+            ? {
+                note: extractPagesRenderData(
+                    rasterOverlayNote,
+                    overlayPageIndexes.map((index) => pageNumbers[index]),
+                ),
+                pageIndexes: overlayPageIndexes,
+            }
+            : undefined;
 
-        const send = (): Promise<string[]> => new Promise((resolve, reject) => {
+        const send = (): Promise<RasterizedPageImage[]> => new Promise((resolve, reject) => {
             worker.onmessage = (e: MessageEvent<RasterizeWorkerResponse>) => {
-                if (e.data.type === 'error') {
-                    reject(new Error(e.data.error));
-                } else if (e.data.type === 'result') {
-                    resolve(e.data.images);
+                const response = e.data;
+                if (response.type === 'error') {
+                    reject(new Error(response.error));
+                } else if (response.type === 'result') {
+                    resolve(response.images.map((imageDataUrl, i) => ({
+                        imageDataUrl,
+                        rasterOverlayDataUrl: response.rasterOverlays?.[i],
+                    })));
                 }
             };
 
@@ -153,6 +189,7 @@ export class WorkerPool {
                 scale,
                 vectorInk: vectorInkPages,
                 backgroundOnly,
+                rasterOverlay,
             };
 
             worker.postMessage(message);
@@ -168,10 +205,18 @@ export class WorkerPool {
     }
 
     // `backgroundOnly`, when present, is a parallel array aligned by index
-    // with allPageNumbers (see the `backgroundOnly` comment on
-    // RasterizeWorkerMessage): the worker strips those pages' bitmap ink
-    // layers before rasterizing and returns plain background-only PNGs.
-    async processPages(note: SupernoteX, allPageNumbers: number[], scale?: number, vectorInkPages?: VectorInkPage[], backgroundOnly?: boolean[]): Promise<string[]> {
+    // with allPageNumbers. Vector-ink callers pass a background note already
+    // split by the public upstream API; legacy callers without vector data
+    // retain the worker's historical all-bitmap-layer strip.
+    async processPages(
+        note: VectorInkRenderNote,
+        allPageNumbers: number[],
+        scale?: number,
+        vectorInkPages?: VectorInkPage[],
+        backgroundOnly?: boolean[],
+        rasterOverlayNote?: VectorInkRenderNote,
+        rasterOverlayPageNumbers?: ReadonlySet<number>,
+    ): Promise<RasterizedPageImage[]> {
         //console.time('Total processing time');
 
         const chunks = chunkPageNumbers(allPageNumbers);
@@ -183,7 +228,8 @@ export class WorkerPool {
         // in flight at once (see processChunk()'s comment). vectorInkPages
         // and backgroundOnly, when present, are aligned by index with
         // allPageNumbers, so slice each the same way each chunk slices the
-        // page numbers.
+        // page numbers. The overlay note is separately sliced to just its
+        // bitmap-only pages and carries their local chunk indexes.
         let offset = 0;
         const results = await Promise.all(
             chunks.map((chunk) => {
@@ -191,7 +237,15 @@ export class WorkerPool {
                 offset += chunk.length;
                 const vip = vectorInkPages?.slice(start, start + chunk.length);
                 const bg = backgroundOnly?.slice(start, start + chunk.length);
-                return this.processChunk(note, chunk, scale, vip, bg);
+                return this.processChunk(
+                    note,
+                    chunk,
+                    scale,
+                    vip,
+                    bg,
+                    rasterOverlayNote,
+                    rasterOverlayPageNumbers,
+                );
             })
         );
 
@@ -261,6 +315,21 @@ function scheduleIdleTeardownIfIdle(): void {
     }, WORKER_POOL_IDLE_TEARDOWN_MS);
 }
 
+export interface RasterizedPageImage {
+    imageDataUrl: string;
+    // Present only when this page has bitmap-only text-box/Digest content
+    // which must paint above vector ink.
+    rasterOverlayDataUrl?: string;
+}
+
+function pageMayNeedRasterOverlay(note: SupernoteX, vectorInkPage: VectorInkPage): boolean {
+    const disable = note.pages[vectorInkPage.pageNumber - 1]?.DISABLE;
+    // buildRasterInkOverlayNote() treats malformed values as transparent, so
+    // this inexpensive prefilter can conservatively send an unnecessary page
+    // for malformed metadata without ever losing real overlay ink.
+    return vectorInkPage.useVectorInk && disable !== undefined && disable !== '' && disable !== 'none';
+}
+
 export class ImageConverter {
     // `scale` (default 1, full resolution): a positive integer downsample
     // factor forwarded all the way to supernote-typescript's toImage(),
@@ -281,25 +350,70 @@ export class ImageConverter {
             // downsample) — vector coordinates don't survive a downsample,
             // so thumbnails keep the raster path.
             const vectorInkPages = vectorInk && !scale ? prepareVectorInkPages(note, pages, 1) : undefined;
-            return await getSharedWorkerPool().processPages(note, pages, scale, vectorInkPages);
+            const overlayPageNumbers = vectorInkPages
+                ? new Set(vectorInkPages.filter((page) => pageMayNeedRasterOverlay(note, page)).map((page) => page.pageNumber))
+                : undefined;
+            const backgroundNote = vectorInkPages ? buildVectorInkBackgroundNote(note, vectorInkPages) : note;
+            const rasterOverlayNote = overlayPageNumbers && overlayPageNumbers.size > 0
+                ? buildRasterInkOverlayNote(note, vectorInkPages!)
+                : undefined;
+            const rendered = await getSharedWorkerPool().processPages(
+                backgroundNote,
+                pages,
+                scale,
+                vectorInkPages,
+                undefined,
+                rasterOverlayNote,
+                overlayPageNumbers,
+            );
+            return rendered.map((page) => page.imageDataUrl);
         } finally {
             activeWorkerCalls--;
             scheduleIdleTeardownIfIdle();
         }
     }
 
-    // Background-only raster: strips the bitmap ink layers from each
-    // requested page before toImage (see `backgroundOnly` on
-    // RasterizeWorkerMessage) and returns plain PNG data URLs of the bare
-    // paper/ruling/background, no ink — the base layer the web component's
-    // write-on stroke animation mode (src/webcomponent/strokeAnimation.ts)
-    // draws its animated vector ink over. Same memory model as
-    // convertToImages() (sliced pages, chunked, shared pool).
+    // Background-only raster retained for callers that need a bare page even
+    // when it cannot be vectorized. The worker's no-vectorInk compatibility
+    // path strips every bitmap ink layer as it did before write-on overlays.
     async convertToBackgroundImages(note: SupernoteX, pageNumbers?: number[]): Promise<string[]> {
         const pages = pageNumbers ?? Array.from({length: note.pages.length}, (_, i) => i+1);
         activeWorkerCalls++;
         try {
-            return await getSharedWorkerPool().processPages(note, pages, undefined, undefined, pages.map(() => true));
+            const rendered = await getSharedWorkerPool().processPages(note, pages, undefined, undefined, pages.map(() => true));
+            return rendered.map((page) => page.imageDataUrl);
+        } finally {
+            activeWorkerCalls--;
+            scheduleIdleTeardownIfIdle();
+        }
+    }
+
+    // The write-on equivalent of convertToImages(): returns the plain PNG
+    // background below the animator's SVG plus an optional bitmap-only
+    // text-box/Digest image that the component must place above that SVG.
+    // Callers request only animatable pages, so every requested page has
+    // vetted vector ink; keeping this separate avoids changing the legacy
+    // convertToBackgroundImages() contract for other consumers.
+    async convertToAnimationImages(note: SupernoteX, pageNumbers: number[]): Promise<RasterizedPageImage[]> {
+        activeWorkerCalls++;
+        try {
+            const vectorInkPages = prepareVectorInkPages(note, pageNumbers, 1);
+            const overlayPageNumbers = new Set(
+                vectorInkPages.filter((page) => pageMayNeedRasterOverlay(note, page)).map((page) => page.pageNumber),
+            );
+            const backgroundNote = buildVectorInkBackgroundNote(note, vectorInkPages);
+            const rasterOverlayNote = overlayPageNumbers.size > 0
+                ? buildRasterInkOverlayNote(note, vectorInkPages)
+                : undefined;
+            return await getSharedWorkerPool().processPages(
+                backgroundNote,
+                pageNumbers,
+                undefined,
+                vectorInkPages,
+                pageNumbers.map(() => true),
+                rasterOverlayNote,
+                overlayPageNumbers,
+            );
         } finally {
             activeWorkerCalls--;
             scheduleIdleTeardownIfIdle();

--- a/src/render/imageConverter.ts
+++ b/src/render/imageConverter.ts
@@ -322,12 +322,24 @@ export interface RasterizedPageImage {
     rasterOverlayDataUrl?: string;
 }
 
-function pageMayNeedRasterOverlay(note: SupernoteX, vectorInkPage: VectorInkPage): boolean {
-    const disable = note.pages[vectorInkPage.pageNumber - 1]?.DISABLE;
+// Exported for the worker-routing regression test; it is not part of the
+// standalone component API.
+export function pageMayNeedRasterOverlay(note: SupernoteX, vectorInkPage: VectorInkPage): boolean {
+    const pageNumber = vectorInkPage.pageNumber;
+    const disable = note.pages[pageNumber - 1]?.DISABLE;
+    // A FONTSIZE > 0 link is an on-device typeset PDF-link label. It has no
+    // TOTALPATH entry and can sit immediately outside a Digest's DISABLE
+    // rectangle, so the upstream overlay builder retains it as raster ink.
+    // Ordinary link tags use FONTSIZE 0 and can enclose real vector strokes.
+    const hasTypesetLinkLabel = Object.entries(note.links).some(([key, links]) =>
+        Number(key.slice(0, 4)) === pageNumber && links.some((link) => Number(link.FONTSIZE) > 0),
+    );
     // buildRasterInkOverlayNote() treats malformed values as transparent, so
     // this inexpensive prefilter can conservatively send an unnecessary page
     // for malformed metadata without ever losing real overlay ink.
-    return vectorInkPage.useVectorInk && disable !== undefined && disable !== '' && disable !== 'none';
+    return vectorInkPage.useVectorInk && (
+        (disable !== undefined && disable !== '' && disable !== 'none') || hasTypesetLinkLabel
+    );
 }
 
 export class ImageConverter {

--- a/src/render/linkOverlay.test.ts
+++ b/src/render/linkOverlay.test.ts
@@ -12,6 +12,7 @@ function fakeLink(overrides: Partial<ILink> = {}): ILink {
         LINKBITMAP: '0',
         LINKSTYLE: '0',
         LINKTIMESTAMP: '0',
+        FONTSIZE: '0',
         LINKRECT: '10,20,30,40',
         LINKRECTORI: '0',
         LINKPROTOCAL: 'RATTA_RLE',

--- a/src/webcomponent/SupernoteViewerElement.test.ts
+++ b/src/webcomponent/SupernoteViewerElement.test.ts
@@ -1296,10 +1296,12 @@ describe('<supernote-viewer>', () => {
         // Same setup as the rest of this file (real note parsed off disk,
         // faked rasterizer) plus a faked rasterizeBackgrounds - its real
         // implementation is the same Worker pipeline as rasterizePage (see
-        // convertToBackgroundImages()), which happy-dom can't run.
+        // convertToAnimationImages()), which happy-dom can't run.
         function createAnimationViewer() {
             const el = createViewer();
-            el.rasterizeBackgrounds = vi.fn(async (_sn, pageNumbers: number[]) => pageNumbers.map((n) => `data:image/png;base64,bg${n}`));
+            el.rasterizeBackgrounds = vi.fn(async (_sn, pageNumbers: number[]) =>
+                pageNumbers.map((n) => ({ imageDataUrl: `data:image/png;base64,bg${n}` })),
+            );
             return el;
         }
 
@@ -1355,6 +1357,34 @@ describe('<supernote-viewer>', () => {
             expect(el.shadowRoot!.querySelector('button[aria-label="Play write-on animation"]')).not.toBeNull();
         });
 
+        it('places a bitmap-only overlay above animation ink and removes it on return to static', async () => {
+            const el = createViewer();
+            el.setAttribute('invert-dark', '');
+            el.rasterizeBackgrounds = vi.fn(async () => [{
+                imageDataUrl: 'data:image/png;base64,bg1',
+                rasterOverlayDataUrl: 'data:image/png;base64,overlay1',
+            }]);
+            el.presentation = 'write-on-paused';
+            document.body.appendChild(el);
+            const loaded = waitForEvent<{ pageCount: number }>(el, 'supernote-load');
+            el.noteData = readFixture('turkish-a6x-20230015-handwriting-erase.note');
+            await loaded;
+            await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+            const container = el.shadowRoot!.querySelector('.page-container')!;
+            const image = container.querySelector('img')!;
+            const svg = container.querySelector('svg.stroke-animation-svg')!;
+            const overlay = container.querySelector<HTMLImageElement>('img.stroke-animation-raster-overlay')!;
+            expect(overlay.src).toContain('data:image/png;base64,overlay1');
+            expect(overlay.classList.contains('supernote-invert-dark')).toBe(true);
+            expect(Array.from(container.children).indexOf(svg)).toBeGreaterThan(Array.from(container.children).indexOf(image));
+            expect(Array.from(container.children).indexOf(overlay)).toBeGreaterThan(Array.from(container.children).indexOf(svg));
+
+            el.presentation = 'static';
+            await new Promise((resolve) => window.setTimeout(resolve, 0));
+            expect(container.querySelector('.stroke-animation-raster-overlay')).toBeNull();
+        });
+
         it('write-on-paused opens primed at t=0 - blank until play is pressed', async () => {
             const el = createAnimationViewer();
             el.presentation = 'write-on-paused';
@@ -1406,8 +1436,8 @@ describe('<supernote-viewer>', () => {
 
         it('claims write-on pages before background rasterization, so a forced static load cannot reveal ink mid-entry', async () => {
             const el = createAnimationViewer();
-            let resolveBackgrounds!: (urls: string[]) => void;
-            el.rasterizeBackgrounds = vi.fn(() => new Promise<string[]>((resolve) => { resolveBackgrounds = resolve; }));
+            let resolveBackgrounds!: (layers: { imageDataUrl: string }[]) => void;
+            el.rasterizeBackgrounds = vi.fn(() => new Promise<{ imageDataUrl: string }[]>((resolve) => { resolveBackgrounds = resolve; }));
             el.presentation = 'write-on-paused';
             document.body.appendChild(el);
             const loaded = waitForEvent<{ pageCount: number }>(el, 'supernote-load');
@@ -1421,7 +1451,7 @@ describe('<supernote-viewer>', () => {
             await Promise.resolve();
             expect(el.rasterizePage).not.toHaveBeenCalled();
 
-            resolveBackgrounds(['data:image/png;base64,bg1']);
+            resolveBackgrounds([{ imageDataUrl: 'data:image/png;base64,bg1' }]);
             await new Promise((resolve) => window.setTimeout(resolve, 0));
             expect(el.shadowRoot!.querySelector('.page-container img')!.getAttribute('src')).toBe('data:image/png;base64,bg1');
         });

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -11,6 +11,7 @@
 // not Obsidian's vault-write APIs this codebase otherwise uses).
 import { ILink, SupernoteX } from 'supernote-typescript';
 import { ImageConverter } from '../render/imageConverter';
+import type { RasterizedPageImage } from '../render/imageConverter';
 import { RenderedNotePage, buildNotePagePlaceholders, evictNotePageImage, fillNotePagePlaceholder, parseNote } from '../render/noteRenderer';
 import { WordOverlayEntry, buildWordOverlay, buildWordSearchText, repositionWordOverlay } from '../render/wordOverlay';
 import { LinkOverlayEntry, bucketLinksByPage, buildLinkOverlay, repositionLinkOverlay } from '../render/linkOverlay';
@@ -383,7 +384,8 @@ button[aria-pressed="true"] {
    is an exact fit that tracks every zoom/fit-width resize the container
    goes through. pointer-events: none so find-in-note's word spans and the
    link rects (sibling elements) keep receiving their own clicks. */
-.pages .page-container > .stroke-animation-svg {
+.pages .page-container > .stroke-animation-svg,
+.pages .page-container > .stroke-animation-raster-overlay {
     position: absolute;
     inset: 0;
     width: 100%;
@@ -750,12 +752,14 @@ button[aria-pressed="true"] {
 @media (prefers-color-scheme: dark) {
     :host(:not([dark])) .pages .page-container > img.supernote-invert-dark,
     :host(:not([dark])) .pages .page-container > .stroke-animation-svg.supernote-invert-dark,
+    :host(:not([dark])) .pages .page-container > .stroke-animation-raster-overlay.supernote-invert-dark,
     :host(:not([dark])) .sidebar-list-thumb.supernote-invert-dark {
         filter: invert(1);
     }
 }
 :host([dark]:not([dark="false"])) .pages .page-container > img.supernote-invert-dark,
 :host([dark]:not([dark="false"])) .pages .page-container > .stroke-animation-svg.supernote-invert-dark,
+:host([dark]:not([dark="false"])) .pages .page-container > .stroke-animation-raster-overlay.supernote-invert-dark,
 :host([dark]:not([dark="false"])) .sidebar-list-thumb.supernote-invert-dark {
     filter: invert(1);
 }
@@ -803,10 +807,10 @@ export class SupernoteViewerElement extends HTMLElement {
     };
 
     // Overridable for the same reason rasterizePage is - the write-on
-    // animation's background-only base layers go through the same real
-    // ImageConverter/Worker pipeline via convertToBackgroundImages().
-    rasterizeBackgrounds: (sn: SupernoteX, pageNumbers: number[]) => Promise<string[]> = async (sn, pageNumbers) => {
-        return new ImageConverter().convertToBackgroundImages(sn, pageNumbers);
+    // animation's background bases and optional bitmap-only text/Digest
+    // overlays go through the same real ImageConverter/Worker pipeline.
+    rasterizeBackgrounds: (sn: SupernoteX, pageNumbers: number[]) => Promise<RasterizedPageImage[]> = async (sn, pageNumbers) => {
+        return new ImageConverter().convertToAnimationImages(sn, pageNumbers);
     };
 
     // Overridable hook applied to each page's raw recognized text before
@@ -2818,7 +2822,7 @@ export class SupernoteViewerElement extends HTMLElement {
             // loader's page eligibility check cannot touch animated pages.
             this.startFullInkPageLoading(sn, this.pageStates);
 
-            const backgroundUrls = await this.rasterizeBackgrounds(sn, animIndexes.map((index) => index + 1));
+            const backgroundLayers = await this.rasterizeBackgrounds(sn, animIndexes.map((index) => index + 1));
             // A property change to static, a rerender, or disconnection
             // cancels this transition without allowing stale URLs to land.
             if (token !== this.renderToken || this.activePresentation !== 'write-on-preparing') return;
@@ -2828,15 +2832,26 @@ export class SupernoteViewerElement extends HTMLElement {
                 // This image now belongs to write-on presentation, not the
                 // static lazy-load/evict cycle.
                 state.loaded = true;
-                fillNotePagePlaceholder(state, backgroundUrls[k]);
+                const layer = backgroundLayers[k];
+                fillNotePagePlaceholder(state, layer.imageDataUrl);
                 const svg = this.pageAnimations[index]!.svg;
                 // The worker background inherits this class from the page
                 // placeholder. Keep the separately-rendered animation ink
-                // in the same dark-mode color space.
-                if (state.imageEl.classList.contains('supernote-invert-dark')) {
-                    svg.classList.add('supernote-invert-dark');
-                }
+                // and any bitmap-only text/Digest overlay in the same
+                // dark-mode color space.
+                const invertDark = state.imageEl.classList.contains('supernote-invert-dark');
+                if (invertDark) svg.classList.add('supernote-invert-dark');
+                state.containerEl.querySelector('.stroke-animation-raster-overlay')?.remove();
                 state.containerEl.appendChild(svg);
+                if (layer.rasterOverlayDataUrl) {
+                    const overlay = document.createElement('img');
+                    overlay.classList.add('stroke-animation-raster-overlay');
+                    if (invertDark) overlay.classList.add('supernote-invert-dark');
+                    overlay.src = layer.rasterOverlayDataUrl;
+                    // Appended after the SVG: bitmap-only text/Digest pixels
+                    // must remain above an animated vector highlighter.
+                    state.containerEl.appendChild(overlay);
+                }
             });
             // fillNotePagePlaceholder() reset each page's container width -
             // reapply whatever zoom/fit-width is currently active, exactly
@@ -2883,6 +2898,7 @@ export class SupernoteViewerElement extends HTMLElement {
         this.pageStates.forEach((state, index) => {
             const pageAnim = this.pageAnimations[index];
             pageAnim?.svg.remove();
+            state.containerEl.querySelector('.stroke-animation-raster-overlay')?.remove();
             if (wasWriteOn && pageAnim && sn) {
                 state.loaded = false;
                 evictNotePageImage(state, sn.pageWidth, sn.pageHeight);


### PR DESCRIPTION
## Summary
- pin `supernote-typescript` to PR #118's raster-overlay API and typeset-link-label fixes
- preserve bitmap-only text boxes, Digests, and typeset PDF-link labels above vector ink in SVG and PDF workers
- carry matching overlay layers into write-on playback
- add regression coverage for overlay order and typeset link labels

## Validation
- `npm test`
- `npm run build`
- `npm run build:webcomponent`
- `npm run lint` (existing warning only)
- `cd supernote-typescript && npm test`