### PR TITLE
Feature: Sync and view annotated PDF/`.mark` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ But, I also use Obsidian for organizing and capturing all of my digital notes.
 
 This plugin enables me (and now you!) to import handwritten notes directly from your device (no cloud!) into Obsidian and view/export/organize them on a desktop, phone or tablet.
 
-This plugin has seven main features:
+This plugin has eight main features:
 
 - 📝 View Supernote `*.note` files in your Obsidian Vault. You can link to these notes from your Markdown notes too `[My Note](example.note)`.
 
 - 🔗 Embed a note inline in another note with `![[example.note]]` (scrollable, with page nav), or just one page with `![[example.note#page=2]]`.
 
 - ➡️  Export Supernote `*.note` files as PNGs, SVGs, PDFs and/or markdown files and attach them to your Vault.
+
+- ✍️ View Supernote `*.mark` ink layers and export a sibling `Document.pdf.mark` with its `Document.pdf` as a separate annotated PDF. The source PDF and `.mark` file remain unchanged.
 
 - 🧠 Attach all of today's modified Supernote notes and text to the current Obsidian note with the "Import notes edited today" command (great when paired with [daily notes](https://obsidian.md/help/plugins/daily-notes))
 
@@ -61,6 +63,10 @@ Thank you to [Tiemen Schuijbroek](https://gitlab.com/Tiemen/supernote) for devel
 **Q** The on-screen note's or exported PDF's ink looks different from the device / renders wrong. Can I turn vector ink off?
 
 **A** Yes. The note viewer and exported PDFs/SVGs draw pen strokes as crisp vector paths by default (instead of rasterizing the ink), so they stay sharp at any zoom. If ink renders incorrectly or differently from your device, disable **Settings → Supernote → Vector ink** — the view and exports then fall back to the original rasterized ink. The setting is on by default. (PNG export and the thumbnail sidebar stay rasterized either way, since a PNG is pixels and a tiny preview gains nothing from vector paths.)
+
+**Q** How do I export annotations made on a PDF?
+
+**A** Keep the PDF and its device-created `.pdf.mark` file together in the vault, then open the `.mark` file and choose **Export annotated sibling PDF**, or run **Export this .pdf.mark file as an annotated PDF**. The generated PDF is a separate attachment named `Document - annotated.pdf`; the original files stay editable on the Supernote.
 
 ## Relevant Resources
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This plugin has eight main features:
 
 - ➡️  Export Supernote `*.note` files as PNGs, SVGs, PDFs and/or markdown files and attach them to your Vault.
 
-- ✍️ View Supernote `*.mark` ink layers and export a sibling `Document.pdf.mark` with its `Document.pdf` as a separate annotated PDF. The source PDF and `.mark` file remain unchanged.
+- ✍️ View Supernote `*.mark` annotation sidecars in-memory directly on top of their original PDF documents in the note viewer without creating any new files. The original PDF and `.mark` file remain unchanged.
 
 - 🧠 Attach all of today's modified Supernote notes and text to the current Obsidian note with the "Import notes edited today" command (great when paired with [daily notes](https://obsidian.md/help/plugins/daily-notes))
 
@@ -64,9 +64,9 @@ Thank you to [Tiemen Schuijbroek](https://gitlab.com/Tiemen/supernote) for devel
 
 **A** Yes. The note viewer and exported PDFs/SVGs draw pen strokes as crisp vector paths by default (instead of rasterizing the ink), so they stay sharp at any zoom. If ink renders incorrectly or differently from your device, disable **Settings → Supernote → Vector ink** — the view and exports then fall back to the original rasterized ink. The setting is on by default. (PNG export and the thumbnail sidebar stay rasterized either way, since a PNG is pixels and a tiny preview gains nothing from vector paths.)
 
-**Q** How do I export annotations made on a PDF?
+**Q** How do I view or export PDF annotations (`.mark` files)?
 
-**A** Keep the PDF and its device-created `.pdf.mark` file together in the vault, then open the `.mark` file and choose **Export annotated sibling PDF**, or run **Export this .pdf.mark file as an annotated PDF**. The generated PDF is a separate attachment named `Document - annotated.pdf`; the original files stay editable on the Supernote.
+**A** Keep the original PDF and its device-created `.pdf.mark` sidecar file together in the vault. When you open the `.pdf.mark` file, the plugin renders your handwritten annotations directly on top of the original PDF in memory—no extra files are generated. If you want to save a standalone annotated PDF file into your vault, run the command **Export this .pdf.mark file as an annotated PDF**. To sync companion PDF and `.mark` pairs from your device, run **Sync PDF annotations from device**.
 
 ## Relevant Resources
 

--- a/src/FileListModal.test.ts
+++ b/src/FileListModal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { scanDeviceSupernoteTree } from './FileListModal';
+import { scanDevicePdfAnnotationTree, scanDeviceSupernoteTree } from './FileListModal';
 import { fetchFromDevice } from './deviceFetch';
 
 vi.mock('obsidian', () => ({
@@ -58,11 +58,38 @@ describe('scanDeviceSupernoteTree entry trust (GHSA-3gx3-r874-5pp4 follow-up)', 
         vi.mocked(fetchFromDevice).mockResolvedValue(mockListing([
             { name: 'diary.note' },
             { name: 'sketch.spd' },
+            { name: 'paper.pdf' },
+            { name: 'paper.pdf.mark' },
         ]));
 
         const files = await scanDeviceSupernoteTree('192.168.1.50');
 
         expect(files.map((f) => f.name).sort()).toEqual(['diary.note', 'sketch.spd']);
+    });
+
+    it('finds PDF documents and mark sidecars for annotation sync', async () => {
+        vi.mocked(fetchFromDevice).mockResolvedValue(mockListing([
+            { name: 'diary.note' },
+            { name: 'paper.pdf' },
+            { name: 'paper.pdf.mark' },
+        ]));
+
+        const files = await scanDevicePdfAnnotationTree('192.168.1.50');
+
+        expect(files.map((f) => f.name).sort()).toEqual(['paper.pdf', 'paper.pdf.mark']);
+    });
+
+    it('ignores PDFs and mark sidecars without their matching companion', async () => {
+        vi.mocked(fetchFromDevice).mockResolvedValue(mockListing([
+            { name: 'paired.pdf' },
+            { name: 'paired.pdf.mark' },
+            { name: 'plain.pdf' },
+            { name: 'orphan.pdf.mark' },
+        ]));
+
+        const files = await scanDevicePdfAnnotationTree('192.168.1.50');
+
+        expect(files.map((f) => f.name).sort()).toEqual(['paired.pdf', 'paired.pdf.mark']);
     });
 
     it('keeps entries whose uri percent-encodes spaces in the filename', async () => {

--- a/src/FileListModal.ts
+++ b/src/FileListModal.ts
@@ -52,12 +52,12 @@ export async function fetchSupernoteDirectory(
 }
 
 const SYNCABLE_EXTENSION_PATTERN = /\.(note|spd)$/i;
+const PDF_ANNOTATION_EXTENSION_PATTERN = /\.pdf(?:\.mark)?$/i;
 
 // Recursively walks the whole device tree starting at `path`, collecting
 // every `.note`/`.spd` file found. Shared by ImportTodayModal (which further
-// filters by date) and the device auto-sync engine (which filters by the
-// configured path patterns) — both need the same "list everything once"
-// traversal, just with different downstream filtering.
+// filters by date) and the standard device auto-sync engine (which filters by
+// configured path patterns).
 export async function scanDeviceSupernoteTree(
     ip: string,
     path = '/',
@@ -65,6 +65,7 @@ export async function scanDeviceSupernoteTree(
     pathLeafName?: string,
     directoryNames: string[] = [],
     directoryNamesByUri: Map<string, string[]> = new Map(),
+    includeFile: (file: SupernoteFile) => boolean = (file) => SYNCABLE_EXTENSION_PATTERN.test(file.name),
 ): Promise<SupernoteFile[]> {
     if (visited.has(path)) return [];
     visited.add(path);
@@ -91,12 +92,35 @@ export async function scanDeviceSupernoteTree(
                 entry.name,
                 entryDirectoryNames,
                 directoryNamesByUri,
+                includeFile,
             ));
-        } else if (SYNCABLE_EXTENSION_PATTERN.test(entry.name) && isTrustedListingEntry(entry)) {
+        } else if (includeFile(entry) && isTrustedListingEntry(entry)) {
             results.push({ ...entry, directoryNames: parentNames });
         }
     }
     return results;
+}
+
+// PDF annotations are a two-file unit on a Supernote: the original `.pdf`
+// and its `.pdf.mark` sidecar. Ignore lone PDFs and lone sidecars so the
+// annotation-specific sync only mirrors documents it can actually render.
+// This separate traversal leaves the normal note sync and the "Import notes
+// edited today" workflow limited to their original `.note`/`.spd` scope.
+export async function scanDevicePdfAnnotationTree(ip: string): Promise<SupernoteFile[]> {
+    const candidates = await scanDeviceSupernoteTree(
+        ip,
+        '/',
+        new Set(),
+        undefined,
+        [],
+        new Map(),
+        (file) => PDF_ANNOTATION_EXTENSION_PATTERN.test(file.name),
+    );
+
+    const uris = new Set(candidates.map((file) => file.uri));
+    return candidates.filter((file) => file.name.toLowerCase().endsWith('.mark')
+        ? uris.has(file.uri.slice(0, -'.mark'.length))
+        : uris.has(`${file.uri}.mark`));
 }
 
 function parentUri(uri: string): string {

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import { runDeviceSync, appendSyncLogEntry } from './syncEngine';
 import { formatSyncFailureLogEntry } from './deviceSync';
 import { SupernoteAtelierEmbed, SupernoteAtelierView, VIEW_TYPE_SUPERNOTE_ATELIER, renderAtelierCompositeDataUrl, renderAtelierCompositeFromBuffer } from './atelierView';
 import { PDFDocument } from 'pdf-lib';
+import { markToAnnotatedPdf } from './markPdf';
 
 function generateTimestamp(): string {
 	const date = new Date();
@@ -584,6 +585,45 @@ class VaultWriter {
 		this.notifyExportComplete(pdfFile);
 	}
 
+	private annotatedSiblingPath(pdf: TFile): string {
+		const parent = pdf.parent?.path;
+		return `${parent ? `${parent}/` : ''}${pdf.basename} - annotated.pdf`;
+	}
+
+	async exportMarkToAnnotatedPdf(file: TFile, notify = true): Promise<TFile | null> {
+		if (!/\.pdf\.mark$/i.test(file.path)) {
+			throw new Error('This command expects a .pdf.mark file.');
+		}
+
+		const pdfPath = file.path.replace(/\.mark$/i, '');
+		const siblingPdf = this.app.vault.getAbstractFileByPath(pdfPath);
+		if (!(siblingPdf instanceof TFile) || siblingPdf.extension.toLowerCase() !== 'pdf') {
+			throw new Error(`No sibling PDF found for "${file.name}".`);
+		}
+
+		const markBytes = await this.app.vault.readBinary(file);
+		const mark = new SupernoteX(new Uint8Array(markBytes));
+		const originalPdf = new Uint8Array(await this.app.vault.readBinary(siblingPdf));
+		const annotatedPdf = await markToAnnotatedPdf(mark, originalPdf);
+
+		if (annotatedPdf === null) {
+			new Notice(`No visible ink found in "${file.name}".`);
+			return null;
+		}
+
+		const outPath = this.annotatedSiblingPath(siblingPdf);
+		const existing = this.app.vault.getAbstractFileByPath(outPath);
+		let outFile: TFile;
+		if (existing instanceof TFile) {
+			await this.app.vault.modifyBinary(existing, toArrayBuffer(annotatedPdf));
+			outFile = existing;
+		} else {
+			outFile = await this.app.vault.createBinary(outPath, toArrayBuffer(annotatedPdf));
+		}
+		if (notify) this.notifyExportComplete(outFile);
+		return outFile;
+	}
+
 	// `.spd` (Supernote Atelier) equivalents of the exports above. Unlike
 	// `.note`, `.spd` has no pages and no recognized/OCR text — just one
 	// flattened composite image (see renderAtelierCompositeDataUrl).
@@ -706,6 +746,16 @@ export class SupernoteView extends FileView {
 	}
 
 	async onLoadFile(file: TFile): Promise<void> {
+		if (file.extension === 'mark') {
+			const annotatedPdf = await vw.exportMarkToAnnotatedPdf(file, false);
+			if (annotatedPdf) {
+				// Opening another file while Obsidian is still committing this
+				// FileView's load can be overwritten by that in-flight transition.
+				window.setTimeout(() => void this.leaf.openFile(annotatedPdf), 0);
+			}
+			return;
+		}
+
 		const container = this.contentEl;
 		container.empty();
 		this.viewerEl = null;
@@ -740,6 +790,9 @@ export class SupernoteView extends FileView {
 		const bytes = await this.app.vault.readBinary(file);
 
 		const viewer = container.createEl('supernote-viewer');
+		if (file.extension === 'mark') {
+			viewer.style.setProperty('--supernote-viewer-page-background', '#ffffff');
+		}
 		// Applies the plugin's custom-dictionary substitution (if enabled)
 		// to recognized text shown in the component's own text mode - the
 		// one piece of SupernoteView's previous behavior <supernote-viewer>
@@ -1050,6 +1103,9 @@ export class SupernoteEmbed extends Component {
 		}
 
 		const viewer = this.containerEl.createEl('supernote-viewer');
+		if (this.file.extension === 'mark') {
+			viewer.style.setProperty('--supernote-viewer-page-background', '#ffffff');
+		}
 		// The outer .supernote-embed container (see styles.css) already
 		// supplies a bordered, resizable frame - `bare` drops the component's
 		// own default chrome so the two don't visually double up.
@@ -1198,7 +1254,7 @@ export default class SupernotePlugin extends Plugin {
 			VIEW_TYPE_SUPERNOTE,
 			(leaf) => new SupernoteView(leaf, this.settings)
 		);
-		this.registerExtensions(['note'], VIEW_TYPE_SUPERNOTE);
+		this.registerExtensions(['note', 'mark'], VIEW_TYPE_SUPERNOTE);
 
 		// `.spd` files (Supernote Atelier app) — see atelierView.ts.
 		this.registerView(
@@ -1219,6 +1275,11 @@ export default class SupernotePlugin extends Plugin {
 				new SupernoteEmbed(this.app, this.settings, context.containerEl, file, parsePageAnchor(subpath))
 			);
 			this.register(() => this.app.embedRegistry?.unregisterExtension('note'));
+
+			this.app.embedRegistry.registerExtension('mark', (context, file, subpath) =>
+				new SupernoteEmbed(this.app, this.settings, context.containerEl, file, parsePageAnchor(subpath))
+			);
+			this.register(() => this.app.embedRegistry?.unregisterExtension('mark'));
 
 			this.app.embedRegistry.registerExtension('spd', (context, file) =>
 				new SupernoteAtelierEmbed(this.app, this.settings, context.containerEl, file)
@@ -1268,6 +1329,26 @@ export default class SupernotePlugin extends Plugin {
 				} catch (err) {
 					new DirectConnectErrorModal(this.app, this.settings, err instanceof Error ? err : new Error(String(err))).open();
 				}
+			},
+		});
+
+		this.addCommand({
+			id: 'export-mark-as-annotated-pdf',
+			name: 'Export this .pdf.mark file as an annotated PDF',
+			checkCallback: (checking: boolean) => {
+				const file = this.app.workspace.getActiveFile();
+				if (!file || file.extension !== 'mark' || !/\.pdf$/i.test(file.basename)) {
+					return false;
+				}
+
+				if (checking) {
+					return true;
+				}
+
+				vw.exportMarkToAnnotatedPdf(file).catch((err: unknown) => {
+					new ErrorModal(this.app, err instanceof Error ? err : new Error(String(err))).open();
+				});
+				return true;
 			},
 		});
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { installAtPolyfill } from './polyfills';
-import { App, Modal, Notice, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, Component, Scope, Platform, setIcon } from 'obsidian';
+import { App, Modal, Notice, TFile, Plugin, Editor, MarkdownView, MarkdownFileInfo, WorkspaceLeaf, FileView, Component, Scope, Platform, setIcon, loadPdfJs } from 'obsidian';
 import { SupernotePluginSettings, SupernoteSettingTab, DEFAULT_SETTINGS, ImportFormat, PageExportImageFormat } from './settings';
 import { SupernoteX, ILink, RecognitionStatuses, fetchMirrorFrame, extractPdfPageData, addSvgPage, prepareVectorInkPages, buildVectorInkBackgroundNote, buildRasterInkOverlayNote, toSvg } from 'supernote-typescript';
 import { encode } from 'image-js';
@@ -20,6 +20,128 @@ import { formatSyncFailureLogEntry } from './deviceSync';
 import { SupernoteAtelierEmbed, SupernoteAtelierView, VIEW_TYPE_SUPERNOTE_ATELIER, renderAtelierCompositeDataUrl, renderAtelierCompositeFromBuffer } from './atelierView';
 import { PDFDocument } from 'pdf-lib';
 import { markToAnnotatedPdf } from './markPdf';
+
+interface PdfJsViewport {
+	width: number;
+	height: number;
+}
+
+interface PdfJsPage {
+	getViewport(params: { scale: number }): PdfJsViewport;
+	render(params: { canvasContext: CanvasRenderingContext2D; viewport: PdfJsViewport }): { promise: Promise<void> };
+}
+
+interface PdfJsDocument {
+	numPages: number;
+	getPage(pageNumber: number): Promise<PdfJsPage>;
+}
+
+interface PdfJsLib {
+	getDocument(params: { data: Uint8Array | ArrayBuffer }): { promise: Promise<PdfJsDocument> };
+}
+
+async function renderMarkViewer(
+	app: App,
+	file: TFile,
+	viewer: SupernoteViewerElement,
+): Promise<boolean> {
+	if (file.extension !== 'mark') return false;
+
+	const pdfPath = file.path.replace(/\.mark$/i, '');
+	const siblingPdf = app.vault.getAbstractFileByPath(pdfPath);
+	if (!(siblingPdf instanceof TFile) || siblingPdf.extension.toLowerCase() !== 'pdf') {
+		return false;
+	}
+
+	try {
+		const markBytes = await app.vault.readBinary(file);
+		const mark = new SupernoteX(new Uint8Array(markBytes));
+		const originalPdf = new Uint8Array(await app.vault.readBinary(siblingPdf));
+		const annotatedPdf = await markToAnnotatedPdf(mark, originalPdf);
+		const pdfBytes = annotatedPdf ?? originalPdf;
+
+		const pdfjsRaw: unknown = await loadPdfJs();
+		const pdfjs = pdfjsRaw as PdfJsLib;
+		const pdfDoc = await pdfjs.getDocument({ data: pdfBytes }).promise;
+		const numPages = pdfDoc.numPages;
+		if (numPages <= 0) return false;
+
+		const firstPage = await pdfDoc.getPage(1);
+		const vp1 = firstPage.getViewport({ scale: 1.0 });
+		const pageWidth = Math.round(vp1.width * 2);
+		const pageHeight = Math.round(vp1.height * 2);
+
+		const emptyLayer = {
+			LAYERTYPE: 'NOTE',
+			LAYERPROTOCOL: 'RATTA_RLE',
+			LAYERNAME: 'MAINLAYER',
+			LAYERPATH: '',
+			LAYERBITMAP: '',
+			LAYERVECTORGRAPH: '',
+			LAYERRECOGN: '',
+			bitmapBuffer: null,
+		};
+
+		const pages = Array.from({ length: numPages }, (_, i) => ({
+			PAGESTYLE: '0',
+			PAGESTYLEMD5: '0',
+			LAYERSWITCH: '0',
+			TOTALPATH: '0',
+			THUMBNAILTYPE: '0',
+			RECOGNSTATUS: RecognitionStatuses.NONE,
+			RECOGNTEXT: '0',
+			RECOGNFILE: '0',
+			RECOGNFILESTATUS: RecognitionStatuses.NONE,
+			ORIENTATION: '0',
+			MAINLAYER: emptyLayer,
+			LAYER1: emptyLayer,
+			LAYER2: emptyLayer,
+			LAYER3: emptyLayer,
+			BGLAYER: emptyLayer,
+			LAYERINFO: [],
+			LAYERSEQ: [],
+			recognitionElements: [],
+			paragraphs: '',
+			text: '',
+			totalPathBuffer: null,
+			PAGEID: mark.pages[i]?.PAGEID ?? `pdf-page-${i + 1}`,
+		}));
+
+		const markNote = {
+			pageWidth,
+			pageHeight,
+			addressSize: 4,
+			lengthFieldSize: 4,
+			signature: 'mark',
+			version: 20260016,
+			defaultLayers: ['MAINLAYER'],
+			header: mark.header,
+			footer: mark.footer,
+			keywords: {},
+			titles: {},
+			links: mark.links,
+			pages,
+		} as unknown as SupernoteX;
+
+		viewer.rasterizePage = async (_sn, pageNumber) => {
+			const page = await pdfDoc.getPage(pageNumber);
+			const vp = page.getViewport({ scale: 2.0 });
+			const canvas = activeWindow.document.createElement('canvas');
+			canvas.width = Math.round(vp.width);
+			canvas.height = Math.round(vp.height);
+			const ctx = canvas.getContext('2d');
+			if (!ctx) throw new Error('Could not get 2d context');
+			await page.render({ canvasContext: ctx, viewport: vp }).promise;
+			return canvas.toDataURL('image/png');
+		};
+
+		viewer.noteObject = markNote;
+		return true;
+	} catch (err) {
+		console.error('Failed to render mark overlay in viewer:', err);
+		return false;
+	}
+}
 
 function generateTimestamp(): string {
 	const date = new Date();
@@ -746,16 +868,6 @@ export class SupernoteView extends FileView {
 	}
 
 	async onLoadFile(file: TFile): Promise<void> {
-		if (file.extension === 'mark') {
-			const annotatedPdf = await vw.exportMarkToAnnotatedPdf(file, false);
-			if (annotatedPdf) {
-				// Opening another file while Obsidian is still committing this
-				// FileView's load can be overwritten by that in-flight transition.
-				window.setTimeout(() => void this.leaf.openFile(annotatedPdf), 0);
-			}
-			return;
-		}
-
 		const container = this.contentEl;
 		container.empty();
 		this.viewerEl = null;
@@ -787,11 +899,9 @@ export class SupernoteView extends FileView {
 			});
 		}
 
-		const bytes = await this.app.vault.readBinary(file);
-
 		const viewer = container.createEl('supernote-viewer');
 		if (file.extension === 'mark') {
-			viewer.style.setProperty('--supernote-viewer-page-background', '#ffffff');
+			viewer.setCssProps({ '--supernote-viewer-page-background': '#ffffff' });
 		}
 		// Applies the plugin's custom-dictionary substitution (if enabled)
 		// to recognized text shown in the component's own text mode - the
@@ -885,7 +995,12 @@ export class SupernoteView extends FileView {
 				if (e.detail.pageNumber === undefined) resolve();
 			}) as EventListener, { once: true });
 		});
-		viewer.noteData = bytes;
+
+		const isMarkWithPdf = await renderMarkViewer(this.app, file, viewer);
+		if (!isMarkWithPdf) {
+			const bytes = await this.app.vault.readBinary(file);
+			viewer.noteData = bytes;
+		}
 		await loaded;
 	}
 
@@ -1104,7 +1219,7 @@ export class SupernoteEmbed extends Component {
 
 		const viewer = this.containerEl.createEl('supernote-viewer');
 		if (this.file.extension === 'mark') {
-			viewer.style.setProperty('--supernote-viewer-page-background', '#ffffff');
+			viewer.setCssProps({ '--supernote-viewer-page-background': '#ffffff' });
 		}
 		// The outer .supernote-embed container (see styles.css) already
 		// supplies a bordered, resizable frame - `bare` drops the component's
@@ -1142,10 +1257,10 @@ export class SupernoteEmbed extends Component {
 			void handleNoteLinkClick(this.app, this.file.basename, this.pageIds, this.viewerEl, e.detail.link);
 		}) as EventListener);
 
-		// createEl() above already appended (and thus connected) it - matters
-		// for its own queueRender() (see SupernoteViewerElement.ts), which
-		// this kicks off via the fetch-free "bytes already in hand" path.
-		viewer.noteData = bytes;
+		const isMarkWithPdf = await renderMarkViewer(this.app, this.file, viewer);
+		if (!isMarkWithPdf) {
+			viewer.noteData = bytes;
+		}
 	}
 
 	// Obsidian's PDF embed never lets the embed shrink below one full page —

--- a/src/main.ts
+++ b/src/main.ts
@@ -1554,9 +1554,15 @@ export default class SupernotePlugin extends Plugin {
 			name: 'Sync supernote notes now',
 			callback: () => { void this.runSync(); },
 		});
+
+		this.addCommand({
+			id: 'sync-pdf-annotations-from-device',
+			name: 'Sync PDF annotations from device',
+			callback: () => { void this.runSync(true); },
+		});
 	}
 
-	async runSync(): Promise<void> {
+	async runSync(pdfAnnotationsOnly = false): Promise<void> {
 		if (this.settings.directConnectIP.length === 0) {
 			new DirectConnectErrorModal(this.app, this.settings, new Error("IP is unset")).open();
 			return;
@@ -1572,13 +1578,19 @@ export default class SupernotePlugin extends Plugin {
 
 		this.syncInFlight = true;
 		try {
-			const result = await runDeviceSync(this.app, this.settings, () => this.saveSettings());
+			const result = await runDeviceSync(
+				this.app,
+				this.settings,
+				() => this.saveSettings(),
+				pdfAnnotationsOnly,
+			);
 
 			const parts = [`${result.synced} synced`, `${result.unchanged} unchanged`];
 			if (result.excluded > 0) parts.push(`${result.excluded} out of scope`);
 			if (result.skippedConflicts.length > 0) parts.push(`${result.skippedConflicts.length} skipped (locally edited)`);
 			if (result.failed.length > 0) parts.push(`${result.failed.length} failed`);
-			new Notice(`Supernote sync: ${parts.join(', ')}`);
+			const label = pdfAnnotationsOnly ? 'Supernote PDF annotation sync' : 'Supernote sync';
+			new Notice(`${label}: ${parts.join(', ')}`);
 
 			if (result.skippedConflicts.length > 0) {
 				console.warn('Supernote sync skipped these files because they were edited locally since the last sync:', result.skippedConflicts);

--- a/src/main.ts
+++ b/src/main.ts
@@ -135,6 +135,21 @@ async function renderMarkViewer(
 			return canvas.toDataURL('image/png');
 		};
 
+		// The default thumbnail renderer decodes markNote's empty layers,
+		// so previews are blank. Render each PDF page at 0.5 scale to match
+		// the viewer's thumbnail downsample factor.
+		viewer.rasterizeThumbnail = async (_sn, pageNumber) => {
+			const page = await pdfDoc.getPage(pageNumber);
+			const vp = page.getViewport({ scale: 0.5 });
+			const canvas = activeWindow.document.createElement('canvas');
+			canvas.width = Math.round(vp.width);
+			canvas.height = Math.round(vp.height);
+			const ctx = canvas.getContext('2d');
+			if (!ctx) throw new Error('Could not get 2d context');
+			await page.render({ canvasContext: ctx, viewport: vp }).promise;
+			return canvas.toDataURL('image/png');
+		};
+
 		viewer.noteObject = markNote;
 		return true;
 	} catch (err) {

--- a/src/markPdf.ts
+++ b/src/markPdf.ts
@@ -1,0 +1,174 @@
+import { encode, Image, ImageColorModel } from 'image-js';
+import { PDFDocument } from 'pdf-lib';
+import { IRenderableNote, SupernoteX, toImage } from 'supernote-typescript';
+
+interface MarkOverlayPage {
+	pdfPageNumber: number;
+	bounds: ImageBounds;
+	overlayPng: Uint8Array;
+}
+
+interface ImageBounds {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+function getMarkedPdfPages(mark: SupernoteX): number[] {
+	const entries = Object.entries(mark.footer.PAGE)
+		.map(([page, offset]) => ({
+			pageNumber: Number.parseInt(page, 10),
+			offset: Number.parseInt(offset, 10),
+		}))
+		.filter((entry) => Number.isFinite(entry.pageNumber) && entry.pageNumber > 0)
+		.sort((a, b) => {
+			const left = Number.isFinite(a.offset) ? a.offset : Number.MAX_SAFE_INTEGER;
+			const right = Number.isFinite(b.offset) ? b.offset : Number.MAX_SAFE_INTEGER;
+			return left - right;
+		});
+
+	return entries.map((entry) => entry.pageNumber);
+}
+
+function alphaBounds(rgba: Uint8Array, width: number, height: number): ImageBounds | null {
+	let minX = width;
+	let minY = height;
+	let maxX = -1;
+	let maxY = -1;
+
+	for (let y = 0; y < height; y++) {
+		for (let x = 0; x < width; x++) {
+			const alpha = rgba[(y * width + x) * 4 + 3];
+			if (alpha === 0) continue;
+			if (x < minX) minX = x;
+			if (y < minY) minY = y;
+			if (x > maxX) maxX = x;
+			if (y > maxY) maxY = y;
+		}
+	}
+
+	if (maxX < minX || maxY < minY) return null;
+	return {
+		x: minX,
+		y: minY,
+		width: maxX - minX + 1,
+		height: maxY - minY + 1,
+	};
+}
+
+function cropRgba(rgba: Uint8Array, sourceWidth: number, bounds: ImageBounds): Uint8Array {
+	const out = new Uint8Array(bounds.width * bounds.height * 4);
+	for (let y = 0; y < bounds.height; y++) {
+		const sourceStart = ((bounds.y + y) * sourceWidth + bounds.x) * 4;
+		const sourceEnd = sourceStart + bounds.width * 4;
+		out.set(rgba.subarray(sourceStart, sourceEnd), y * bounds.width * 4);
+	}
+	return out;
+}
+
+function placement(canvasWidth: number, canvasHeight: number, pageWidth: number, pageHeight: number): { scale: number; offsetX: number; offsetY: number } {
+	// The device stores strokes in canvas pixels, while PDF coordinates are
+	// points. `scale` is canvas pixels per PDF point, not the inverse.
+	const scale = Math.min(canvasWidth / pageWidth, canvasHeight / pageHeight);
+	const fittedWidth = pageWidth * scale;
+	const fittedHeight = pageHeight * scale;
+	return {
+		scale,
+		offsetX: (canvasWidth - fittedWidth) / 2,
+		offsetY: (canvasHeight - fittedHeight) / 2,
+	};
+}
+
+function buildInkOnlyPage(mark: SupernoteX, pageIndex: number): IRenderableNote {
+	const page = mark.pages[pageIndex];
+	const layerNames = page.LAYERSEQ.filter((name) => name !== 'BGLAYER');
+	const inkOnlyPage = {
+		PAGESTYLE: page.PAGESTYLE,
+		LAYERSEQ: layerNames,
+	} as IRenderableNote['pages'][number];
+
+	for (const name of layerNames) {
+		const layer = page[name];
+		inkOnlyPage[name] = {
+			LAYERNAME: layer.LAYERNAME,
+			bitmapBuffer: layer.bitmapBuffer,
+		};
+	}
+
+	return {
+		pageWidth: mark.pageWidth,
+		pageHeight: mark.pageHeight,
+		pages: [inkOnlyPage],
+	};
+}
+
+async function buildOverlays(mark: SupernoteX): Promise<MarkOverlayPage[]> {
+	const pdfPages = getMarkedPdfPages(mark);
+	const overlays: MarkOverlayPage[] = [];
+
+	for (let i = 0; i < mark.pages.length && i < pdfPages.length; i++) {
+		const renderable = buildInkOnlyPage(mark, i);
+		const rendered = (await toImage(renderable, [1]))[0];
+		const { data, width, height } = rendered.getRawImage();
+		// toImage constructs every RLE layer as 8-bit RGBA. image-js's raw
+		// data type is broader because arbitrary input images may be 16-bit.
+		const rgba = data as Uint8Array;
+		const bounds = alphaBounds(rgba, width, height);
+		if (bounds === null) continue;
+
+		const cropped = cropRgba(rgba, width, bounds);
+		const png = encode(new Image(bounds.width, bounds.height, {
+			colorModel: ImageColorModel.RGBA,
+			data: cropped,
+		}));
+
+		overlays.push({
+			pdfPageNumber: pdfPages[i],
+			bounds,
+			overlayPng: png,
+		});
+	}
+
+	return overlays;
+}
+
+export async function markToAnnotatedPdf(mark: SupernoteX, originalPdfBytes: Uint8Array): Promise<Uint8Array | null> {
+	const overlays = await buildOverlays(mark);
+	if (overlays.length === 0) return null;
+
+	const doc = await PDFDocument.load(originalPdfBytes, { ignoreEncryption: true });
+	const pages = doc.getPages();
+	let stamped = 0;
+
+	for (let i = 0; i < overlays.length; i++) {
+		const overlay = overlays[i];
+		const page = pages[overlay.pdfPageNumber - 1];
+		if (!page) continue;
+
+		const image = await doc.embedPng(overlay.overlayPng);
+		const size = page.getSize();
+		const rotation = page.getRotation().angle % 360;
+		const swapped = rotation === 90 || rotation === 270;
+		const viewWidth = swapped ? size.height : size.width;
+		const viewHeight = swapped ? size.width : size.height;
+
+		const fit = placement(mark.pageWidth, mark.pageHeight, viewWidth, viewHeight);
+		const drawX = (overlay.bounds.x - fit.offsetX) / fit.scale;
+		const drawYTop = (overlay.bounds.y - fit.offsetY) / fit.scale;
+		const drawWidth = image.width / fit.scale;
+		const drawHeight = image.height / fit.scale;
+		const drawY = viewHeight - drawYTop - drawHeight;
+
+		page.drawImage(image, {
+			x: drawX,
+			y: drawY,
+			width: drawWidth,
+			height: drawHeight,
+		});
+		stamped++;
+	}
+
+	if (stamped === 0) return null;
+	return doc.save();
+}

--- a/src/markPdf.ts
+++ b/src/markPdf.ts
@@ -15,20 +15,14 @@ interface ImageBounds {
 	height: number;
 }
 
+// `mark.footer.PAGE` keys are 1-indexed PDF page numbers. `mark.pages` uses
+// these keys in numeric order, so keep this list sorted by page number rather
+// than by file offset. Offsets can change when pages are edited and saved.
 function getMarkedPdfPages(mark: SupernoteX): number[] {
-	const entries = Object.entries(mark.footer.PAGE)
-		.map(([page, offset]) => ({
-			pageNumber: Number.parseInt(page, 10),
-			offset: Number.parseInt(offset, 10),
-		}))
-		.filter((entry) => Number.isFinite(entry.pageNumber) && entry.pageNumber > 0)
-		.sort((a, b) => {
-			const left = Number.isFinite(a.offset) ? a.offset : Number.MAX_SAFE_INTEGER;
-			const right = Number.isFinite(b.offset) ? b.offset : Number.MAX_SAFE_INTEGER;
-			return left - right;
-		});
-
-	return entries.map((entry) => entry.pageNumber);
+	return Object.keys(mark.footer.PAGE)
+		.map((page) => Number.parseInt(page, 10))
+		.filter((pageNumber) => Number.isFinite(pageNumber) && pageNumber > 0)
+		.sort((a, b) => a - b);
 }
 
 function alphaBounds(rgba: Uint8Array, width: number, height: number): ImageBounds | null {

--- a/src/syncEngine.ts
+++ b/src/syncEngine.ts
@@ -1,6 +1,6 @@
 import { App, TFile } from 'obsidian';
 import { SupernotePluginSettings } from './settings';
-import { scanDeviceSupernoteTree } from './FileListModal';
+import { scanDevicePdfAnnotationTree, scanDeviceSupernoteTree } from './FileListModal';
 import { fetchFromDevice, DEVICE_TRANSFER_TIMEOUT_MS } from './deviceFetch';
 import {
     DeviceNoteListing,
@@ -101,13 +101,16 @@ export async function runDeviceSync(
     app: App,
     settings: SupernotePluginSettings,
     saveSettings: () => Promise<void>,
+    pdfAnnotationsOnly = false,
 ): Promise<DeviceSyncResult> {
     const ip = settings.directConnectIP;
     if (!ip) {
         throw new Error('Supernote IP is unset');
     }
 
-    const deviceFiles = await scanDeviceSupernoteTree(ip);
+    const deviceFiles = pdfAnnotationsOnly
+        ? await scanDevicePdfAnnotationTree(ip)
+        : await scanDeviceSupernoteTree(ip);
     const listings: DeviceNoteListing[] = deviceFiles.map((f) => ({ uri: f.uri, date: f.date, size: f.size }));
     const patterns = parsePathFilters(settings.syncPathFiltersRaw);
     const plan = planSync(listings, settings.noteSyncState, patterns);

--- a/src/syncEngine.ts
+++ b/src/syncEngine.ts
@@ -111,16 +111,29 @@ export async function runDeviceSync(
     const listings: DeviceNoteListing[] = deviceFiles.map((f) => ({ uri: f.uri, date: f.date, size: f.size }));
     const patterns = parsePathFilters(settings.syncPathFiltersRaw);
     const plan = planSync(listings, settings.noteSyncState, patterns);
+    // A device listing can be unchanged while its vault copy was deleted.
+    // Restore those files from the unchanged bucket; a missing file is safe to
+    // create, unlike a present file whose hash no longer matches the manifest.
+    const toSync = [...plan.toSync];
+    const unchanged: DeviceNoteListing[] = [];
+    for (const listing of plan.unchanged) {
+        const record = settings.noteSyncState[listing.uri];
+        if (record && await currentHash(app, record.vaultPath) === null) {
+            toSync.push(listing);
+        } else {
+            unchanged.push(listing);
+        }
+    }
 
     const result: DeviceSyncResult = {
         synced: 0,
-        unchanged: plan.unchanged.length,
+        unchanged: unchanged.length,
         excluded: plan.excluded.length,
         skippedConflicts: [],
         failed: [],
     };
 
-    for (const listing of plan.toSync) {
+    for (const listing of toSync) {
         try {
             const deviceFile = deviceFiles.find((f) => f.uri === listing.uri);
             if (!deviceFile) continue; // Listing changed between the scan and here; pick it up next run.
@@ -161,16 +174,16 @@ export async function runDeviceSync(
         }
     }
 
-    // The loop above only ever looks at plan.toSync — files the *device*
+    // The loop above only ever looks at toSync — files the *device*
     // reports as new or changed. A file the user edited locally (in the
     // vault, or directly on disk) whose device counterpart hasn't changed
     // would otherwise go completely unnoticed: nothing threatens to
     // overwrite it, but nothing flags the drift either, until the device
-    // copy eventually changes too and the file re-enters plan.toSync. Since
+    // copy eventually changes too and the file re-enters toSync. Since
     // this only reads vault-local files (no device/network round-trip — the
     // actual cost planSync's change detection avoids), it's cheap enough to
     // check on every run rather than waiting for that.
-    for (const listing of plan.unchanged) {
+    for (const listing of unchanged) {
         const record = settings.noteSyncState[listing.uri];
         if (!record) continue; // 'unchanged' implies a record exists; defensive only.
 

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -876,6 +876,7 @@ export class SupernoteViewerElement extends HTMLElement {
     private renderQueued = false;
     private renderToken = 0;
     private _noteData: ArrayBuffer | Uint8Array | null = null;
+    private _noteObject: SupernoteX | null = null;
     private findBarEl: HTMLElement | null = null;
     private findInputEl: HTMLInputElement | null = null;
     private findCountEl: HTMLElement | null = null;
@@ -954,6 +955,15 @@ export class SupernoteViewerElement extends HTMLElement {
 
     set noteData(value: ArrayBuffer | Uint8Array | null) {
         this._noteData = value;
+        this.queueRender();
+    }
+
+    get noteObject(): SupernoteX | null {
+        return this._noteObject;
+    }
+
+    set noteObject(value: SupernoteX | null) {
+        this._noteObject = value;
         this.queueRender();
     }
 
@@ -1191,32 +1201,36 @@ export class SupernoteViewerElement extends HTMLElement {
         const token = ++this.renderToken;
         this.teardownForRerender();
 
-        if (!this._noteData && !this.getAttribute('src')) {
+        if (!this._noteObject && !this._noteData && !this.getAttribute('src')) {
             this.showStatus('No Supernote file loaded — set the "src" attribute or the noteData property.');
             return;
         }
 
         this.showStatus('Loading…');
 
-        let bytes: ArrayBuffer;
-        try {
-            bytes = await this.loadBytes();
-        } catch (err) {
-            if (token !== this.renderToken) return;
-            this.handleLoadError(err);
-            return;
-        }
-        if (token !== this.renderToken) return;
-
         let sn: SupernoteX;
-        try {
-            sn = parseNote(bytes);
-        } catch (err) {
+        if (this._noteObject) {
+            sn = this._noteObject;
+        } else {
+            let bytes: ArrayBuffer;
+            try {
+                bytes = await this.loadBytes();
+            } catch (err) {
+                if (token !== this.renderToken) return;
+                this.handleLoadError(err);
+                return;
+            }
             if (token !== this.renderToken) return;
-            this.handleLoadError(err);
-            return;
+
+            try {
+                sn = parseNote(bytes);
+            } catch (err) {
+                if (token !== this.renderToken) return;
+                this.handleLoadError(err);
+                return;
+            }
+            if (token !== this.renderToken) return;
         }
-        if (token !== this.renderToken) return;
 
         this.sn = sn;
         this.buildViewer(sn);

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -534,6 +534,7 @@ button[aria-pressed="true"] {
 .pages .page-container {
     position: relative;
     max-width: 100%;
+	background: var(--supernote-viewer-page-background, transparent);
     /* Centers a page narrower than .pages via auto-margin absorption
        instead of relying on .pages' own align-items: center - real,
        reported bug: a flex/grid item centered via the *container's* own

--- a/src/webcomponent/SupernoteViewerElement.ts
+++ b/src/webcomponent/SupernoteViewerElement.ts
@@ -807,6 +807,18 @@ export class SupernoteViewerElement extends HTMLElement {
         return imageDataUrl;
     };
 
+    // Thumbnail equivalent of rasterizePage. Separate so hosts that override
+    // rasterizePage, such as PDF-backed views, need not reimplement thumbnail
+    // scaling or rasterize every page at full resolution. Hosts without bitmap
+    // layers get blank thumbnails unless they override this hook. This fixes
+    // the bug where full-page views worked but sidebar thumbnails stayed empty.
+    rasterizeThumbnail: (sn: SupernoteX, pageNumber: number) => Promise<string> = async (sn, pageNumber) => {
+        const [imageDataUrl] = await new ImageConverter().convertToImages(
+            sn, [pageNumber], SupernoteViewerElement.THUMBNAIL_SCALE, this.vectorInk,
+        );
+        return imageDataUrl;
+    };
+
     // Overridable for the same reason rasterizePage is - the write-on
     // animation's background bases and optional bitmap-only text/Digest
     // overlays go through the same real ImageConverter/Worker pipeline.
@@ -1798,9 +1810,7 @@ export class SupernoteViewerElement extends HTMLElement {
         const item = this.thumbItems[index];
         if (!item || item.imgEl.src) return;
         try {
-            const [dataUrl] = await new ImageConverter().convertToImages(
-                sn, [index + 1], SupernoteViewerElement.THUMBNAIL_SCALE,
-            );
+            const dataUrl = await this.rasterizeThumbnail(sn, index + 1);
             fillSidebarThumbnail(item, dataUrl);
         } catch (err) {
             console.error(`supernote-viewer: page ${index + 1}'s thumbnail failed to load`, err);


### PR DESCRIPTION
**Summary:** Adds support for viewing and syncing Supernote PDF annotation sidecar files (`.pdf.mark`). `.pdf.mark` files render **in memory** on top of the original sibling PDF directly inside the `<supernote-viewer>` web component. The viewer lazily rasterizes pages as you scroll and automatically evicts off-screen page images to keep RAM usage low. Also renders annotations on sidebar thumbnails of pages. The original PDF and `.pdf.mark` sidecar files remain untouched.

**In-memory `.mark` overlay & viewer rendering**
-  Reads `.pdf.mark` and sibling `.pdf` bytes into RAM and applies `markToAnnotatedPdf()` to generate annotated PDF page buffers in memory.
- Feeds the composite PDF data stream to PDF.js engine.
- Added a `noteObject` property to `<supernote-viewer>` to accept structural note stubs. `<supernote-viewer>` calls `pdfDoc.getPage().render()` to render each page on demand as PNG data URLs.
- Does not require physical `Document - annotated.pdf` file generation when opening `.mark` files.

**RAM & performance** 
- Builds empty DOM placeholders with fixed aspect ratios upfront for instant scrollbar & page-counter sizing.
- Only rasterizes pages within a 2-page window around the visible viewport (debounced by 150 ms).
- Clears the `src` attribute of off-screen page `<img>` tags to free browser memory during long scroll passes.
- Memory usage remains constant (O(1)) regardless of total page count.

**Device sync & commands**
- Added `Sync PDF annotations from device` to sync matching `.pdf` + `.pdf.mark` companion pairs from a Supernote device.
- Standard `Sync supernote notes now` command remains scoped to `.note` and `.spd` files.
- `feat/view-annotated-pdfs` is now rebased on top of #258, so the deleted-file-restore code lives once (from `fix/sync-engine`) and this branch commits sit on top of it.

**Testing & other notes**
- Added scanner unit tests in `FileListModal.test.ts` covering note sync, PDF/mark pair discovery.
- Updated `README.md` to document the `.mark` file viewing workflow.
- Build passes with no errors & tests pass locally
- Manually verified viewing, scrolling, zooming, and page switching on an N6 `.pdf.mark` file in Obsidian.

### Small PDF example:
<img width="1580" height="956" alt="image" src="https://github.com/user-attachments/assets/9ff715c3-1b41-4501-9aaf-3ba7799cb5c4" />

### Large PDF example: 
<img width="832" height="890" alt="image" src="https://github.com/user-attachments/assets/46518b6d-a6ba-41ad-82ad-97fdd32851c2" />

### Sidebar preview annotations 
<img width="710" height="820" alt="image" src="https://github.com/user-attachments/assets/85f4c27e-24e8-4e9e-ab1c-37cbf9f422b5" />

